### PR TITLE
fix: prevent attribution errors in LLM grounding

### DIFF
--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -21,7 +21,8 @@ SYSTEM_PROMPT = """You are a precise document assistant. Answer questions based 
 Rules:
 - Answer only from the context. Do not invent information.
 - If the context doesn't contain the answer, say so clearly.
-- Be concise. Cite the source document when relevant.
+- Always cite which source document each fact comes from (use the document title shown in brackets).
+- If the user's question mentions a specific document but the answer comes from a different one, explicitly note the correction (e.g., "That information is not in [X] but in [Y]").
 - For code questions, provide working code examples from the context."""
 
 
@@ -40,7 +41,7 @@ def _build_prompt(query: str, chunks: list[SearchResult]) -> str:
 
     context_parts: list[str] = []
     for i, chunk in enumerate(chunks, 1):
-        source = f"[{chunk.title}]"
+        source = f"[{chunk.title}] (from: {chunk.path})"
         context_parts.append(f"--- Context {i} {source} ---\n{chunk.text}")
 
     context = "\n\n".join(context_parts)


### PR DESCRIPTION
## Summary

- System prompt now **requires explicit source citation** for every fact
- LLM must **correct the user** when a question names the wrong source document
- Context format includes **file path** for better source disambiguation

## Test plan

- [x] 331 unit tests passing
- [x] 9/9 anti-hallucination tests passing:
  - Off-topic (empanadas) → "not in documents"
  - False premise (GPT-4/Pinecone) → "not mentioned, uses sqlite-vec"
  - False data (1024-dim, F1=0.45) → corrected to 384-dim, F1=0.952
  - Contradiction (spread vs distance) → correctly picked current data
  - Negation → correctly denied
  - Multi-hop (3700÷5) → calculated 740 correctly
  - **Attribution** → **FIXED**: "that info is not in Product Improvements but in Vstash Paper"
  - Chunk boundary → reconstructed full formula
  - Outdated info → explained historical vs current

🤖 Generated with [Claude Code](https://claude.com/claude-code)