### PR TITLE
🐛 fix: close stem connections from any thread (#125)

### DIFF
--- a/tests/test_stem_conn_cleanup.py
+++ b/tests/test_stem_conn_cleanup.py
@@ -1,0 +1,97 @@
+"""Tests for cross-thread stem connection cleanup (#125).
+
+Verifies that ``VstashStore.close()`` releases per-thread FTS5
+stemming connections registered by ``_stem_terms()`` regardless of
+which thread created them.
+
+Before #125, ``_stem_terms()`` stored its connection in
+``threading.local()``, so connections created in worker threads
+(e.g., a vstash serve request handler) were invisible to ``close()``
+running on the main thread and would leak until process exit.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from vstash.store import VstashStore
+
+
+class TestStemConnCleanup:
+    def test_main_thread_stem_conn_released(self, sample_store: VstashStore):
+        """A stem conn created on the main thread should be released by close()."""
+        # Trigger creation of the stem conn
+        sample_store._stem_terms(["running", "tests"])
+        assert len(sample_store._stem_conns) == 1
+        sample_store.close()
+        # close() should have cleared the dict
+        assert sample_store._stem_conns == {}
+
+    def test_worker_thread_stem_conn_released(self, sample_store: VstashStore):
+        """A stem conn created on a worker thread should be released by close()."""
+        worker_started = threading.Event()
+        worker_done = threading.Event()
+
+        def worker():
+            sample_store._stem_terms(["worker", "thread", "stems"])
+            worker_started.set()
+            # Wait until the main thread has verified the conn exists
+            worker_done.wait(timeout=5)
+
+        t = threading.Thread(target=worker, daemon=True)
+        t.start()
+        worker_started.wait(timeout=5)
+
+        # Main thread sees the worker's conn registered
+        assert len(sample_store._stem_conns) == 1
+        worker_tid = next(iter(sample_store._stem_conns.keys()))
+        assert worker_tid != threading.get_ident()
+
+        # Let the worker exit and main thread closes the store
+        worker_done.set()
+        t.join(timeout=5)
+
+        sample_store.close()
+        # The worker's conn should now be released, even though we're
+        # calling close() from the main thread
+        assert sample_store._stem_conns == {}
+
+    def test_multiple_threads_each_get_own_conn(self, sample_store: VstashStore):
+        """Each thread should get a distinct stem connection."""
+        n_threads = 4
+        barrier = threading.Barrier(n_threads)
+
+        def worker():
+            barrier.wait()
+            sample_store._stem_terms(["multi", "thread", "test"])
+
+        threads = [threading.Thread(target=worker, daemon=True) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        # n_threads distinct connections should be registered
+        assert len(sample_store._stem_conns) == n_threads
+        # All keys should be unique thread ids
+        assert len(set(sample_store._stem_conns.keys())) == n_threads
+
+        # close() releases all of them
+        sample_store.close()
+        assert sample_store._stem_conns == {}
+
+    def test_double_close_is_safe(self, sample_store: VstashStore):
+        """Calling close() twice should not raise."""
+        sample_store._stem_terms(["one", "two"])
+        sample_store.close()
+        # Second close should be a no-op (sqlite3 tolerates double-close)
+        sample_store.close()
+        assert sample_store._stem_conns == {}
+
+    def test_no_stem_conn_no_close_failure(self, sample_store: VstashStore):
+        """close() should work even if _stem_terms() was never called."""
+        # No stem conn created — _stem_conns is empty
+        assert sample_store._stem_conns == {}
+        sample_store.close()
+        # Still empty, no exception
+        assert sample_store._stem_conns == {}

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -123,6 +123,13 @@ class VstashStore:
         # Thread-local so concurrent searches on a shared instance don't race.
         self._thread_local = threading.local()
         self._thread_local.last_best_distance = 0.0
+        # Per-thread in-memory FTS5 stemming connections.  We use a plain
+        # dict keyed by thread id (instead of threading.local()) so that
+        # close() can iterate and release connections from any thread —
+        # otherwise stem conns created in worker threads (vstash serve,
+        # MCP) would leak until process exit.
+        self._stem_conns: dict[int, sqlite3.Connection] = {}
+        self._stem_lock = threading.Lock()
         self._conn = self._connect()
 
         # --- Adaptive RRF cache ---
@@ -1517,16 +1524,28 @@ class VstashStore:
     def _stem_terms(self, words: list[str]) -> list[str]:
         """Stem words using the same FTS5 porter tokenizer as the index.
 
-        Uses a thread-local in-memory FTS5 table to ensure stemming is
-        identical to what fts5vocab reports.  ~0.02ms per call.  Thread-safe
-        because each thread gets its own connection.
+        Uses a per-thread in-memory FTS5 connection so stemming is
+        identical to what fts5vocab reports.  ~0.02ms per call.  Thread-
+        safe because each thread gets its own dedicated connection,
+        registered in ``self._stem_conns`` so ``close()`` can release
+        every thread's connection on shutdown.
         """
-        conn = getattr(self._thread_local, "_stem_conn", None)
-        if conn is None:
-            conn = sqlite3.connect(":memory:")
-            conn.execute('CREATE VIRTUAL TABLE _stem USING fts5(x, tokenize="porter ascii")')
-            conn.execute("CREATE VIRTUAL TABLE _stem_v USING fts5vocab(_stem, row)")
-            self._thread_local._stem_conn = conn
+        tid = threading.get_ident()
+        with self._stem_lock:
+            conn = self._stem_conns.get(tid)
+            if conn is None:
+                # check_same_thread=False so close() (running on the
+                # main thread on shutdown) can release stem connections
+                # created by worker threads.  We still only USE each
+                # conn from the thread that owns it — the dict keying
+                # by thread id guarantees that.
+                conn = sqlite3.connect(":memory:", check_same_thread=False)
+                conn.execute('CREATE VIRTUAL TABLE _stem USING fts5(x, tokenize="porter ascii")')
+                conn.execute("CREATE VIRTUAL TABLE _stem_v USING fts5vocab(_stem, row)")
+                self._stem_conns[tid] = conn
+        # Use the connection outside the lock — sqlite3 connections are
+        # not safe to share across threads, but each thread only ever
+        # touches its own connection here, so no contention.
         conn.execute("DELETE FROM _stem")
         conn.execute("INSERT INTO _stem VALUES (?)", [" ".join(words)])
         rows = conn.execute("SELECT term FROM _stem_v").fetchall()
@@ -1923,23 +1942,26 @@ class VstashStore:
             return processed
 
     def close(self) -> None:
-        """Close the database connection and any thread-local resources.
+        """Close the database connection and all stem-conn resources.
 
-        Also closes the thread-local FTS5 stemming connection used by
-        ``_stem_terms()`` if one was created in the current thread.
-        Connections in *other* threads cannot be closed from here — they
-        will be cleaned up when their owning threads exit.  See #125 for
-        a follow-up that closes stem connections from any thread.
+        Releases every per-thread FTS5 stemming connection registered
+        by ``_stem_terms()``, regardless of which thread created them.
+        SQLite in-memory connections can be closed from any thread
+        (unlike file connections opened with ``check_same_thread=True``),
+        so this is safe to call from the main thread on shutdown of a
+        multi-threaded server like ``vstash serve`` or the MCP server.
         """
         import contextlib
 
-        # Close the thread-local stem connection if this thread has one.
-        stem_conn = getattr(self._thread_local, "_stem_conn", None)
-        if stem_conn is not None:
-            # sqlite3.Error covers the realistic failure modes (already
-            # closed, locked, etc.).  Anything else is a real bug worth
-            # surfacing rather than silently swallowing during teardown.
-            with contextlib.suppress(sqlite3.Error):
-                stem_conn.close()
-            self._thread_local._stem_conn = None
+        # Close all per-thread stem connections under the lock so we
+        # don't race a worker thread that's just creating a new one.
+        with self._stem_lock:
+            for stem_conn in self._stem_conns.values():
+                # sqlite3.Error covers the realistic failure modes
+                # (already closed, locked, etc.).  Anything else is a
+                # real bug worth surfacing rather than silently
+                # swallowing during teardown.
+                with contextlib.suppress(sqlite3.Error):
+                    stem_conn.close()
+            self._stem_conns.clear()
         self._conn.close()


### PR DESCRIPTION
## Summary
Closes #125 — the follow-up from PR #124's review.

\`VstashStore.close()\` now releases per-thread FTS5 stemming connections regardless of which thread created them.  In long-lived multi-threaded servers (\`vstash serve\`, MCP), worker threads that triggered \`_stem_terms()\` would leak their in-memory stem connections until process exit, because \`threading.local()\` made them invisible to \`close()\` running on the main thread.

## Changes

### `vstash/store.py`
- Replace \`self._thread_local._stem_conn\` with \`self._stem_conns: dict[int, sqlite3.Connection]\` keyed by \`threading.get_ident()\`, guarded by \`self._stem_lock\`
- Stem connections are created with \`check_same_thread=False\` so they can be closed from any thread (each connection is still **used** only from its owning thread, the dict-by-tid lookup guarantees that)
- \`close()\` iterates the dict and releases every connection under the lock

### `tests/test_stem_conn_cleanup.py` (new, 5 tests)
- Main thread creates → \`close()\` releases
- **Worker thread creates → main-thread \`close()\` releases** (the scenario that exposed the original bug)
- Multiple worker threads → distinct conns, all released
- Double \`close()\` is safe
- \`close()\` works when no \`_stem_terms()\` was ever called

## Why \`check_same_thread=False\` is needed

Without it, sqlite3 silently rejects \`close()\` from a thread that didn't create the connection — that's how I discovered the leak: my first version of this fix passed all 5 unit tests but still produced 4 ResourceWarnings because the sqlite library was rejecting the cross-thread closes.

## Test plan
- [x] 596 tests pass (591 + 5 new)
- [x] 0 \`ResourceWarning: unclosed database\` in full suite
- [x] ruff check + format clean

Closes #125