### PR TITLE
feat: semantic chunking — split by Markdown headers and paragraphs

### DIFF
--- a/benchmark/CHUNKING_BENCHMARK.md
+++ b/benchmark/CHUNKING_BENCHMARK.md
@@ -1,6 +1,6 @@
 # Chunking Benchmark: Fixed Window vs Semantic
 
-**Date:** 2026-03-23 19:02
+**Date:** 2026-03-23 19:17
 **Config:** chunk_size=1024, overlap=128
 
 
@@ -8,22 +8,22 @@
 
 | File | Tokens | Fixed Chunks | Semantic Chunks | Fixed Avg Tok | Semantic Avg Tok | Headers Preserved (Semantic) |
 |------|--------|-------------|----------------|--------------|-----------------|------------------------------|
-| climate_change_report.md | 1248 | 2 | 11 | 688.0 | 113.4 | 18/18 |
-| fastapi_patterns.md | 1155 | 2 | 8 | 641.0 | 143.4 | 19/19 |
-| neural_architecture_search.md | 1652 | 2 | 13 | 890.0 | 127.0 | 18/18 |
-| alice_wonderland.txt | 41028 | 46 | 43 | 1017.2 | 953.4 | 0/0 |
-| art_of_war.txt | 82207 | 92 | 87 | 1020.2 | 942.4 | 0/0 |
-| **Total** | — | **144** | **162** | — | — | **55/55** |
+| climate_change_report.md | 1248 | 2 | 9 | 688.0 | 138.3 | 18/18 |
+| fastapi_patterns.md | 1155 | 2 | 5 | 641.0 | 230.0 | 19/19 |
+| neural_architecture_search.md | 1652 | 2 | 12 | 890.0 | 137.5 | 18/18 |
+| alice_wonderland.txt | 41028 | 46 | 44 | 1017.2 | 931.7 | 0/0 |
+| art_of_war.txt | 82207 | 92 | 89 | 1020.2 | 921.3 | 0/0 |
+| **Total** | — | **144** | **159** | — | — | **55/55** |
 
 ## Performance
 
 | File | Fixed Time | Semantic Time | Overhead |
 |------|-----------|--------------|----------|
-| climate_change_report.md | 0.28ms | 0.48ms | 71% |
-| fastapi_patterns.md | 0.28ms | 0.57ms | 104% |
-| neural_architecture_search.md | 0.3ms | 0.6ms | 100% |
-| alice_wonderland.txt | 7.61ms | 24.8ms | 226% |
-| art_of_war.txt | 20.93ms | 46.29ms | 121% |
+| climate_change_report.md | 0.29ms | 0.52ms | 79% |
+| fastapi_patterns.md | 0.24ms | 0.51ms | 112% |
+| neural_architecture_search.md | 0.4ms | 0.75ms | 88% |
+| alice_wonderland.txt | 8.8ms | 24.05ms | 173% |
+| art_of_war.txt | 16.3ms | 46.42ms | 185% |
 
 ## Sample Chunks (first chunk of each file)
 
@@ -71,5 +71,5 @@
 ## Verdict
 
 - Semantic chunking preserved **55/55** headers with their body content
-- Fixed window: **144** chunks vs Semantic: **162** chunks
-- **12% more chunks** with semantic — more granular, but each chunk is more coherent
+- Fixed window: **144** chunks vs Semantic: **159** chunks
+- **10% more chunks** with semantic — more granular, but each chunk is more coherent

--- a/benchmark/benchmark_chunking.py
+++ b/benchmark/benchmark_chunking.py
@@ -17,18 +17,9 @@ import tiktoken
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-# Import the chunking functions directly to avoid store.py import chain
-# which requires Python 3.11+ for datetime.UTC
-import importlib.util
-
-_ingest_spec = importlib.util.spec_from_file_location(
-    "_ingest_chunking",
-    str(Path(__file__).parent.parent / "vstash" / "ingest.py"),
-    submodule_search_locations=[],
-)
-
-# We can't import ingest.py directly due to relative imports — extract functions inline
-# Copy the logic here to keep benchmark self-contained on Python 3.10
+# We can't import ingest.py directly due to relative imports that pull in
+# store.py (requires Python 3.11+ for datetime.UTC). Functions are inlined
+# here to keep the benchmark self-contained on Python 3.10.
 
 _HEADER_RE = re.compile(r"^(#{1,6})\s+", re.MULTILINE)
 _MIN_CHUNK_TOKENS = 80
