### PR TITLE
📝 docs: fix dedup contradictions and update tool lists

### DIFF
--- a/docs/claude-integration.md
+++ b/docs/claude-integration.md
@@ -164,10 +164,13 @@ After restart, Claude will have these tools available:
 | `vstash_search` | Semantic search across all documents |
 | `vstash_ask` | Search + LLM answer in one step |
 | `vstash_add` | Ingest files, directories, or URLs |
+| `vstash_remember` | Ingest text directly without a file |
+| `vstash_get_chunk` | Retrieve a chunk by database row ID |
 | `vstash_list` | List all documents in memory |
 | `vstash_stats` | Memory statistics |
-| `vstash_find` | Find a document by partial name |
-| `vstash_forget` | Remove a document |
+| `vstash_forget` | Remove a document (supports fuzzy matching) |
+| `vstash_journal_save` | Save a cross-session memory entry |
+| `vstash_journal_recall` | Search journal entries |
 
 **4. Add documents**
 

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -425,12 +425,22 @@ vstash as a building block for agents and pipelines.
 - [x] SDK benchmark suite
 - [x] 147 pytest tests across 9 test modules
 
-### Phase 4 — Sync & Integrations
+### Phase 4 — Profiles & Agent Memory ✅ Done (v0.11.0–v0.13.0)
+Multi-profile support, cross-session journal, and direct chunk access.
+
+- [x] Multiple memory profiles: `vstash --profile work ask "..."` (v0.11.0)
+- [x] Federated search across profiles (v0.11.0)
+- [x] Cross-session journal: save/recall/log/prune (v0.12.0)
+- [x] Transcript parsing for Claude Code sessions (v0.12.0)
+- [x] Direct chunk access: `get_chunk(id)` / `get_chunks(ids)` (v0.13.0)
+- [x] `ChunkInfo` model for typed chunk lookups (v0.13.0)
+- [x] 556 pytest tests across 14 test modules
+
+### Phase 5 — Sync & Integrations
 Share memory across machines and expose to non-Python tools.
 
 - [ ] `cr-sqlite` integration — CRDT-based SQLite sync (peer-to-peer)
 - [ ] `vstash sync` — merge two `.db` files intelligently
-- [ ] Multiple memory profiles: `vstash --profile work ask "..."`
 - [ ] REST API mode (opt-in, local only) for non-Python integrations
 - [ ] Web UI (optional, lightweight, localhost only)
 
@@ -448,7 +458,7 @@ Share memory across machines and expose to non-Python tools.
 - **sqlite-vec** is new and underused — devs will want to see it in production
 - **Backend agnostic** — Cerebras for speed, OpenAI for flexibility, Ollama for privacy
 - **Dead simple** — `pip install vstash`, one config file, running in 5 minutes
-- **Typed and tested** — Pydantic v2 models + 147 pytest tests across 9 modules
+- **Typed and tested** — Pydantic v2 models + 556 pytest tests across 14 modules
 - **Benchmarked** — E2E timing, grep comparison, chunking A/B, SDK overhead, scalability to 500K chunks
 
 ---

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -108,11 +108,19 @@ The **adaptive maturity gate (γ)** scales the frequency component based on how 
 
 Chunks you search for often and recently get a boost. See [Memory Scoring](scoring.md) for the full explanation, parameters, and tuning guide.
 
-### Document Deduplication
+### Intra-Document MMR Deduplication
 
-*Added in v0.6.0*
+*Hard dedup added in v0.6.0 · Replaced by MMR in v0.8.0*
 
