### PR TITLE
docs: update documentation for v0.9.0 and v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to vstash are documented here.
 
+## [0.10.0] — 2026-03-31
+
+### Added
+- **Hybrid code splitting** — 3-tier backend with graceful degradation:
+  1. **tree-sitter** (AST-level, 25+ languages) via optional `tree-sitter-language-pack`
+  2. **parso** (AST-level, Python only) — now a base dependency
+  3. **regex** (pattern-based, 6 languages) — original fallback
+- New `vstash/code_split.py` module with clean separation from `ingest.py`
+- **25+ language support** via tree-sitter: Python, JS/TS, Go, Rust, Java, C, C++, Ruby, PHP, Swift, Kotlin, Scala, Lua, R, C#, Bash, Zig, Elixir, Erlang, Haskell, OCaml, Dart, Vue, Svelte
+- **Backend-forcing tests** — each splitting tier tested independently via monkeypatching
+- **Unicode safety** — tree-sitter byte-offset handling correctly handles multi-byte characters
+- Optional dependency: `pip install vstash[treesitter]` for tree-sitter support
+
+### Fixed
+- UTF-8 byte vs char offset bug in tree-sitter backend (multi-byte characters safe)
+- Data loss between definitions — full source preserved by slicing between definition boundaries
+- C/C++ `declaration` node type added for proper function prototype recognition
+
+### Changed
+- `parso>=0.8.0` moved to base dependencies (was not included before)
+- Code splitting logic extracted from `ingest.py` into dedicated `code_split.py` module
+- 356 tests (up from 326)
+
+---
+
+## [0.9.0] — 2026-03-31
+
+### Added
+- **Auto-generated titles for `vstash remember`** — when no `--title` is provided, generates a slug from the first 5 words + UTC timestamp with microsecond precision (e.g. `oauth2-uses-pkce-20260330-143052474102`)
+- **`vstash forget` support for remembered text** — use `text://<title>` path prefix
+
+### Fixed
+- `Memory.remove()` no longer mangles `text://` synthetic paths via `Path.resolve()`
+- `ingest_text()` signature: `title` is now keyword-only, `cfg` and `store` are required positional params
+- Added missing `tests/__init__.py` — all tests now collect correctly
+
+---
+
 ## [0.8.0] — 2026-03-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,11 @@ vstash stats
 
 ```
 vstash/
-  __init__.py       # version (__version__ = "0.8.0")
-  cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export
+  __init__.py       # version (__version__ = "0.10.0")
+  cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember
   store.py          # VstashStore — SQLite + sqlite-vec + FTS5, RRF, scoring, MMR dedup, reindex
-  ingest.py         # parse → chunk → embed pipeline, code-aware chunking (6 languages)
+  ingest.py         # parse → chunk → embed pipeline
+  code_split.py     # hybrid code splitting: tree-sitter → parso → regex (25+ languages)
   embed.py          # FastEmbed ONNX + MLX backends, model registry (English + multilingual)
   config.py         # Pydantic v2 config from vstash.toml, all defaults
   chat.py           # LLM chat/ask with retrieval context
@@ -40,7 +41,9 @@ vstash/
 
 tests/
   test_store.py     # Store CRUD, search, MMR dedup, reindex, scoring, context expansion
-  test_ingest.py    # Ingestion, chunking, code-aware splitting
+  test_ingest.py    # Ingestion, chunking
+  test_code_split.py  # Hybrid code splitting backends (tree-sitter / parso / regex)
+  test_code_chunking.py # Code-aware chunking integration
   test_cli_commands.py  # CLI command tests
   test_scoring_e2e.py   # End-to-end scoring scenarios
   conftest.py       # Fixtures (tmp_db_path, sample_store)
@@ -56,7 +59,7 @@ docs/               # User-facing documentation
 - **Scoring**: Post-RRF re-ranking with frequency + temporal decay. Adaptive maturity gate (γ) suppresses scoring until access patterns show outlier signal.
 - **MMR dedup**: Intra-document Maximal Marginal Relevance replaces hard per-document dedup. `mmr_lambda=0.5` default, configurable.
 - **Embeddings**: FastEmbed (ONNX) or MLX (Apple Silicon). Default `BAAI/bge-small-en-v1.5` (384 dims). Multilingual models available via `vstash reindex`.
-- **Code-aware chunking**: Regex-based splitting at column-0 definitions for Python, JS/TS, Go, Rust, Java. 3-tier fallback: regex → paragraph → fixed-window.
+- **Code-aware chunking**: Hybrid 3-tier splitting — tree-sitter AST (25+ languages, optional) → parso AST (Python) → regex (6 languages). Graceful degradation. See `code_split.py`.
 - **Single SQLite file**: WAL mode, foreign keys, all data in one `.db`.
 
 ## Conventions
@@ -65,7 +68,7 @@ docs/               # User-facing documentation
 - **Pydantic v2** for all config and data models (frozen=True)
 - **Type hints** on all public functions
 - **ruff** for linting and formatting (enforced in CI)
-- **pytest** for testing (312 tests as of v0.8.0)
+- **pytest** for testing (356 tests as of v0.10.0)
 - **Conventional commits** with emoji prefixes (feat, fix, docs, chore, perf)
 
 ## Database schema

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Most RAG tools are slow, cloud-dependent, or require a running server. vstash is
 
 **Zero cloud required for search. Inference is optional.**
 
+### What's new in v0.10
+
+- **Hybrid code splitting** — 3-tier backend: tree-sitter AST → parso AST → regex fallback. Each backend gracefully degrades to the next.
+- **25+ languages** — tree-sitter support for C, C++, Ruby, PHP, Swift, Kotlin, Scala, Lua, R, C#, Bash, Zig, Elixir, Erlang, Haskell, OCaml, Dart, Vue, Svelte (plus all previously supported).
+- **Optional install** — `pip install vstash[treesitter]` for tree-sitter, or use parso (Python) + regex (6 languages) by default.
+
+### What's new in v0.9
+
+- **Auto-generated titles** — `vstash remember` generates descriptive slugs when no `--title` is provided.
+- **Forget remembered text** — `vstash forget "text://<title>"` removes text ingested via `remember`.
+
 ### What's new in v0.8
 
 - **Multilingual embeddings** — search in any language. Queries in English and Spanish return the same results. Cross-lingual similarity improves ~40%.
@@ -194,7 +205,9 @@ For full privacy, use `backend = "ollama"` or skip inference entirely and use `v
 
 ## Supported File Types
 
