### PR TITLE
feat: add vstash remember for direct text ingestion

### DIFF
--- a/tests/test_remember.py
+++ b/tests/test_remember.py
@@ -1,0 +1,132 @@
+"""Tests for vstash remember — direct text ingestion."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from vstash.ingest import ingest_text
+
+
+class TestIngestText:
+    """Test the ingest_text function."""
+
+    def test_empty_text_returns_empty(self) -> None:
+        cfg = MagicMock()
+        store = MagicMock()
+        result = ingest_text("", "title", cfg, store)
+        assert result.status == "empty"
+
+    def test_whitespace_only_returns_empty(self) -> None:
+        cfg = MagicMock()
+        store = MagicMock()
+        result = ingest_text("   \n  ", "title", cfg, store)
+        assert result.status == "empty"
+
+    @patch("vstash.ingest._embed_with_progress")
+    def test_basic_text_ingestion(self, mock_embed) -> None:
+        mock_embed.return_value = [[0.1] * 384]
+
+        store = MagicMock()
+        store.add_document.return_value = "abc123"
+
+        cfg = MagicMock()
+        cfg.chunking.size = 1024
+        cfg.chunking.overlap = 128
+        cfg.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        result = ingest_text(
+            "This is some important text about architecture decisions.",
+            "arch-notes",
+            cfg,
+            store,
+            collection="docs",
+            project="myproj",
+        )
+
+        assert result.status == "ok"
+        assert result.title == "arch-notes"
+        assert result.chunks >= 1
+        assert result.doc_id == "abc123"
+
+        # Verify store was called with synthetic path
+        call_kwargs = store.add_document.call_args
+        assert call_kwargs[1]["path"] == "text://arch-notes"
+        assert call_kwargs[1]["source_type"] == "text"
+        assert call_kwargs[1]["collection"] == "docs"
+        assert call_kwargs[1]["project"] == "myproj"
+
+    @patch("vstash.ingest._embed_with_progress")
+    def test_frontmatter_extraction(self, mock_embed) -> None:
+        mock_embed.return_value = [[0.1] * 384]
+
+        store = MagicMock()
+        store.add_document.return_value = "def456"
+
+        cfg = MagicMock()
+        cfg.chunking.size = 1024
+        cfg.chunking.overlap = 128
+        cfg.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        text = """---
+project: my-project
+tags: [api, design]
+---
+
+# API Design Notes
+
+The API uses REST with JSON payloads."""
+
+        result = ingest_text(text, "api-notes", cfg, store)
+        assert result.status == "ok"
+
+        call_kwargs = store.add_document.call_args
+        assert call_kwargs[1]["project"] == "my-project"
+        assert call_kwargs[1]["tags"] == "api,design"
+
+    @patch("vstash.ingest._embed_with_progress")
+    def test_metadata_params_override_frontmatter(self, mock_embed) -> None:
+        mock_embed.return_value = [[0.1] * 384]
+
+        store = MagicMock()
+        store.add_document.return_value = "ghi789"
+
+        cfg = MagicMock()
+        cfg.chunking.size = 1024
+        cfg.chunking.overlap = 128
+        cfg.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        text = """---
+project: frontmatter-project
+---
+
+This is enough content to generate at least one chunk for the embedding pipeline to process correctly."""
+
+        result = ingest_text(
+            text, "note", cfg, store, project="override-project"
+        )
+        assert result.status == "ok"
+
+        call_kwargs = store.add_document.call_args
+        assert call_kwargs[1]["project"] == "override-project"
+
+
+class TestRememberCLI:
+    """Test the vstash remember CLI command."""
+
+    def test_remember_help(self) -> None:
+        from typer.testing import CliRunner
+        from vstash.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["remember", "--help"])
+        assert result.exit_code == 0
+        assert "Ingest text directly" in result.output
+
+    def test_remember_no_input(self) -> None:
+        from typer.testing import CliRunner
+        from vstash.cli import app
+
+        runner = CliRunner()
+        # No argument and no stdin → should fail
+        result = runner.invoke(app, ["remember"])
+        assert result.exit_code != 0

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -3,6 +3,7 @@ cli.py — vstash command line interface.
 
 Commands:
   vstash add <file/url>   → ingest document
+  vstash remember "text"  → ingest text directly (no file needed)
   vstash search "<query>" → semantic search (no LLM, free)
   vstash ask "<query>"    → single question (requires LLM)
   vstash chat             → interactive mode
@@ -813,6 +814,63 @@ def watch(
             extensions=extensions,
             debounce_s=debounce,
         )
+
+
+@app.command()
+def remember(
+    text: str | None = typer.Argument(None, help="Text to ingest (or pipe via stdin)"),
+    title: str = typer.Option("note", "--title", "-t", help="Title for the document"),
+    collection: str = typer.Option("default", "--collection", "-c", help="Collection to add to"),
+    project: str | None = typer.Option(None, "--project", "-p", help="Project tag"),
+    layer: str | None = typer.Option(None, "--layer", "-l", help="Layer tag"),
+    tags: str | None = typer.Option(None, "--tags", help="Comma-separated tags"),
+) -> None:
+    """Ingest text directly — no file needed.
+
+    Pass text as an argument, or pipe it via stdin:
+
+        vstash remember "The API uses OAuth2 with PKCE" --title "auth-notes"
+        echo "deployment steps..." | vstash remember --title "deploy"
+        cat notes.md | vstash remember --title "meeting-notes" --project myproj
+    """
+    import sys
+
+    # Read from argument or stdin
+    if text is None:
+        if sys.stdin.isatty():
+            console.print("[red]✗ No text provided. Pass as argument or pipe via stdin.[/red]")
+            raise typer.Exit(1)
+        text = sys.stdin.read()
+
+    if not text.strip():
+        console.print("[yellow]⚠ Empty text, nothing to ingest.[/yellow]")
+        raise typer.Exit(1)
+
+    from .ingest import ingest_text
+
+    cfg, store = _get_store()
+    meta = {"project": project, "layer": layer, "tags": tags}
+
+    with store:
+        result = ingest_text(
+            text,
+            title,
+            cfg,
+            store,
+            collection=collection,
+            **meta,
+        )
+
+        if result.status == "ok":
+            parts = (
+                f"[green]✓[/green] [bold]{result.title}[/bold] — "
+                f"{result.chunks} chunks in {result.elapsed_s}s"
+            )
+            if collection != "default":
+                parts += f" [cyan]→ {collection}[/cyan]"
+            console.print(parts)
+        else:
+            console.print(f"[yellow]⚠ {result.status}: {result.source}[/yellow]")
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -598,6 +598,101 @@ def ingest(
     )
 
 
+def ingest_text(
+    text: str,
+    title: str,
+    cfg: VstashConfig,
+    store: VstashStore,
+    *,
+    collection: str = "default",
+    project: str | None = None,
+    layer: str | None = None,
+    tags: str | None = None,
+) -> IngestResult:
+    """Ingest raw text directly — no file or URL needed.
+
+    This is the agent-friendly ingestion path. Instead of writing text
+    to a temp file and then ingesting, callers pass the text directly.
+
+    Args:
+        text: The content to ingest.
+        title: Human-readable title for the document.
+        cfg: Vex configuration.
+        store: Vector store instance.
+        collection: Named collection to group this document.
+        project: Project identifier.
+        layer: Layer/category tag.
+        tags: Comma-separated tags.
+
+    Returns:
+        IngestResult with status, chunk count, timing, etc.
+    """
+    start_time = time.time()
+
+    if not text or not text.strip():
+        return IngestResult(status="empty", source=f"text://{title}")
+
+    # Use a synthetic path so the store can deduplicate by title+collection
+    source_path = f"text://{title}"
+    char_count = len(text)
+
+    # Extract frontmatter if present
+    frontmatter = _extract_frontmatter(text)
+    fm_project = project or frontmatter.get("project")
+    fm_layer = layer or frontmatter.get("layer")
+    if fm_project is not None:
+        if isinstance(fm_project, (dict, list)):
+            fm_project = None
+        else:
+            fm_project = str(fm_project)
+    if fm_layer is not None:
+        if isinstance(fm_layer, (dict, list)):
+            fm_layer = None
+        else:
+            fm_layer = str(fm_layer)
+    fm_tags_raw = tags or frontmatter.get("tags")
+    fm_tags: str | None = None
+    if fm_tags_raw:
+        if isinstance(fm_tags_raw, list):
+            fm_tags = ",".join(str(t) for t in fm_tags_raw)
+        elif not isinstance(fm_tags_raw, (dict,)):
+            fm_tags = str(fm_tags_raw)
+    text = _strip_frontmatter(text)
+
+    # Chunk
+    chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
+    if not chunks:
+        return IngestResult(status="empty", source=source_path)
+
+    # Embed
+    embeddings = _embed_with_progress(chunks, cfg.embeddings.model)
+
+    # Store
+    doc_id = store.add_document(
+        path=source_path,
+        title=title,
+        chunks=chunks,
+        embeddings=embeddings,
+        source_type="text",
+        collection=collection,
+        project=fm_project,
+        layer=fm_layer,
+        tags=fm_tags,
+    )
+
+    elapsed = round(time.time() - start_time, 2)
+
+    return IngestResult(
+        status="ok",
+        doc_id=doc_id,
+        source=source_path,
+        title=title,
+        chunks=len(chunks),
+        chars=char_count,
+        elapsed_s=elapsed,
+    )
+
+
 def _load_gitignore(directory: Path) -> list[str]:
     """Load top-level .gitignore patterns from directory.
 

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -314,6 +314,55 @@ def vstash_add(
 
 
 @mcp_server.tool()
+def vstash_remember(
+    text: str,
+    title: str = "note",
+    collection: str = "default",
+    project: str | None = None,
+    layer: str | None = None,
+    tags: str | None = None,
+) -> str:
+    """Ingest text directly into vstash memory — no file needed.
+
+    Agent-friendly alternative to vstash_add. Pass text content directly
+    instead of writing to a temp file first. Ideal for storing notes,
+    decisions, code snippets, or any text an agent wants to remember.
+
+    Args:
+        text: The content to ingest and remember.
+        title: Human-readable title for the document (used in search results).
+        collection: Named collection to group this document (default: 'default').
+        project: Project tag for this document.
+        layer: Layer/category for this document.
+        tags: Comma-separated tags.
+
+    Returns:
+        JSON string with ingestion result (chunks created, timing, etc.).
+    """
+    try:
+        from .ingest import ingest_text
+
+        cfg = _get_config()
+        store = _get_store()
+
+        result = ingest_text(
+            text,
+            title,
+            cfg,
+            store,
+            collection=collection,
+            project=project,
+            layer=layer,
+            tags=tags,
+        )
+        return _ok(result)
+
+    except Exception as exc:
+        logger.exception("vstash_remember failed")
+        return _error(f"Ingestion failed: {exc}")
+
+
+@mcp_server.tool()
 def vstash_job(job_id: str) -> str:
     """Check the status of a background ingestion job.
 

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -148,6 +148,53 @@ class Memory:
         )
         return [result]
 
+    def remember(
+        self,
+        text: str,
+        title: str = "note",
+        *,
+        collection: object = _UNSET,
+        project: object = _UNSET,
+        layer: str | None = None,
+        tags: str | None = None,
+    ) -> IngestResult:
+        """Ingest raw text directly — no file needed.
+
+        Agent-friendly alternative to ``add()``. Chunks and embeds the text
+        in-memory without writing a temporary file to disk.
+
+        Args:
+            text: The content to ingest.
+            title: Human-readable title for the document.
+            collection: Override the default collection. Pass None for no collection.
+            project: Override the default project tag. Pass None for no project.
+            layer: Layer/category tag.
+            tags: Comma-separated tags.
+
+        Returns:
+            Single IngestResult.
+
+        Example::
+
+            mem = Memory(project="myproj")
+            mem.remember("OAuth2 uses PKCE for public clients", title="auth-notes")
+        """
+        from .ingest import ingest_text
+
+        col = self._collection if collection is _UNSET else collection
+        proj = self._project if project is _UNSET else project
+
+        return ingest_text(
+            text,
+            title,
+            self._cfg,
+            self._store,
+            collection=col,
+            project=proj,
+            layer=layer,
+            tags=tags,
+        )
+
     def search(
         self,
         query: str,


### PR DESCRIPTION
## Summary

- **New `ingest_text()` function** in `ingest.py` — accepts raw text, runs it through chunk → embed → store without touching the filesystem
- **`vstash remember` CLI command** — text as argument or piped via stdin
- **`Memory.remember()` SDK method** — one-liner for Python agents
- **`vstash_remember` MCP tool** — for Claude Desktop and other MCP clients
- **7 new tests** covering empty input, frontmatter extraction, metadata override, CLI help, and error handling

## Test plan

- [x] `python -m pytest tests/test_remember.py -v` — 7/7 passing
- [x] `vstash remember "text" --title x --project y` — end-to-end verified
- [x] `echo "text" | vstash remember --title x` — stdin pipe verified
- [ ] Verify MCP tool works via Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)