### PR TITLE
fix: add missing ExplainInfo fields, bump v0.17.3

### DIFF
--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"
 
 from .memory import Memory
 from .models import ChunkInfo, DocumentInfo, ExplainInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -42,6 +42,12 @@ class ExplainInfo(BaseModel):
     mmr_penalty: float = Field(
         default=0.0, description="MMR applied penalty: (1-lambda)*max_similarity"
     )
+    rrf_vec_weight: float | None = Field(
+        default=None, description="Adaptive RRF weight applied to vector component"
+    )
+    rrf_fts_weight: float | None = Field(
+        default=None, description="Adaptive RRF weight applied to FTS component"
+    )
     fts_terms: list[str] = Field(default_factory=list, description="FTS query terms searched")
 
 


### PR DESCRIPTION
## Summary
- Add `rrf_vec_weight` and `rrf_fts_weight` fields to `ExplainInfo` model — these were assigned in `store.py` but never declared, causing Pydantic to silently drop them
- Fixes 2 failing CI tests: `TestAdaptiveRRF::test_adaptive_enabled_by_default` and `test_adaptive_disabled_uses_fixed`
- Bump version to 0.17.3

## Test plan
- [x] `pytest tests/test_store.py::TestAdaptiveRRF` — 10/10 pass
- [x] `ruff check` + `ruff format --check` pass