@@ -55,6 +46,7 @@ def _fixed_window_chunks(text: str, chunk_size: int, overlap: int) -> list[str]:
     tokens = enc.encode(text)
     if not tokens:
         return []
+    safe_overlap = min(overlap, chunk_size - 1) if chunk_size > 0 else 0
     chunks: list[str] = []
     start = 0
     while start < len(tokens):
@@ -64,7 +56,7 @@ def _fixed_window_chunks(text: str, chunk_size: int, overlap: int) -> list[str]:
             chunks.append(chunk_text_str)
         if end >= len(tokens):
             break
-        start += chunk_size - overlap
+        start += chunk_size - safe_overlap
     return chunks
 
 
@@ -84,11 +76,13 @@ def _split_by_paragraphs(text: str, chunk_size: int, overlap: int) -> list[str]:
                 current, current_tokens = [], 0
             result.extend(_fixed_window_chunks(para, chunk_size, overlap))
             continue
-        if current_tokens + para_tokens > chunk_size and current:
+        separator_cost = len(enc.encode("\n\n")) if current else 0
+        if current_tokens + separator_cost + para_tokens > chunk_size and current:
             result.append("\n\n".join(current))
             current, current_tokens = [], 0
+            separator_cost = 0
         current.append(para)
-        current_tokens += para_tokens
+        current_tokens += separator_cost + para_tokens
     if current:
         result.append("\n\n".join(current))
     return result
@@ -102,9 +96,11 @@ def _merge_small_chunks(chunks: list[str], chunk_size: int) -> list[str]:
     current_tokens = len(enc.encode(current))
     for chunk in chunks[1:]:
         chunk_tokens = len(enc.encode(chunk))
-        if current_tokens < _MIN_CHUNK_TOKENS and current_tokens + chunk_tokens <= chunk_size:
+        separator_cost = len(enc.encode("\n\n"))
+        can_merge = current_tokens + separator_cost + chunk_tokens <= chunk_size
+        if can_merge and (current_tokens < _MIN_CHUNK_TOKENS or chunk_tokens < _MIN_CHUNK_TOKENS):
             current = current + "\n\n" + chunk
-            current_tokens += chunk_tokens
+            current_tokens += separator_cost + chunk_tokens
         else:
             merged.append(current)
             current = chunk

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -189,10 +189,27 @@ class TestMergeSmallChunks:
         assert "Hi." in result[0]
         assert "Bye." in result[0]
 
-    def test_large_chunk_stays_alone(self) -> None:
+    def test_small_trailing_chunk_gets_merged(self) -> None:
+        """Bidirectional: a small trailing chunk merges into a large predecessor."""
         big = "word " * 200  # ~200 tokens, well above _MIN_CHUNK_TOKENS
         chunks = [big, "Small tail."]
         result = _merge_small_chunks(chunks, chunk_size=1024)
+        # "Small tail." is below _MIN_CHUNK_TOKENS, so it should merge
+        assert len(result) == 1
+        assert "Small tail." in result[0]
+
+    def test_two_large_chunks_stay_separate(self) -> None:
+        """Two chunks both above _MIN_CHUNK_TOKENS should not merge."""
+        big1 = "word " * 200
+        big2 = "other " * 200
+        result = _merge_small_chunks([big1, big2], chunk_size=2048)
+        assert len(result) == 2
+
+    def test_merge_respects_chunk_size_limit(self) -> None:
+        """Even if a chunk is small, don't merge if it would exceed chunk_size."""
+        big = "word " * 500  # ~500 tokens
+        small = "tail."
+        result = _merge_small_chunks([big, small], chunk_size=100)
         assert len(result) == 2
 
 
