### PR TITLE
release: v0.5.2 — vstash search + scoring fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to vstash are documented here.
 
+## [0.5.2] — 2026-03-27
+
+### Added
+- **`vstash search` CLI command** — semantic search without LLM, free and fully local
+  - Table output with normalized scores, source, and text preview
+  - `--json` flag for programmatic output
+  - Supports `--collection`, `--project`, `--layer` filters
+- **PyPI metadata** — project.urls, classifiers, sdist exclusions (~1MB → 70KB)
+- **docs/ directory** — 9 standalone guides (configuration, scoring, MCP, LangChain, how-it-works, embedding models, future improvements)
+- Demo GIF re-recorded with full flow (add → search → add URL → ask → stats)
+
+### Fixed
+- **CLI scoring passthrough** — `search`, `ask`, and `chat` now pass `scoring=cfg.scoring` to `store.search()` (was silently disabled for all CLI users)
+- **access_count default 0** — ingestion is not an access; chunks start at 0 instead of 1
+- **Capped frequency score** — normalized to [0,1] via `log1p(freq) / log1p(100)` to prevent heavily-accessed chunks from dominating semantic relevance
+- **Type safety** — `scoring` param typed as `ScoringConfig | None` instead of `object`
+- **Config validation** — `model_validator` enforcing `alpha + beta <= 1.0`
+- **track_access logging** — failures now log at DEBUG instead of silent `pass`
+- **last_accessed_at initialized** on chunk insert to avoid NULL propagation
+
+---
+
 ## [0.5.1] — 2026-03-27
 
 ### Added
@@ -27,7 +49,7 @@ All notable changes to vstash are documented here.
   - Configurable via `[scoring]` section in `vstash.toml`
 - Schema migration adds `access_count`, `last_accessed_at`, `created_at` columns to chunks table
   - Automatic backfill on existing databases (created_at from document's added_at)
-  - Cold start: new chunks get `access_count = 1` (ingestion counts as first access)
+  - Cold start: new chunks get `access_count = 0` (fixed in v0.5.2 — ingestion is not an access)
 - `rerank_with_decay()` method on `VstashStore` with min-max normalization of RRF scores
 - `track_access()` records access frequency and recency on each search
 - `ScoringConfig` with Pydantic validation in `vstash.toml`

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -54,19 +54,19 @@ class TestScoringMigration:
     """Test that scoring columns are added correctly."""
 
     def test_chunks_have_access_count(self, scoring_store: VstashStore) -> None:
-        """New chunks should have access_count = 1."""
+        """New chunks should have access_count = 0 (never searched)."""
         rows = scoring_store._conn.execute("SELECT access_count FROM chunks").fetchall()
-        assert all(row["access_count"] == 1 for row in rows)
+        assert all(row["access_count"] == 0 for row in rows)
 
     def test_chunks_have_created_at(self, scoring_store: VstashStore) -> None:
         """New chunks should have created_at set."""
         rows = scoring_store._conn.execute("SELECT created_at FROM chunks").fetchall()
         assert all(row["created_at"] is not None for row in rows)
 
-    def test_chunks_have_null_last_accessed(self, scoring_store: VstashStore) -> None:
-        """New chunks should have last_accessed_at = NULL (never searched)."""
+    def test_chunks_have_last_accessed_at(self, scoring_store: VstashStore) -> None:
+        """New chunks should have last_accessed_at set to creation time."""
         rows = scoring_store._conn.execute("SELECT last_accessed_at FROM chunks").fetchall()
-        assert all(row["last_accessed_at"] is None for row in rows)
+        assert all(row["last_accessed_at"] is not None for row in rows)
 
     def test_migration_on_existing_db(self, tmp_path) -> None:
         """Opening an old DB (pre-scoring schema) should add scoring columns via migration."""
@@ -121,7 +121,7 @@ class TestScoringMigration:
         # Re-open via VstashStore — migration should add columns + backfill
         store = VstashStore(db_path, embedding_dim=4)
         row = store._conn.execute("SELECT access_count, created_at FROM chunks LIMIT 1").fetchone()
-        assert row["access_count"] == 1
+        assert row["access_count"] == 0  # migration default for pre-existing chunks
         assert row["created_at"] == "2026-01-01T00:00:00+00:00"  # backfilled from added_at
         store.close()
 
@@ -145,7 +145,7 @@ class TestTrackAccess:
             f"SELECT access_count FROM chunks WHERE id IN ({','.join('?' * len(chunk_ids))})",
             chunk_ids,
         ).fetchall()