-PDF, DOCX, PPTX, XLSX, Markdown, TXT, HTML, CSV, Python, JavaScript, TypeScript, Go, Rust, Java — and any URL.
+PDF, DOCX, PPTX, XLSX, Markdown, TXT, HTML, CSV — and any URL.
+
+**Code files (25+ languages with tree-sitter):** Python, JavaScript, TypeScript, Go, Rust, Java, C, C++, Ruby, PHP, Swift, Kotlin, Scala, Lua, R, C#, Bash, Zig, Elixir, Erlang, Haskell, OCaml, Dart, Vue, Svelte.
 
 ---
 
@@ -242,7 +255,8 @@ Run all experiments: `python -m experiments.run_all`
 - **Phase 5 ✅:** Memory scoring — frequency + temporal decay re-ranking
 - **Phase 6 ✅:** Retrieval quality — distance-based relevance signal, document dedup, context expansion
 - **Phase 7 ✅:** Multilingual — cross-lingual embeddings, `vstash reindex`, MMR dedup
-- **Phase 8:** Sync — cr-sqlite CRDT peer-to-peer sync, multiple profiles
+- **Phase 8 ✅:** Hybrid code splitting — tree-sitter + parso + regex, 25+ languages
+- **Phase 9:** Sync — cr-sqlite CRDT peer-to-peer sync, multiple profiles
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ top_k = 5
 code_aware = true
 ```
 
-When `code_aware` is enabled, source code files (Python, JS/TS, Go, Rust, Java) are split at top-level function and class definitions. Non-code files use semantic chunking (Markdown headers → paragraphs → fixed-window fallback).
+When `code_aware` is enabled, source code files are split at top-level function and class definitions using a 3-tier backend: tree-sitter AST (25+ languages, requires `pip install vstash[treesitter]`) → parso AST (Python, included by default) → regex (Python, JS/TS, Go, Rust, Java). Non-code files use semantic chunking (Markdown headers → paragraphs → fixed-window fallback).
 
 ---
 

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -1,6 +1,6 @@
 # Future Improvements
 
-Consolidated from past reviews, plans, and brainstorms. Only items that remain relevant as of v0.5.1.
+Consolidated from past reviews, plans, and brainstorms. Only items that remain relevant as of v0.10.0.
 
 ---
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -39,19 +39,28 @@ text
 
 Headers stay with their body content. Paragraphs aren't torn mid-sentence. Tiny fragments are merged to avoid low-quality embeddings.
 
-**Code-aware chunking** (Python, JS/TS, Go, Rust, Java):
+**Code-aware chunking** (25+ languages):
 
 ```
 source code