@@ -212,6 +229,18 @@ class TestFixedWindowChunks:
             "Short text that fits in one window.", chunk_size=100, overlap=10,
         )
         assert len(result) == 1
+
+    def test_overlap_equal_to_chunk_size_does_not_loop(self) -> None:
+        """overlap >= chunk_size should be clamped, not cause infinite loop."""
+        text = "word " * 500
+        # This would infinite loop without the guard
+        result = _fixed_window_chunks(text, chunk_size=100, overlap=100)
+        assert len(result) > 1
+
+    def test_overlap_greater_than_chunk_size_does_not_loop(self) -> None:
+        text = "word " * 500
+        result = _fixed_window_chunks(text, chunk_size=100, overlap=200)
+        assert len(result) > 1
 
     def test_overlap_creates_more_chunks(self) -> None:
         text = "word " * 500

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -152,13 +152,17 @@ def _split_by_paragraphs(
             result.extend(_fixed_window_chunks(para, chunk_size, overlap))
             continue
 
+        # Account for "\n\n" separator tokens when joining paragraphs
+        separator_cost = len(_enc.encode("\n\n")) if current else 0
+
         # Would adding this paragraph overflow?
-        if current_tokens + para_tokens > chunk_size and current:
+        if current_tokens + separator_cost + para_tokens > chunk_size and current:
             result.append("\n\n".join(current))
             current, current_tokens = [], 0
+            separator_cost = 0
 
         current.append(para)
-        current_tokens += para_tokens
+        current_tokens += separator_cost + para_tokens
 
     if current:
         result.append("\n\n".join(current))
@@ -183,6 +187,9 @@ def _fixed_window_chunks(
     if not tokens:
         return []
 
+    # Guard against infinite loop: overlap must be strictly less than chunk_size
+    safe_overlap = min(overlap, chunk_size - 1) if chunk_size > 0 else 0
+
     chunks: list[str] = []
     start = 0
     while start < len(tokens):
@@ -196,7 +203,7 @@ def _fixed_window_chunks(
         if end >= len(tokens):
             break
 
-        start += chunk_size - overlap
+        start += chunk_size - safe_overlap
 
     return chunks
 
@@ -216,10 +223,13 @@ def _merge_small_chunks(chunks: list[str], chunk_size: int) -> list[str]:
     for chunk in chunks[1:]:
         chunk_tokens = len(_enc.encode(chunk))
 
-        # If current is small and merging won't overflow, merge
-        if current_tokens < _MIN_CHUNK_TOKENS and current_tokens + chunk_tokens <= chunk_size:
+        separator_cost = len(_enc.encode("\n\n"))
+        can_merge = current_tokens + separator_cost + chunk_tokens <= chunk_size
+
+        # Merge if EITHER side is small (bidirectional merging)
+        if can_merge and (current_tokens < _MIN_CHUNK_TOKENS or chunk_tokens < _MIN_CHUNK_TOKENS):
             current = current + "\n\n" + chunk
-            current_tokens += chunk_tokens
+            current_tokens += separator_cost + chunk_tokens
         else:
             merged.append(current)
             current = chunk


### PR DESCRIPTION
Replace fixed 1024-token sliding window with a semantic-first strategy:
1. Split at Markdown headers (keeps sections intact)
2. Within oversized sections, split at paragraph boundaries
3. Fall back to fixed-token window only for oversized paragraphs
4. Merge adjacent tiny chunks (< 80 tokens) to avoid low-quality embeddings

Benchmark results on 5 corpus files (3 Markdown + 2 plain text):
- 55/55 Markdown headers preserved with their body content (was 0)
- Chunking time: ~0.5ms per Markdown file (acceptable overhead)
- Plain text files chunk similarly to before (paragraph-aware)

Includes 20+ new tests covering all chunking layers and a dedicated
benchmark script (benchmark/benchmark_chunking.py) for A/B comparison.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