-        assert all(row["access_count"] == 2 for row in rows)  # 1 (initial) + 1
+        assert all(row["access_count"] == 1 for row in rows)  # 0 (initial) + 1
 
     def test_track_access_sets_last_accessed(self, scoring_store: VstashStore) -> None:
         """track_access should set last_accessed_at."""
@@ -170,7 +170,7 @@ class TestTrackAccess:
         row = scoring_store._conn.execute(
             "SELECT access_count FROM chunks WHERE id = ?", [chunk_ids[0]]
         ).fetchone()
-        assert row["access_count"] == 6  # 1 (initial) + 5
+        assert row["access_count"] == 5  # 0 (initial) + 5
 
     def test_track_access_empty_list(self, scoring_store: VstashStore) -> None:
         """track_access with empty list should be a no-op."""
@@ -200,15 +200,15 @@ class TestRerankWithDecay:
             r["id"] for r in scoring_store._conn.execute("SELECT id FROM chunks LIMIT 2").fetchall()
         ]
         # Give second chunk many accesses
-        for _ in range(20):
+        for _ in range(50):
             scoring_store.track_access([chunk_ids[1]])
 
         candidates = [
             {"id": chunk_ids[0], "rrf": 0.016, "text": "a", "title": "t", "path": "p", "chunk": 0},
             {"id": chunk_ids[1], "rrf": 0.014, "text": "b", "title": "t", "path": "p", "chunk": 1},
         ]
-        result = scoring_store.rerank_with_decay(candidates, beta=0.5)
-        # With enough accesses and beta=0.5, the boosted chunk should win
+        result = scoring_store.rerank_with_decay(candidates, alpha=0.2, beta=0.8)
+        # With enough accesses and high beta, the boosted chunk should win
         assert result[0]["id"] == chunk_ids[1]
 
     def test_decay_reduces_old_access_influence(self, scoring_store: VstashStore) -> None:

--- a/tests/test_scoring_e2e.py
+++ b/tests/test_scoring_e2e.py
@@ -171,9 +171,9 @@ class TestScoringEnabled:
             scoring=e2e_config.scoring,
         )
 
-        # At least some chunks should have access_count > 1
+        # At least some chunks should have access_count > 0 (incremented from initial 0)
         rows = e2e_store._conn.execute(
-            "SELECT access_count FROM chunks WHERE access_count > 1"
+            "SELECT access_count FROM chunks WHERE access_count > 0"
         ).fetchall()
         assert len(rows) > 0
 

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -195,6 +195,7 @@ def ask(
                 collection=collection,
                 project=project,
                 layer=layer,
+                scoring=cfg.scoring,
             )
 
         if not chunks:
@@ -245,6 +246,7 @@ def search(
     ),
     project: str | None = typer.Option(None, "--project", "-p", help="Restrict to project"),
     layer: str | None = typer.Option(None, "--layer", "-l", help="Restrict to layer"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output results as JSON"),
 ) -> None:
     """Semantic search without LLM (free, local)."""
     cfg, store = _get_store(warm=True)
@@ -261,13 +263,24 @@ def search(
                 collection=collection,
                 project=project,
                 layer=layer,
+                scoring=cfg.scoring,
             )
 
         if not chunks:
+            if json_output:
+                print("[]")
+                raise typer.Exit()
             console.print(
                 "[yellow]No relevant documents found. "
                 "Try adding some with [bold]vstash add[/bold].[/yellow]"
             )
+            raise typer.Exit()
+
+        if json_output:
+            import json
+            # Model dump using Pydantic v2
+            out = [c.model_dump() for c in chunks]
+            print(json.dumps(out, indent=2))
             raise typer.Exit()
 
         # Normalize scores to [0, 1] for display
