### PR TITLE
feat: add extra_body support for OpenAI-compatible APIs

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -116,6 +116,20 @@ class TestConfigModelValidate:
         assert cfg.inference.backend == "cerebras"
         assert cfg.chunking.size == 1024
 
+    def test_openai_extra_body(self) -> None:
+        raw = {
+            "openai": {
+                "model": "Qwen/Qwen3-32B",
+                "extra_body": {"chat_template_kwargs": {"enable_thinking": True}},
+            }
+        }
+        cfg = VstashConfig.model_validate(raw)
+        assert cfg.openai.extra_body == {"chat_template_kwargs": {"enable_thinking": True}}
+
+    def test_openai_extra_body_default_none(self) -> None:
+        cfg = VstashConfig.model_validate({})
+        assert cfg.openai.extra_body is None
+
 
 class TestLoadConfig:
     """Test load_config file resolution."""

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -319,15 +319,13 @@ def _ask_openai(
     model = cfg.openai.model
 
     try:
-        kwargs: dict = dict(
+        response = client.chat.completions.create(
             model=model,
-            messages=messages,
+            messages=messages,  # type: ignore[arg-type]
             max_completion_tokens=2048,
             temperature=0.2,
+            extra_body=cfg.openai.extra_body,
         )
-        if cfg.openai.extra_body:
-            kwargs["extra_body"] = cfg.openai.extra_body
-        response = client.chat.completions.create(**kwargs)  # type: ignore[arg-type]
         return response.choices[0].message.content or ""
     except Exception as exc:
         raise ConnectionError(f"OpenAI API error: {exc}") from exc
@@ -371,16 +369,14 @@ def _stream_openai(
     model = cfg.openai.model
 
     try:
-        kwargs: dict = dict(
+        response_stream = client.chat.completions.create(
             model=model,
-            messages=messages,
+            messages=messages,  # type: ignore[arg-type]
             max_completion_tokens=2048,
             temperature=0.2,
             stream=True,
+            extra_body=cfg.openai.extra_body,
         )
-        if cfg.openai.extra_body:
-            kwargs["extra_body"] = cfg.openai.extra_body
-        response_stream = client.chat.completions.create(**kwargs)  # type: ignore[arg-type]
         for chunk in response_stream:
             if chunk.choices and chunk.choices[0].delta.content:
                 yield chunk.choices[0].delta.content

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -77,7 +77,7 @@ class OpenAIConfig(BaseModel):
         default=None,
         description="Custom base URL for OpenAI-compatible APIs",
     )
-    extra_body: dict | None = Field(
+    extra_body: dict[str, object] | None = Field(
         default=None,
         description="Extra JSON body fields passed to chat completions (e.g., chat_template_kwargs for Qwen thinking mode)",
     )


### PR DESCRIPTION
## Summary
- Adds `openai.extra_body` config field for passing arbitrary JSON to OpenAI chat completions
- Useful for OpenAI-compatible APIs that need extra params (e.g., Qwen thinking mode `chat_template_kwargs`, vLLM sampling params)
- Applied to both `_ask_openai` and `_stream_openai` in `chat.py`

### Usage
```toml
[openai]
backend = "openai"
model = "Qwen/Qwen3-32B"
base_url = "http://localhost:8000/v1"

[openai.extra_body]
chat_template_kwargs = { enable_thinking = true }
```

### Files changed
| File | Change |
|------|--------|
| `vstash/config.py` | Add `extra_body: dict \| None` to `OpenAIConfig` |
| `vstash/chat.py` | Pass `extra_body` to `client.chat.completions.create()` |

## Test plan
- [x] 348 tests pass, zero regressions
- [x] ruff clean
- [ ] Manual: `vstash ask` with `extra_body` in vstash.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)