### PR TITLE
🔖 chore: bump version to 0.12.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,10 @@ vstash stats
 
 ```
 vstash/
-  __init__.py       # version (__version__ = "0.11.0")
-  cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile
+  __init__.py       # version (__version__ = "0.12.0")
+  cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile, journal
   profile.py        # Multi-profile management: resolution chain, CRUD, federated search
+  journal.py        # Cross-session memory: save, recall, log, prune, transcript parsing
   store.py          # VstashStore — SQLite + sqlite-vec + FTS5, RRF, scoring, MMR dedup, reindex
   ingest.py         # parse → chunk → embed pipeline
   code_split.py     # hybrid code splitting: tree-sitter → parso → regex (25+ languages)
@@ -53,6 +54,7 @@ tests/
   test_retry_e2e.py   # Retry with backoff e2e tests
   test_url_titles_e2e.py # URL title extraction e2e tests
   test_profile.py   # Multi-profile resolution, management, federated search, CLI, SDK
+  test_journal.py   # Journal save/recall/log/prune, CLI, SDK, MCP, transcript parsing
   conftest.py       # Fixtures (tmp_db_path, sample_store)
 
 experiments/        # Research experiment scripts + results
@@ -76,7 +78,7 @@ docs/               # User-facing documentation
 - **Pydantic v2** for all config and data models (frozen=True)
 - **Type hints** on all public functions
 - **ruff** for linting and formatting (enforced in CI)
-- **pytest** for testing (490 tests as of v0.11.0)
+- **pytest** for testing (521 tests as of v0.12.0)
 - **Conventional commits** with emoji prefixes (feat, fix, docs, chore, perf)
 
 ## Database schema

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 from .memory import Memory
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats


### PR DESCRIPTION
## Summary
- Version bump to 0.12.0 for journal feature release
- Update CLAUDE.md: add journal.py, test_journal.py, update test count (521)

🤖 Generated with [Claude Code](https://claude.com/claude-code)