### PR TITLE
feat: dynamic chunk_size in Memory and CLI (#92)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,22 @@ code_aware = true
 
 When `code_aware` is enabled, source code files are split at top-level function and class definitions using a 3-tier backend: tree-sitter AST (25+ languages, requires `pip install vstash[treesitter]`) → parso AST (Python, included by default) → regex (Python, JS/TS, Go, Rust, Java). Non-code files use semantic chunking (Markdown headers → paragraphs → fixed-window fallback).
 
+**Per-document override:** Chunk size can be overridden per document via the SDK or CLI without changing the config file:
+
+```python
+# SDK — larger chunks for medical/legal documents
+mem = Memory(project="medical", chunk_size=2048, chunk_overlap=256)
+mem.add("protocol.pdf")                        # uses 2048
+mem.add("code.py", chunk_size=512)             # per-file override
+```
+
+```bash
+# CLI
+vstash add paper.pdf --chunk-size 2048 --chunk-overlap 256
+```
+
+Validation: `chunk_size` must be positive, `chunk_overlap` must be non-negative and less than `chunk_size`.
+
 ---
 
 ## `[scoring]`

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -372,3 +372,55 @@ class TestSdkDbResolution:
             mem = Memory(db=explicit)
             assert mock_store.call_args[0][0] == explicit
             mem.close()
+
+
+# ------------------------------------------------------------------ #
+# Dynamic chunk_size                                                   #
+# ------------------------------------------------------------------ #
+
+
+class TestDynamicChunkSize:
+    """Test chunk_size/chunk_overlap parameters in Memory."""
+
+    def test_constructor_chunk_size(self, tmp_db_path: str) -> None:
+        """Constructor chunk_size is stored and used."""
+        mem = Memory(db=tmp_db_path, chunk_size=2048, chunk_overlap=256)
+        assert mem._chunk_size == 2048
+        assert mem._chunk_overlap == 256
+        mem.close()
+
+    def test_default_chunk_size_is_none(self, tmp_db_path: str) -> None:
+        mem = Memory(db=tmp_db_path)
+        assert mem._chunk_size is None
+        assert mem._chunk_overlap is None
+        mem.close()
+
+    def test_per_call_chunk_size_override(self, tmp_db_path: str) -> None:
+        """Per-call chunk_size produces different chunk counts."""
+        with Memory(db=tmp_db_path) as mem:
+            # Small chunk_size → more chunks
+            mem.remember("word " * 2000, title="small-chunks", chunk_size=256)
+            stats1 = mem.stats()
+            count_small = stats1.chunks
+
+            mem.remember("word " * 2000, title="large-chunks", chunk_size=4096)
+            stats2 = mem.stats()
+            count_large = stats2.chunks - count_small
+
+            assert count_small > count_large
+
+    def test_constructor_chunk_size_used_by_add(self, tmp_db_path: str) -> None:
+        """Constructor chunk_size flows through to add()."""
+        with Memory(db=tmp_db_path, chunk_size=512) as mem:
+            mem.add("tests/conftest.py")
+            stats = mem.stats()
+            chunk_count_512 = stats.chunks
+
+        with Memory(db=tmp_db_path + "_large") as mem2:
+            mem2.add("tests/conftest.py", chunk_size=4096)
+            stats2 = mem2.stats()
+            chunk_count_4096 = stats2.chunks
+            mem2.close()
+
+        # Smaller chunk_size should produce more chunks
+        assert chunk_count_512 >= chunk_count_4096

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -155,6 +155,12 @@ def add(
     tags: str | None = typer.Option(
         None, "--tags", "-t", help="Comma-separated tags (overrides frontmatter)"
     ),
+    chunk_size: int | None = typer.Option(
+        None, "--chunk-size", help="Override chunk size in tokens (default: from config)"
+    ),
+    chunk_overlap: int | None = typer.Option(
+        None, "--chunk-overlap", help="Override chunk overlap in tokens (default: from config)"
+    ),
 ) -> None:
     """Add documents or URLs to memory."""
     cfg, store = _get_store(profile=_profile_from_ctx(ctx))
@@ -173,6 +179,8 @@ def add(
                     store,
                     force=force,
                     collection=collection,
+                    chunk_size=chunk_size,
+                    chunk_overlap=chunk_overlap,
                     **meta,
                 )
                 ok = [r for r in results if r.status == "ok"]
@@ -193,6 +201,8 @@ def add(
                 store,
                 force=force,
                 collection=collection,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
                 **meta,
             )
 
@@ -518,8 +528,12 @@ def search(
                     lines.append("  FTS:     not in keyword results (vector-only match)")
 
                 # RRF
+                weight_info = ""
+                if ex.rrf_vec_weight is not None:
+                    weight_info = f" w={ex.rrf_vec_weight:.1f}/{ex.rrf_fts_weight:.1f}"
                 lines.append(
-                    f"  RRF:     {ex.rrf_total:.4f} (vec: {ex.rrf_vec:.4f} + fts: {ex.rrf_fts:.4f})"
+                    f"  RRF:     {ex.rrf_total:.4f} "
+                    f"(vec: {ex.rrf_vec:.4f} + fts: {ex.rrf_fts:.4f}){weight_info}"
                 )
 
                 # Scoring (only if active)
@@ -1030,6 +1044,12 @@ def remember(
     project: str | None = typer.Option(None, "--project", "-p", help="Project tag"),
     layer: str | None = typer.Option(None, "--layer", "-l", help="Layer tag"),
     tags: str | None = typer.Option(None, "--tags", help="Comma-separated tags"),
+    chunk_size: int | None = typer.Option(
+        None, "--chunk-size", help="Override chunk size in tokens"
+    ),
+    chunk_overlap: int | None = typer.Option(
+        None, "--chunk-overlap", help="Override chunk overlap in tokens"
+    ),
 ) -> None:
     """Ingest text directly — no file needed.
 
@@ -1064,6 +1084,8 @@ def remember(
             store,
             title=title,
             collection=collection,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
             **meta,
         )
 

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -505,6 +505,12 @@ def ingest(
     with console.status("[bold cyan]Chunking...[/bold cyan]", spinner="dots"):
         cs = chunk_size if chunk_size is not None else cfg.chunking.size
         co = chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap
+        if cs <= 0:
+            raise ValueError(f"chunk_size must be positive, got {cs}")
+        if co < 0:
+            raise ValueError(f"chunk_overlap must be non-negative, got {co}")
+        if co >= cs:
+            raise ValueError(f"chunk_overlap ({co}) must be less than chunk_size ({cs})")
         if is_code:
             ext = Path(source).suffix.lower()
             language = _EXT_TO_LANG.get(ext, "")
@@ -632,11 +638,15 @@ def ingest_text(
     text = _strip_frontmatter(text)
 
     # Chunk
-    chunks = chunk_text(
-        text,
-        chunk_size if chunk_size is not None else cfg.chunking.size,
-        chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap,
-    )
+    cs = chunk_size if chunk_size is not None else cfg.chunking.size
+    co = chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap
+    if cs <= 0:
+        raise ValueError(f"chunk_size must be positive, got {cs}")
+    if co < 0:
+        raise ValueError(f"chunk_overlap must be non-negative, got {co}")
+    if co >= cs:
+        raise ValueError(f"chunk_overlap ({co}) must be less than chunk_size ({cs})")
+    chunks = chunk_text(text, cs, co)
     if not chunks:
         return IngestResult(status="empty", source=source_path)
 

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -398,6 +398,8 @@ def ingest(
     project: str | None = None,
     layer: str | None = None,
     tags: str | None = None,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
 ) -> IngestResult:
     """Ingest a single file or URL into the store.
 
@@ -501,12 +503,14 @@ def ingest(
 
     # --- Step 3: Chunk ---
     with console.status("[bold cyan]Chunking...[/bold cyan]", spinner="dots"):
+        cs = chunk_size or cfg.chunking.size
+        co = chunk_overlap or cfg.chunking.overlap
         if is_code:
             ext = Path(source).suffix.lower()
             language = _EXT_TO_LANG.get(ext, "")
-            chunks = chunk_code(text, cfg.chunking.size, cfg.chunking.overlap, language)
+            chunks = chunk_code(text, cs, co, language)
         else:
-            chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
+            chunks = chunk_text(text, cs, co)
 
     if not chunks:
         console.print(f"[yellow]⚠ No chunks generated from {source}[/yellow]")
@@ -569,6 +573,8 @@ def ingest_text(
     project: str | None = None,
     layer: str | None = None,
     tags: str | None = None,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
 ) -> IngestResult:
     """Ingest raw text directly — no file or URL needed.
 
@@ -626,7 +632,9 @@ def ingest_text(
     text = _strip_frontmatter(text)
 
     # Chunk
-    chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
+    chunks = chunk_text(
+        text, chunk_size or cfg.chunking.size, chunk_overlap or cfg.chunking.overlap
+    )
     if not chunks:
         return IngestResult(status="empty", source=source_path)
 
@@ -741,6 +749,8 @@ def ingest_directory(
     project: str | None = None,
     layer: str | None = None,
     tags: str | None = None,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
 ) -> list[IngestResult]:
     """Recursively ingest all supported files in a directory.
 
@@ -814,6 +824,8 @@ def ingest_directory(
                 project=project,
                 layer=layer,
                 tags=tags,
+                chunk_size=chunk_size,
+                chunk_overlap=chunk_overlap,
             )
             results.append(result)
             progress.advance(task)

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -503,8 +503,8 @@ def ingest(
 
     # --- Step 3: Chunk ---
     with console.status("[bold cyan]Chunking...[/bold cyan]", spinner="dots"):
-        cs = chunk_size or cfg.chunking.size
-        co = chunk_overlap or cfg.chunking.overlap
+        cs = chunk_size if chunk_size is not None else cfg.chunking.size
+        co = chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap
         if is_code:
             ext = Path(source).suffix.lower()
             language = _EXT_TO_LANG.get(ext, "")
@@ -633,7 +633,9 @@ def ingest_text(
 
     # Chunk
     chunks = chunk_text(
-        text, chunk_size or cfg.chunking.size, chunk_overlap or cfg.chunking.overlap
+        text,
+        chunk_size if chunk_size is not None else cfg.chunking.size,
+        chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap,
     )
     if not chunks:
         return IngestResult(status="empty", source=source_path)

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -63,10 +63,14 @@ class Memory:
         collection: str = "default",
         db: str | Path | None = None,
         profile: str | None = None,
+        chunk_size: int | None = None,
+        chunk_overlap: int | None = None,
     ) -> None:
         self._cfg = _load_config_from(config)
         self._project = project
         self._collection = collection
+        self._chunk_size = chunk_size
+        self._chunk_overlap = chunk_overlap
 
         # Resolution: explicit db param > unified resolve_db_path chain
         if db:
@@ -111,6 +115,8 @@ class Memory:
         project: object = _UNSET,
         layer: str | None = None,
         tags: str | None = None,
+        chunk_size: int | None = None,
+        chunk_overlap: int | None = None,
     ) -> list[IngestResult]:
         """Ingest a file, URL, or directory into memory.
 
@@ -142,6 +148,14 @@ class Memory:
             if resolved.is_dir():
                 from .ingest import ingest_directory
 
+        cs = chunk_size or self._chunk_size
+        co = chunk_overlap or self._chunk_overlap
+
+        if not is_url:
+            resolved = Path(source).expanduser().resolve()
+            if resolved.is_dir():
+                from .ingest import ingest_directory
+
                 return ingest_directory(
                     str(resolved),
                     self._cfg,
@@ -151,6 +165,8 @@ class Memory:
                     project=proj,
                     layer=layer,
                     tags=tags,
+                    chunk_size=cs,
+                    chunk_overlap=co,
                 )
 
         result = ingest(
@@ -162,6 +178,8 @@ class Memory:
             project=proj,
             layer=layer,
             tags=tags,
+            chunk_size=cs,
+            chunk_overlap=co,
         )
         return [result]
 
@@ -174,6 +192,8 @@ class Memory:
         project: object = _UNSET,
         layer: str | None = None,
         tags: str | None = None,
+        chunk_size: int | None = None,
+        chunk_overlap: int | None = None,
     ) -> IngestResult:
         """Ingest raw text directly — no file needed.
 
@@ -211,6 +231,8 @@ class Memory:
             project=proj,
             layer=layer,
             tags=tags,
+            chunk_size=chunk_size or self._chunk_size,
+            chunk_overlap=chunk_overlap or self._chunk_overlap,
         )
 
     def search(

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -143,13 +143,8 @@ class Memory:
         # URLs: skip Path.resolve() which can fail or be meaningless
         is_url = source_str.startswith(("http://", "https://"))
 
-        if not is_url:
-            resolved = Path(source).expanduser().resolve()
-            if resolved.is_dir():
-                from .ingest import ingest_directory
-
-        cs = chunk_size or self._chunk_size
-        co = chunk_overlap or self._chunk_overlap
+        cs = chunk_size if chunk_size is not None else self._chunk_size
+        co = chunk_overlap if chunk_overlap is not None else self._chunk_overlap
 
         if not is_url:
             resolved = Path(source).expanduser().resolve()
@@ -231,8 +226,8 @@ class Memory:
             project=proj,
             layer=layer,
             tags=tags,
-            chunk_size=chunk_size or self._chunk_size,
-            chunk_overlap=chunk_overlap or self._chunk_overlap,
+            chunk_size=chunk_size if chunk_size is not None else self._chunk_size,
+            chunk_overlap=chunk_overlap if chunk_overlap is not None else self._chunk_overlap,
         )
 
     def search(


### PR DESCRIPTION
## Summary

Allows overriding chunk size per-document or per-Memory instance without modifying vstash.toml. Closes #92.

### API

```python
# Instance default
mem = Memory(project="medical", chunk_size=2048, chunk_overlap=256)
mem.add("protocol.pdf")                     # uses 2048
mem.add("code.py", chunk_size=512)          # per-file override
mem.remember(text, chunk_size=2048)         # per-call override
```

```bash
# CLI
vstash add paper.pdf --chunk-size 2048 --chunk-overlap 256
vstash remember "text" --chunk-size 2048
```

### Override chain
per-call > constructor > vstash.toml > default (1024/128)

### Validation
- `chunk_size` must be positive
- `chunk_overlap` must be non-negative and less than `chunk_size`

### Implementation
- `Memory.__init__`, `Memory.add()`, `Memory.remember()` accept chunk params
- `ingest()`, `ingest_text()`, `ingest_directory()` accept chunk params
- CLI `add` and `remember` commands accept `--chunk-size`/`--chunk-overlap`
- Uses `is not None` (not `or`) to correctly handle edge values

## Test plan
- [x] 4 new tests (constructor, defaults, per-call, add with constructor)
- [x] 612 tests passing
- [x] Lint clean
- [x] Docs updated (configuration.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)