-After scoring, multiple chunks from the same document often cluster in the top-*k*. vstash deduplicates by keeping only the highest-scoring chunk per document path before truncating to `top_k`. This improves result diversity from ~3.2 to 5.0 unique documents per top-5 while also improving NDCG@5 by +1.8%.
+After scoring, multiple chunks from the same document often cluster in the top-*k*. vstash applies **Maximal Marginal Relevance (MMR)** within documents to balance relevance and diversity:
+
+```
+MMR(c) = λ · score(c) − (1 − λ) · max_sim(c, selected_same_doc)
+```
+
+Chunks from *different* documents compete purely on score. When multiple chunks from the *same* document are candidates, the second is penalized by its cosine similarity to the first. If two sections are semantically diverse, both appear; if they're near-duplicates, the second is suppressed.
+
+Configure with `mmr_lambda` (default 0.5): 0.0 = maximum diversity, 1.0 = one chunk per document (old hard dedup behavior). See [Memory Scoring](scoring.md#intra-document-mmr-deduplication) for the full explanation.
 
 ### Distance-Based Relevance Signal
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -42,14 +42,20 @@ The vstash tools should appear in Claude's tool list.
 | Tool | Description |
 |------|-------------|
 | `vstash_add(path)` | Ingest a file, directory, or URL into memory |
+| `vstash_remember(text, title)` | Ingest text directly without a file |
 | `vstash_ask(query, top_k)` | Semantic search + LLM-generated answer with sources |
 | `vstash_search(query, top_k)` | Hybrid search with context expansion and relevance signal |
+| `vstash_get_chunk(chunk_id)` | Retrieve a single chunk by database row ID |
 | `vstash_list()` | List all ingested documents |
 | `vstash_stats()` | Database statistics (doc count, chunks, size) |
 | `vstash_forget(source)` | Remove a document from memory |
 | `vstash_collections()` | List all available collections |
 | `vstash_export(...)` | Export chunks with metadata for training data curation |
 | `vstash_job(job_id)` | Check status of background directory ingestion |
+| `vstash_journal_save(text)` | Save a journal entry (cross-session memory) |
+| `vstash_journal_recall(query)` | Search journal entries semantically |
+| `vstash_journal_log()` | List recent journal entries chronologically |
+| `vstash_journal_prune(older_than)` | Remove old journal entries |
 
 ### Search Response Fields
 

--- a/docs/vstash_SKILL_v0.10.0.md
+++ b/docs/vstash_SKILL_v0.10.0.md
@@ -127,9 +127,12 @@ To find the correct path, use `vstash_list()` or `vstash_search()` first.
   `cfg` and `store` are required positional params.
 - **Test suite fix:** Added missing `tests/__init__.py` — 326/326 tests passing.
 
-### v0.8.0–0.8.1 — Direct Text Ingestion & Code Chunking
+### v0.8.0–0.8.1 — Direct Text Ingestion, Code Chunking & MMR
 - **`vstash remember` command:** Ingest text directly without writing files.
   Agent-friendly alternative to `vstash add`.
+- **MMR deduplication:** Replaced hard per-document dedup with intra-document
+  Maximal Marginal Relevance. Multiple chunks from the same document can appear
+  if semantically diverse. Configurable via `mmr_lambda`.
 - **Code-aware chunking:** Regex-based splitting at column-0 definitions
   for Python, JS/TS, Go, Rust, Java. 3-tier fallback: regex → paragraph → fixed-window.
 - **Multilingual embeddings:** Search in any language via `vstash reindex`.


### PR DESCRIPTION
## Summary
- **how-it-works.md**: Replace outdated hard dedup section with MMR explanation (was describing pre-v0.8 behavior)
- **vstash_SKILL**: Add MMR to v0.8.0 changelog (was missing)
- **constitution.md**: Add Phase 4 (profiles v0.11, journal v0.12, get_chunk v0.13), update test count 147→556
- **mcp-server.md**: Add missing tools (remember, get_chunk, journal_save/recall/log/prune)
- **claude-integration.md**: Remove nonexistent `vstash_find`, add new tools (remember, get_chunk, journal)

## Context
Found contradictions where how-it-works.md described hard per-document dedup (v0.6.0) but the code has used MMR since v0.8.0. Also multiple docs had stale tool lists missing features added in v0.11–v0.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)