### PR TITLE
🔖 chore: bump version to 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to vstash are documented here.
 
+## [0.10.4] — 2026-04-01
+
+### Added
+- **`delete_by_path_prefix` empty-prefix guard** — raises `ValueError` on empty prefix to prevent accidental full wipe
+- **4 tests for `delete_by_path_prefix`** — basic prefix match, zero-match returns 0, SQL LIKE wildcard escaping (%, _), empty-prefix ValueError
+
+---
+
 ## [0.10.3] — 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Most RAG tools are slow, cloud-dependent, or require a running server. vstash is
 
 **Zero cloud required for search. Inference is optional.**
 
+### What's new in v0.10.4
+
+- **`delete_by_path_prefix` safety** — empty-prefix guard prevents accidental full-wipe; SQL LIKE wildcards properly escaped.
+- **4 new tests** — prefix matching, zero-match, special character escaping, empty-prefix ValueError.
+
 ### What's new in v0.10.3
 
 - **API retry with backoff** — transient errors (429, 503, timeout) are retried automatically across all inference backends.

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats


### PR DESCRIPTION
## Summary
- Bump version to 0.10.4 for PyPI publish
- Update CHANGELOG and README with v0.10.4 notes (delete_by_path_prefix guard + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)