### PR TITLE
🔖 chore: bump version to 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 All notable changes to vstash are documented here.
 
-## [0.10.2] — 2026-04-01
+## [0.10.3] — 2026-04-01
 
 ### Added
-- **`openai.extra_body` config** — pass arbitrary JSON fields to OpenAI-compatible chat completions (e.g., `chat_template_kwargs` for Qwen thinking mode, vLLM sampling params)
 - **Watch mode file deletion** — `on_deleted` handler automatically removes deleted files from the store
 - **Stream interruption warning** — shows "Stream interrupted after N tokens" on mid-stream errors
 - **Frontmatter validation warnings** — warns when `project`/`layer` is a dict/list instead of silently dropping
@@ -25,6 +24,14 @@ All notable changes to vstash are documented here.
 
 ### Changed
 - 447 tests (up from 368), including 9 watch e2e integration tests and 13 robustness tests
+
+---
+
+## [0.10.2] — 2026-04-01
+
+### Added
+- **`openai.extra_body` config** — pass arbitrary JSON fields to OpenAI-compatible chat completions (e.g., `chat_template_kwargs` for Qwen thinking mode, vLLM sampling params)
+- 2 new config tests for `extra_body` loading
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ vstash stats
 
 ```
 vstash/
-  __init__.py       # version (__version__ = "0.10.2")
+  __init__.py       # version (__version__ = "0.10.3")
   cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember
   store.py          # VstashStore — SQLite + sqlite-vec + FTS5, RRF, scoring, MMR dedup, reindex
   ingest.py         # parse → chunk → embed pipeline
@@ -74,7 +74,7 @@ docs/               # User-facing documentation
 - **Pydantic v2** for all config and data models (frozen=True)
 - **Type hints** on all public functions
 - **ruff** for linting and formatting (enforced in CI)
-- **pytest** for testing (447 tests as of v0.10.2)
+- **pytest** for testing (447 tests as of v0.10.3)
 - **Conventional commits** with emoji prefixes (feat, fix, docs, chore, perf)
 
 ## Database schema

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats


### PR DESCRIPTION
## Summary

- Bump version to 0.10.3 for PyPI publish with robustness fixes
- Update CHANGELOG with v0.10.3 section
- Update CLAUDE.md version refs

## Test plan

- [x] Version bump only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)