@@ -354,7 +367,7 @@ def chat(
 
                 # Search
                 q_embedding = embed_query(query, cfg.embeddings.model)
-                chunks = store.search(q_embedding, query, top_k=k)
+                chunks = store.search(q_embedding, query, top_k=k, scoring=cfg.scoring)
 
                 if not chunks:
                     console.print("[yellow]No relevant context found.[/yellow]")

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -20,7 +20,7 @@ try:
 except ImportError:  # Python 3.10
     import tomli as tomllib  # type: ignore[no-redef]
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class InferenceConfig(BaseModel):
@@ -113,7 +113,10 @@ class StorageConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    db_path: str = Field(default="~/.vstash/memory.db", description="Path to SQLite database file")
+    db_path: str = Field(
+        default_factory=lambda: os.getenv("VSTASH_DB_PATH") or "~/.vstash/memory.db",
+        description="Path to SQLite database file",
+    )
 
 
 class ScoringConfig(BaseModel):
@@ -140,6 +143,13 @@ class ScoringConfig(BaseModel):
         default=True,
         description="Record access counts on search (enabled by default when scoring is on)",
     )
+
+    @model_validator(mode="after")
+    def _validate_weights(self) -> ScoringConfig:
+        if self.alpha + self.beta > 1.0:
+            msg = f"alpha ({self.alpha}) + beta ({self.beta}) must be <= 1.0"
+            raise ValueError(msg)
+        return self
 
 
 class VstashConfig(BaseModel):

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -11,6 +11,7 @@ Single .db file. WAL mode for safe concurrent reads.
 from __future__ import annotations
 
 import hashlib
+import logging
 import math
 import sqlite3
 import struct
@@ -22,6 +23,7 @@ import threading
 
 import sqlite_vec
 
+from .config import ScoringConfig
 from .models import DocumentInfo, SearchResult, StoreStats
 
 
@@ -46,6 +48,10 @@ def _deserialize(data: bytes) -> list[float]:
 
 # Standard RRF constant — balances precision vs recall
 RRF_K = 60
+
+# Frequency score saturation point — access counts above this
+# produce diminishing returns in the log1p normalization.
+FREQ_SATURATION = 100
 
 
 class VstashStore:
@@ -198,7 +204,7 @@ class VstashStore:
         # Frequency + decay scoring columns on chunks
         chunk_columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)").fetchall()}
         if "access_count" not in chunk_columns:
-            migrations.append("ALTER TABLE chunks ADD COLUMN access_count INTEGER DEFAULT 1")
+            migrations.append("ALTER TABLE chunks ADD COLUMN access_count INTEGER DEFAULT 0")
         if "last_accessed_at" not in chunk_columns:
             migrations.append("ALTER TABLE chunks ADD COLUMN last_accessed_at TEXT")
         if "created_at" not in chunk_columns:
@@ -215,6 +221,15 @@ class VstashStore:
                 UPDATE chunks SET created_at = (
                     SELECT d.added_at FROM documents d WHERE d.id = chunks.doc_id
                 ) WHERE created_at IS NULL
+            """)
+            conn.commit()
+
+        # Fix v0.5.0 data: ingestion set access_count=1 for chunks that were
+        # never actually searched. Detect by access_count=1 + no last_accessed_at.
+        if "access_count" in chunk_columns:
+            conn.execute("""
+                UPDATE chunks SET access_count = 0
+                WHERE access_count = 1 AND last_accessed_at IS NULL
             """)
             conn.commit()
 
@@ -299,9 +314,9 @@ class VstashStore:
                 for seq, (text, embedding) in enumerate(zip(chunks, embeddings)):
                     # Insert chunk — get rowid for linking vec + fts tables
                     cursor = self._conn.execute(
-                        "INSERT INTO chunks (doc_id, seq, text, access_count, created_at)"
-                        " VALUES (?, ?, ?, 1, ?)",
-                        [doc_id, seq, text, now_iso],
+                        "INSERT INTO chunks (doc_id, seq, text, access_count, created_at, last_accessed_at)"
+                        " VALUES (?, ?, ?, 0, ?, ?)",
+                        [doc_id, seq, text, now_iso, now_iso],
                     )
                     rowid = cursor.lastrowid
 
@@ -392,7 +407,7 @@ class VstashStore:
         collection: str | None = None,
         project: str | None = None,
         layer: str | None = None,
-        scoring: object | None = None,
+        scoring: ScoringConfig | None = None,
     ) -> list[SearchResult]:
         """Hybrid search: vector (semantic) + FTS5 (keyword) combined with RRF.
 
