### PR TITLE
feat: relevance signal + Claude Code integration (v0.5.3)

### DIFF
--- a/.claude/commands/memory.md
+++ b/.claude/commands/memory.md
@@ -1,0 +1,30 @@
+---
+argument-hint: <query>
+description: Search your vstash document memory for relevant context
+---
+
+# vstash Memory Search
+
+Search your local document memory using vstash semantic search. Use this before answering questions that might benefit from project docs, specs, notes, or past decisions.
+
+## Instructions
+
+1. Run `vstash search` with the user's query using the Bash tool:
+
+```bash
+vstash search "$ARGUMENTS" --top-k 5 --json
+```
+
+2. Parse the JSON results and present a concise summary of the most relevant chunks found.
+
+3. If no results are found, tell the user their memory is empty for that query and suggest adding documents with `vstash add`.
+
+4. If the query has filters (collection, project), pass them:
+```bash
+vstash search "$ARGUMENTS" --top-k 5 --json --collection <name>
+vstash search "$ARGUMENTS" --top-k 5 --json --project <name>
+```
+
+## Output Format
+
+Present results as a brief list with source and relevance, then use the context to help answer the user's underlying question. Do not just dump raw chunks — synthesize them.

--- a/.claude/commands/remember.md
+++ b/.claude/commands/remember.md
@@ -1,0 +1,30 @@
+---
+argument-hint: <file, directory, or URL>
+description: Add documents to vstash memory for future context
+---
+
+# vstash Remember
+
+Ingest files, directories, or URLs into vstash so they're available for future `/memory` searches.
+
+## Instructions
+
+1. Run `vstash add` with the provided source using the Bash tool:
+
+```bash
+vstash add $ARGUMENTS
+```
+
+2. If the user provides multiple sources, pass them all at once:
+```bash
+vstash add file1.pdf file2.md https://example.com/article
+```
+
+3. If the user specifies a collection or project, pass the flags:
+```bash
+vstash add $ARGUMENTS --collection <name> --project <name>
+```
+
+4. After ingestion, confirm what was added with a brief summary (title, chunks, collection).
+
+5. If the user asks to remember a directory, warn them about large directories and suggest using `--collection` to organize.