-  → split at function/class definitions   (regex at column 0)
+  → detect language from extension        (.py → python, .go → go, etc.)
+  → try tree-sitter AST splitting         (25+ languages, optional dependency)
+  → try parso AST splitting               (Python only, base dependency)
+  → fall back to regex splitting          (Python, JS/TS, Go, Rust, Java)
   → attach decorators to their function   (Python @decorator, Java @Annotation)
   → fallback for oversized functions      (paragraph → fixed-window)
   → merge small chunks                    (imports, constants get merged)
 ```
 
-Each chunk starts at a top-level definition (`def`, `class`, `func`, `fn`, etc.). Indented methods stay inside their class. Decorators and annotations stay attached to their function.
+The splitting backend is selected automatically with graceful degradation:
 
-Supported languages: Python, JavaScript, TypeScript (including JSX/TSX), Go, Rust, Java.
+| Backend | Languages | Resolution | Install |
+|---------|-----------|------------|---------|
+| **tree-sitter** | 25+ (C, C++, Ruby, PHP, Swift, Kotlin, Scala, etc.) | AST-level — exact definition boundaries | `pip install vstash[treesitter]` |
+| **parso** | Python only | AST-level — funcdef, classdef, decorated | Included by default |
+| **regex** | Python, JS/TS, Go, Rust, Java | Pattern-based — column-0 definitions | Included by default |
+
+Each chunk starts at a top-level definition (`def`, `class`, `func`, `fn`, etc.). Indented methods stay inside their class. Decorators and annotations stay attached to their function. Preambles (imports, package declarations) are preserved as a separate chunk.
 
 Disable code-aware chunking with `code_aware = false` in `[chunking]` — files will fall back to markitdown + semantic chunking.
 

--- a/docs/vstash_SKILL_v0.10.0.md
+++ b/docs/vstash_SKILL_v0.10.0.md
@@ -1,0 +1,188 @@
+---
+name: vstash
+description: >
+  Persistent memory system for Jay using vstash MCP tools. USE THIS SKILL at the
+  start of EVERY session to load context from previous sessions. Also use it
+  whenever Jay mentions past work, projects, decisions, or asks about something
+  that might have been discussed before — even casually (like "remember when we...",
+  "what did we decide about...", "how does X work again?").
+  Always proactively ingest important new information during sessions — architectural
+  decisions, project names, benchmarks, key outcomes, action items. Clean up
+  irrelevant or outdated data when it's no longer useful.
+  vstash is Jay's long-term memory. Treat it as the source of truth for context
+  across sessions.
+---
+
+# vstash Memory System
+
+Jay uses vstash as persistent memory between Cowork sessions. The MCP tools
+connect directly to his Mac. Use them without asking for permission.
+
+## Session Start Protocol
+
+At the start of every session, before answering questions that might involve
+past context, run:
+
+```
+vstash_ask("current projects, decisions, and context for Jay")
+```
+
+Use the result silently to inform your responses. Don't announce "I queried
+vstash" unless it's directly relevant to the user's question.
+
+---
+
+## Saving to vstash
+
+Always use `vstash_remember(text="...", title="...")`. The `title` parameter
+makes each note identifiable in search results — **always provide one**.
+
+If `title` is omitted, vstash auto-generates a slug from the first words +
+UTC timestamp (e.g. `oauth2-uses-pkce-for-public-20260330-143052474102`).
+This is useful but less readable — prefer explicit titles.
+
+**Naming convention for title:** `YYYY-MM-DD — Topic`
+Examples: `2026-03-31 — Meetings`, `2026-03-30 — Daily Outlook`, `2026-03-30 — Decision: Auth Flow`
+
+**Example:**
+```python
+vstash_remember(
+    text="- 11:30 OKR Monthly Review\n- 13:00 Daily standup...",
+    title="2026-03-31 — Meetings"
+)
+```
+
+### vstash_add (for files and URLs only)
+
+vstash runs on Jay's Mac. The MCP server cannot see VM paths like /sessions/...
+
+| VM path (write files here) | Mac path (use in vstash_add) |
+|---|---|
+| /sessions/[session]/mnt/Personal/Projects/vstash-memory/ | /Users/jaysonsteffens/Desktop/Personal/Projects/vstash-memory/ |
+
+Never call vstash_add with a /sessions/... path — it will always fail.
+
+---
+
+## When to Ingest
+
+Save information to vstash when:
+- An important architectural or technical decision is made
+- A project reaches a milestone (shipped, published, merged, etc.)
+- Key benchmarks or data points are established
+- Action items or next steps are agreed upon
+- Personal context about Jay's work or preferences is shared
+
+Keep entries concise. Use headers: ## Project, ## Decision, ## Context, ## Next Steps
+
+## When to Forget
+
+Remove documents from vstash when:
+- Information is outdated and replaced by newer context
+- A project was abandoned or renamed
+- Temporary test data is no longer needed
+
+Use the **full path** with `vstash_forget`:
+- Files: `vstash_forget("<Mac file path>")`
+- URLs: `vstash_forget("<url>")`
+- Text ingested via `vstash_remember`: `vstash_forget("text://<title>")`
+
+Examples:
+```
+vstash_forget("/Users/jaysonsteffens/Desktop/notes.md")
+vstash_forget("https://example.com/article")
+vstash_forget("text://2026-03-31 — Meetings")
+```
+
+To find the correct path, use `vstash_list()` or `vstash_search()` first.
+
+---
+
+## Key Context About Jay
+
+- Works in QA at Pluxee, experiments with dev tools personally
+- Hardware: Apple M4 Pro 24GB
+- GitHub: stffns | PyPI: vstash published at pypi.org/project/vstash
+- Cerebras API key stored in ~/.vstash/vstash.toml
+- vstash project directory: ~/Desktop/Personal/Projects/vex/
+- Memory folder: ~/Desktop/Personal/Projects/vstash-memory/
+- vstash MCP server configured in Claude Desktop
+
+## Current Version: 0.10.0 (March 2026)
+
+### v0.10.0 — Hybrid Code Splitting
+- **3-tier code splitting**: tree-sitter AST → parso AST → regex fallback
+- **25+ languages** via optional `tree-sitter-language-pack`
+- **parso** added as base dependency for Python AST splitting
+- **UTF-8 safe** byte-offset handling in tree-sitter backend
+- New `vstash/code_split.py` module — 356 tests passing
+
+### v0.9.0 — Auto-Generated Titles & SDK Fix
+- **Auto-generated descriptive titles for `vstash remember`:** When no `title`
+  is provided, vstash generates a slug from the first 5 words + UTC timestamp
+  with microsecond precision (e.g. `oauth2-uses-pkce-20260330-143052474102`).
+- **`Memory.remove()` fix:** `text://` paths are no longer mangled by
+  `Path.resolve()`, so `forget` works correctly from the Python SDK.
+- **`ingest_text()` signature change:** `title` is now keyword-only,
+  `cfg` and `store` are required positional params.
+- **Test suite fix:** Added missing `tests/__init__.py` — 326/326 tests passing.
+
+### v0.8.0–0.8.1 — Direct Text Ingestion & Code Chunking
+- **`vstash remember` command:** Ingest text directly without writing files.
+  Agent-friendly alternative to `vstash add`.
+- **Code-aware chunking:** Regex-based splitting at column-0 definitions
+  for Python, JS/TS, Go, Rust, Java. 3-tier fallback: regex → paragraph → fixed-window.
+- **Multilingual embeddings:** Search in any language via `vstash reindex`.
+- **Python SDK (`from vstash import Memory`):** Programmatic access to
+  add, search, ask, remember, remove, list, stats.
+- **LangChain integration:** `VstashRetriever` for LangChain pipelines.
+- **MCP server:** Full tool suite for Claude Desktop integration.
+
+### v0.7.0 — Adaptive Scoring & Cold Start Fix
+- **Adaptive scoring with maturity gate (γ):** suppresses frequency+decay signals
+  until access patterns show genuine signal.
+- **Zero-cost cold start:** when γ = 0, scoring overhead is eliminated entirely.
+
+### v0.6.0 — Confidence & Deduplication
+- **Distance-based confidence signals** for relevance filtering (F1=0.952)
+- **Document deduplication** — diversity improved to 5.0 unique docs per top-5
+- **Context expansion** with adjacent chunks (±1) for 2.64× richer LLM context
+- **LLM grounding** with anti-hallucination system prompt rules
+
+### Key Capabilities
+- Hybrid ranking via Reciprocal Rank Fusion (semantic + keyword)
+- FastEmbed for embeddings (~700 chunks/s, fully local ONNX)
+- SQLite-vec vector store in single `.db` file
+- Supports: PDF, DOCX, PPTX, XLSX, Markdown, HTML, CSV, code files, URLs
+- Hybrid code-aware chunking: tree-sitter (25+ langs) → parso (Python) → regex (6 langs)
+- Privacy: search is 100% local; only inference hits external APIs
+- Ollama option for fully private inference
+
+## Tools Available (MCP)
+
+| Tool | Use for |
+|------|---------|
+| vstash_ask(query) | Query memory with LLM answer |
+| vstash_search(query) | Raw retrieval without LLM (free, fast) |
+| vstash_remember(text, title) | Ingest text content directly — always pass title |
+| vstash_add(path, collection, project, layer, tags) | Ingest file or URL (Mac paths only) |
+| vstash_forget(source) | Remove document (use `text://<title>` for remembered text) |
+| vstash_list() | List all ingested documents |
+| vstash_stats() | Check DB size and doc count |
+| vstash_collections() | List all collections |
+| vstash_export() | Export data as JSONL for curation |
+| vstash_job(job_id) | Check status of background ingestion (directories) |
+
+## CLI Commands (on Mac)
+
+| Command | Use for |
+|---------|---------|
+| `vstash add` | Ingest documents |
+| `vstash remember` | Ingest text directly (with optional `--title`) |
+| `vstash search` | Local semantic search (free) |
+| `vstash ask` | LLM-powered Q&A |
+| `vstash chat` | Interactive sessions |
+| `vstash list` / `vstash stats` / `vstash forget` | Management |
+| `vstash watch` | File change monitoring |
+| `vstash export` | JSONL data curation |
+| `vstash config` | Display configuration |


### PR DESCRIPTION
## Summary
- CHANGELOG: add v0.9.0 and v0.10.0 entries
- README: "What's new" sections, 25+ languages, updated roadmap
- how-it-works: rewrite code chunking with 3-tier backend table
- configuration: update chunking description
- CLAUDE.md: version, structure, test count
- Rename skill file to v0.10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)