@@ -423,10 +438,9 @@ class VstashStore:
             Ranked list of SearchResult ordered by descending score.
         """
         # Determine effective pool size — over-fetch when scoring is enabled
-        scoring_enabled = scoring is not None and getattr(scoring, "enabled", False)
         effective_k = top_k
-        if scoring_enabled:
-            effective_k = max(top_k, getattr(scoring, "over_fetch", 50))
+        if scoring is not None and scoring.enabled:
+            effective_k = max(top_k, scoring.over_fetch)
 
         # Adaptive candidate pool — avoid pulling half the corpus on small DBs
         total_chunks = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
@@ -525,13 +539,13 @@ class VstashStore:
         ranked = sorted(scores.values(), key=lambda x: float(x["rrf"]), reverse=True)
 
         # Apply frequency+decay re-ranking if scoring is enabled
-        if scoring_enabled:
+        if scoring is not None and scoring.enabled:
             ranked = ranked[:effective_k]
             ranked = self.rerank_with_decay(
                 ranked,
-                alpha=getattr(scoring, "alpha", 0.8),
-                beta=getattr(scoring, "beta", 0.2),
-                decay_lambda=getattr(scoring, "decay_lambda", 0.05),
+                alpha=scoring.alpha,
+                beta=scoring.beta,
+                decay_lambda=scoring.decay_lambda,
             )
 
         ranked = ranked[:top_k]
@@ -548,13 +562,13 @@ class VstashStore:
         ]
 
         # Track access for returned chunks (best-effort, failures don't affect results)
-        if scoring_enabled and getattr(scoring, "track_access", True):
+        if scoring is not None and scoring.enabled and scoring.track_access:
             try:
                 result_ids = [int(r["id"]) for r in ranked if "id" in r]
                 if result_ids:
                     self.track_access(result_ids)
             except Exception:
-                pass  # Access tracking is non-critical; never break search
+                logging.getLogger(__name__).debug("Access tracking failed", exc_info=True)
 
         return results
 
@@ -882,7 +896,7 @@ class VstashStore:
         for c in candidates:
             chunk_id = int(c["id"])
             info = meta.get(chunk_id, {})
-            access_count = info.get("access_count", 1) or 1
+            access_count = info.get("access_count", 0) or 0
             last_accessed = info.get("last_accessed_at")
             created = info.get("created_at")
 
@@ -899,8 +913,11 @@ class VstashStore:
                     ref_dt = ref_dt.replace(tzinfo=timezone.utc)
                 days_ago = max(0.0, (now - ref_dt).total_seconds() / 86400)
 
-            freq_score = access_count * math.exp(-decay_lambda * days_ago)
-            c["final_score"] = alpha * normalized_rrf + beta * math.log(1 + freq_score)
+            # +1 baseline so zero-access chunks still get a small nonzero score
+            freq_score = (1 + access_count) * math.exp(-decay_lambda * days_ago)
+            # Normalize frequency component to [0, 1] via log1p, capped at 1.0
+            freq_normalized = min(1.0, math.log1p(freq_score) / math.log1p(FREQ_SATURATION))
+            c["final_score"] = alpha * normalized_rrf + beta * freq_normalized
 
         candidates.sort(key=lambda c: float(c["final_score"]), reverse=True)
         return candidates
@@ -920,7 +937,7 @@ class VstashStore:
         placeholders = ",".join("?" * len(chunk_ids))
         with self._write_lock:
             self._conn.execute(
-                f"UPDATE chunks SET access_count = COALESCE(access_count, 1) + 1, "
+                f"UPDATE chunks SET access_count = COALESCE(access_count, 0) + 1, "
                 f"last_accessed_at = ? WHERE id IN ({placeholders})",
                 [now_iso, *chunk_ids],
             )


### PR DESCRIPTION
## Summary

Merges develop → main for v0.5.2 release.

### New
- **`vstash search`** CLI command — semantic search without LLM (free, local)
- **docs/** directory with 9 guides
- **PyPI metadata** — project.urls, classifiers, slim sdist

### Fixed
- CLI `search`/`ask`/`chat` now pass `scoring` config (was silently disabled)
- `access_count` default 0 (ingestion ≠ access) + migration fix for v0.5.0 data
- Frequency score capped to [0,1] via `FREQ_SATURATION` constant
- `scoring` typed as `ScoringConfig | None` with proper type narrowing
- `alpha + beta <= 1.0` validation
- `track_access` logs failures instead of silent `pass`
- `last_accessed_at` initialized on chunk insert
- `VSTASH_DB_PATH=""` fallback fixed

## Test plan
- [x] All 280 tests pass
- [ ] Tag v0.5.2 and publish to PyPI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)