--- a/.claude/hooks/vstash-context.sh
+++ b/.claude/hooks/vstash-context.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Hook: auto-search vstash memory before responding to user prompts.
+# Injects relevant document chunks as additional context.
+#
+# Filtering strategy: pattern-based (not score-based).
+# Score thresholds don't work on small corpora — everything scores ~0.83+.
+# Instead, skip prompts that are clearly actions/commands, not questions.
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt')
+
+# Skip short prompts and slash commands
+if [ ${#PROMPT} -lt 20 ] || [[ "$PROMPT" == /* ]]; then
+  exit 0
+fi
+
+# Skip action prompts — commands, git ops, deploys, confirmations.
+# These don't benefit from document context.
+if echo "$PROMPT" | grep -iEq '(^(haz|crea|sube|publica|borra|ejecuta|corre|run|push|merge|commit|delete|fix|refactor|deploy|tag|build|test|lint) |commit|merge|PR|pull request|pypi|tests? |please$|por favor$|github|git )'; then
+  exit 0
+fi
+
+# Run vstash search (JSON output, top 3 chunks, stderr suppressed)
+RESULTS=$(vstash search "$PROMPT" --top-k 3 --json 2>/dev/null)
+
+# Skip if no results or empty array
+if [ -z "$RESULTS" ] || [ "$RESULTS" = "[]" ]; then
+  exit 0
+fi
+
+# Format: title + truncated text (200 chars max per chunk)
+CONTEXT=$(echo "$RESULTS" | jq -r '
+  [.[] | "[\(.title)] \(.text[:200] | gsub("\n"; " "))..."]
+  | join("\n")
+')
+
+jq -n --arg ctx "$CONTEXT" '{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": ("vstash context:\n" + $ctx)
+  }
+}'
+
+exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to vstash are documented here.
 
+## [0.5.3] — 2026-03-27
+
+### Added
+- **Relevance signal** — search results now include a `relevance` field (`high`, `low`, `none`) based on score spread
+  - CLI: shows `⚠ Results may not be relevant` warning when spread < 0.15
+  - CLI `--json`: includes `relevance` field in output
+  - MCP: `vstash_search` returns `relevance` + `hint` so LLM clients can filter noise
+- **MCP server instructions** — explicit guidance for LLM clients on when to use/skip vstash tools
+- **Claude Code integration** — hook, skills, and setup guide
+  - `vstash-context.sh` hook: auto-injects document context on knowledge questions
+  - `/memory` and `/remember` slash commands
+  - `docs/claude-integration.md` — setup guide for Claude Code (hook) and Claude Desktop (MCP)
+
+---
+
 ## [0.5.2] — 2026-03-27
 
 ### Added

--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -1,0 +1,202 @@
+# Integrating vstash with Claude
+
+vstash can provide document memory to Claude in two ways: as a **Claude Code hook** (automatic) or as a **Claude Desktop MCP server** (tool-based). Both are independent — you can use one, the other, or both.
+
+---
+
+## Option A: Claude Code — Auto-Context Hook
+
+Every time you send a message, vstash automatically searches your document memory and injects relevant context. No manual action needed.
+
+### How it works
+
+```
+You type a question
+       ↓
+Hook runs `vstash search` with your prompt
+       ↓
+Relevant chunks injected as context
+       ↓
+Claude responds with document knowledge
+```
+
+### Setup
+
+**1. Create the hook script**
+
+```bash
+mkdir -p .claude/hooks
+```
+
+Create `.claude/hooks/vstash-context.sh`:
+
+```bash
+#!/bin/bash
+# Auto-search vstash memory before Claude responds.
+# Skips action prompts (commit, merge, push) — only injects on knowledge questions.
+
+INPUT=$(cat)
+PROMPT=$(echo "$INPUT" | jq -r '.prompt')
+
+# Skip short prompts and slash commands
+if [ ${#PROMPT} -lt 20 ] || [[ "$PROMPT" == /* ]]; then
+  exit 0
+fi
+
+# Skip action prompts that don't benefit from document context
+if echo "$PROMPT" | grep -iEq '(^(haz|crea|sube|publica|borra|ejecuta|corre|run|push|merge|commit|delete|fix|refactor|deploy|tag|build|test|lint) |commit|merge|PR|pull request|pypi|tests? |please$|por favor$|github|git )'; then
+  exit 0
+fi
+
+RESULTS=$(vstash search "$PROMPT" --top-k 3 --json 2>/dev/null)
+
+if [ -z "$RESULTS" ] || [ "$RESULTS" = "[]" ]; then
+  exit 0
+fi
+
+CONTEXT=$(echo "$RESULTS" | jq -r '
+  [.[] | "[\(.title)] \(.text[:200] | gsub("\n"; " "))..."]
+  | join("\n")
+')
+
+jq -n --arg ctx "$CONTEXT" '{
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": ("vstash context:\n" + $ctx)
+  }
+}'
+
+exit 0
+```
+
+```bash
+chmod +x .claude/hooks/vstash-context.sh
+```
+
+**2. Register the hook in `.claude/settings.json`**
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/vstash-context.sh",
+            "timeout": 15,
+            "statusMessage": "Searching vstash memory..."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**3. Add documents to memory**
+
+```bash
+vstash add docs/ --collection my-project
+vstash add https://some-spec.com/api-docs
+```
+
+**4. Use normally** — ask questions and vstash context appears automatically.
+
+### Optional: Manual skills
+
+Create `.claude/commands/memory.md` for explicit searches:
+
+```markdown
+---
+argument-hint: <query>
+description: Search your vstash document memory for relevant context
+---
+
+Run `vstash search "$ARGUMENTS" --top-k 5 --json` and present a summary of the results.
+```
+
+Usage: `/memory how does authentication work`
+
+### Scope
+
+- **Project-level**: Place files in `.claude/` inside your repo (shareable via git)
+- **Global**: Place files in `~/.claude/` (applies to all projects, requires vstash installed globally)
+
+---
+
+## Option B: Claude Desktop — MCP Server
+
+Claude Desktop connects to vstash via the Model Context Protocol. This gives Claude tools to search, add, and ask your document memory.
+
+### Setup
+
+**1. Install vstash with MCP support**
+
+```bash
+pip install vstash[mcp]
+```
+
+**2. Configure Claude Desktop**
+
+Open Claude Desktop settings and edit `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "vstash": {
+      "command": "vstash-mcp",
+      "env": {
+        "VSTASH_CONFIG": "~/.vstash/vstash.toml"
+      }
+    }
+  }
+}
+```
+
+**3. Restart Claude Desktop**
+
+After restart, Claude will have these tools available:
+
+| Tool | Description |
+|------|-------------|
+| `vstash_search` | Semantic search across all documents |
+| `vstash_ask` | Search + LLM answer in one step |
+| `vstash_add` | Ingest files, directories, or URLs |
+| `vstash_list` | List all documents in memory |
+| `vstash_stats` | Memory statistics |
+| `vstash_find` | Find a document by partial name |
+| `vstash_forget` | Remove a document |
+
+**4. Add documents**
+
+Either via CLI:
+```bash
+vstash add report.pdf notes.md
+```
+
+Or ask Claude Desktop directly:
+> "Add this URL to my memory: https://example.com/api-docs"
+
+**5. Use naturally**
+
+> "What does the API spec say about authentication?"
+> "Summarize the key findings from the report I added yesterday"
+
+Claude Desktop will call `vstash_search` or `vstash_ask` automatically.
+
+---
+
+## Comparison
+
+| | Claude Code (Hook) | Claude Desktop (MCP) |
+|---|---|---|
+| Context injection | Automatic on every prompt | On-demand (Claude decides) |
+| Requires | `vstash` CLI + `jq` | `vstash[mcp]` |
+| Config | `.claude/settings.json` | `claude_desktop_config.json` |
+| Tools available | Search only (via hook) | Search, add, ask, list, forget |
+| Best for | Coding with document context | Research, Q&A, document management |
+| Interference | None between them | None between them |
+
+Both use the same `~/.vstash/memory.db` by default, so documents added via CLI are available in both Claude Code and Claude Desktop.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -164,9 +164,11 @@ class TestVstashSearch:
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
         result = json.loads(vstash_search("test query"))
-        assert len(result) == 1
-        assert result[0]["text"] == "relevant text"
-        assert result[0]["score"] == 0.5
+        assert "chunks" in result
+        assert len(result["chunks"]) == 1
+        assert result["chunks"][0]["text"] == "relevant text"
+        assert result["chunks"][0]["score"] == 0.5
+        assert result["relevance"] in ("high", "low")
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -178,7 +180,8 @@ class TestVstashSearch:
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
         result = json.loads(vstash_search("nothing here"))
-        assert result == []
+        assert result["chunks"] == []
+        assert result["relevance"] == "none"
 
     @patch("vstash.mcp._get_store", side_effect=FileNotFoundError("no db"))
     def test_search_db_not_found(self, mock_store: MagicMock) -> None:

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -276,16 +276,26 @@ def search(
             )
             raise typer.Exit()
 
+        # Compute relevance signal from score spread
+        scores = [c.score for c in chunks]
+        spread = max(scores) - min(scores) if len(scores) > 1 else 0.0
+        low_relevance = spread < 0.15
+
         if json_output:
             import json
-            # Model dump using Pydantic v2
-            out = [c.model_dump() for c in chunks]
+            out = {
+                "chunks": [c.model_dump() for c in chunks],
+                "relevance": "low" if low_relevance else "high",
+            }
             print(json.dumps(out, indent=2))
             raise typer.Exit()
 
+        if low_relevance:
+            console.print("[dim]⚠ Results may not be specifically relevant to this query.[/dim]\n")
+
         # Normalize scores to [0, 1] for display
-        max_score = max(c.score for c in chunks) if chunks else 1.0
-        min_score = min(c.score for c in chunks) if len(chunks) > 1 else 0.0
+        max_score = max(scores) if scores else 1.0
+        min_score = min(scores) if len(scores) > 1 else 0.0
         score_range = max_score - min_score
 
         table = Table(show_header=True, header_style="bold cyan", padding=(0, 1))

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -41,7 +41,16 @@ mcp_server = FastMCP(
     "vstash",
     instructions=(
         "vstash — local document memory with hybrid semantic search. "
-        "Ingest files, URLs, or directories and query them with natural language."
+        "Ingest files, URLs, or directories and query them with natural language.\n\n"
+        "WHEN TO USE vstash_search/vstash_ask:\n"
+        "- User asks a knowledge question about their documents (how, what, why, explain)\n"
+        "- User needs context from specs, docs, notes, or past decisions\n"
+        "- User references information they previously added to memory\n\n"
+        "WHEN NOT TO USE vstash_search/vstash_ask:\n"
+        "- User gives an action command (commit, merge, push, deploy, build, test)\n"
+        "- User gives a short confirmation (yes, no, ok, do it)\n"
+        "- User asks about current code or git state (use other tools instead)\n"
+        "- The query is not related to stored documents"
     ),
 )
 
@@ -411,6 +420,9 @@ def vstash_search(
     Performs hybrid semantic + keyword search using Reciprocal Rank Fusion.
     Useful for retrieving context without consuming LLM tokens.
 
+    Only use this for knowledge questions about stored documents.
+    Do NOT call this for action commands (commit, merge, push, test, deploy).
+
     Args:
         query: Natural language search query.
         top_k: Number of results to return (default: 5).
@@ -419,7 +431,7 @@ def vstash_search(
         layer: If set, restrict search to documents with this layer tag.
 
     Returns:
-        JSON array of matching chunks with text, title, path, and score.
+        JSON object with chunks array and relevance hint.
     """
     try:
         top_k = int(top_k)
@@ -437,7 +449,21 @@ def vstash_search(
             scoring=cfg.scoring,
         )
 
-        return _ok(chunks)
+        if not chunks:
+            return _ok({"chunks": [], "relevance": "none"})
+
+        # Compute score spread — low variance means nothing is particularly relevant
+        scores = [c.score for c in chunks]
+        spread = max(scores) - min(scores) if len(scores) > 1 else 0.0
+        relevance = "high" if spread > 0.15 else "low"
+
+        return _ok({
+            "chunks": [c.model_dump() for c in chunks],
+            "relevance": relevance,
+            "hint": "Results may not be relevant to the query — scores are uniformly high."
+            if relevance == "low"
+            else "Results appear relevant to the query.",
+        })
 
     except FileNotFoundError:
         return _error("vstash database not found. Ingest documents first with vstash_add.")


### PR DESCRIPTION
## Summary
- **Relevance signal** — search results include `relevance` field (`high`, `low`, `none`) based on score spread (threshold 0.15)
  - CLI: shows `⚠ Results may not be relevant` warning for low-spread results
  - CLI `--json`: includes `relevance` field
  - MCP: `vstash_search` returns `relevance` + `hint` so LLM clients can filter noise
- **MCP server instructions** — explicit guidance for LLM clients on when to use/skip vstash tools
- **Claude Code integration** — hook, skills, and setup guide
  - `vstash-context.sh` hook: auto-injects document context on knowledge questions
  - `/memory` and `/remember` slash commands
  - `docs/claude-integration.md` setup guide

## Test plan
- [ ] `python -m pytest tests/ -q` passes
- [ ] `vstash search 'test query' --json` returns `relevance` field
- [ ] MCP `vstash_search` returns structured response with `relevance` and `hint`
- [ ] Hook fires on knowledge questions, skips action commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)