### PR TITLE
🔖 Release v0.27.0 — RRF ergonomics part 2 + collection scoping fix

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Optimize Pure Python Vector Math]
+**Learning:** Pure python vector math like cosine similarity can be optimized by using `math.hypot(*vec)` for the $L_2$ norm and `sum(map(operator.mul, a, b))` for dot products. This avoids slow list comprehensions and generators in Python.
+**Action:** Use these built-in C-accelerated functions whenever dealing with short to medium sized pure python vectors (like embeddings) where numpy overhead or dependency limits restrict external native backends.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-05-18 - [Optimize Pure Python Vector Math]
-**Learning:** Pure python vector math like cosine similarity can be optimized by using `math.hypot(*vec)` for the $L_2$ norm and `sum(map(operator.mul, a, b))` for dot products. This avoids slow list comprehensions and generators in Python.
-**Action:** Use these built-in C-accelerated functions whenever dealing with short to medium sized pure python vectors (like embeddings) where numpy overhead or dependency limits restrict external native backends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to vstash are documented here.
 
+## [0.27.0] — 2026-04-09
+
+### ⚠️ Breaking change
+
+- **`Memory.search()` now honors the instance collection when it is the literal string `"default"`** (#165, PR #166). Prior to v0.27, `Memory(collection="default").search("x")` silently searched **every collection** in the database because `_resolve_collection` had a `!= "default"` shortcut that treated `"default"` as a sentinel for "no filter". This created a read/write asymmetry — writes were scoped to `"default"` while reads leaked across collections. The shortcut is removed. Callers who relied on the old "search everywhere" behavior must now pass `collection=None` explicitly:
+
+    ```python
+    # old (implicit):
+    mem = Memory(db=...)
+    mem.search("x")
+
+    # new (explicit, preserves old behavior):
+    mem = Memory(db=...)
+    mem.search("x", collection=None)
+    ```
+
+    The fix also applies to `list()`, `get_document_chunks()`, and `miss_analysis()` — every method that calls `_resolve_collection`. Downstream consumers that maintain a second collection in the same store (engram's audit log, medlocal-style multi-profile setups) will now get correct isolation without needing the explicit-collection workaround.
+
+### Added
+
+- **MCP RRF passthrough** (#159, PR #168) — the MCP server tools `vstash_search` and `vstash_ask` now expose `vec_weight`, `fts_weight`, and `fts_only` parameters, mirroring the SDK surface added in v0.26.0. Claude Desktop and any other MCP client can now pin RRF weights or force FTS-only retrieval on a per-call basis, making the paraphrase-multilingual clinical-domain mitigation (documented in `docs/embedding-models.md`) reachable from outside Python.
+- **Defensive type coercion** for MCP-supplied RRF parameters — MCP clients inconsistently send JSON strings where floats/bools are expected (e.g. `"0.5"` or `"true"`). New `_coerce_optional_float` and `_coerce_bool` helpers in `vstash/mcp.py` handle this permissively, rejecting NaN and ±Inf explicitly so non-finite weights cannot propagate into RRF scoring. Unparseable values surface as structured MCP errors naming the offending field, not server crashes.
+- **`fts_only` precedence rule** for MCP tools — when `fts_only=true`, `vec_weight` and `fts_weight` are dropped before coercion and validation. A caller can safely pass `fts_only=true` with an invalid or out-of-range weight and still get a successful FTS-only query.
+
+### Performance
+
+- **Pure-Python `_cosine_sim` is 5–11× faster** (#149, PR #149). Version-gated dispatch: `math.sumprod` on Python 3.12+ (3× faster than `sum(map(operator.mul, ...))`) with a fallback to the map-based path for 3.10/3.11. `math.hypot(*vec)` replaces the generator-expression norm on all versions. Real-world impact: `_cosine_sim` is called inside the triple-nested loop of `_mmr_dedup`, saving ~20–25 ms per search on corpora where MMR dedup fires with multi-chunk documents. Zero impact on single-chunk-per-doc corpora (the MMR path short-circuits). Credit to @google-labs-jules for surfacing the opportunity; the `math.sumprod` refinement was added on top.
+
+### Fixed
+
+- **`_resolve_collection` review follow-ups** (#166 review): trimmed verbose docstring (historical bug context moved to commit message), and added a regression tripwire test covering `list()` to catch any future refactor that accidentally re-introduces the `"default"` shortcut — the fix applies to four methods, not just `search()`.
+- **#168 review feedback** (7 items, all applied): NaN/Inf float rejection, `fts_only` precedence short-circuit, `ValueError` split from broad except (no stack traces for user-input errors), `"none"`/`"null"` recognized as `_coerce_bool` false values, docs correction on weight alone-or-together semantics, two new regression tests.
+
+### Documentation
+
+- **`docs/mcp-server.md`** — new "Per-call RRF controls" section documenting the three new parameters, when to use each, type coercion behavior, and the precedence rule.
+
+---
+
 ## [0.26.0] — 2026-04-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ vstash stats
 
 ```
 vstash/
-  __init__.py       # version (__version__ = "0.26.0")
+  __init__.py       # version (__version__ = "0.27.0")
   cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile, journal
   profile.py        # Multi-profile management: resolution chain, CRUD, federated search
   journal.py        # Cross-session memory: save, recall, log, prune, transcript parsing
@@ -88,7 +88,7 @@ docs/               # User-facing documentation
 - **Pydantic v2** for all config and data models (frozen=True)
 - **Type hints** on all public functions
 - **ruff** for linting and formatting (enforced in CI)
-- **pytest** for testing (~740 tests + 6 benchmark regression tests as of v0.26.0)
+- **pytest** for testing (~750 tests + 6 benchmark regression tests as of v0.27.0)
 - **Conventional commits** with emoji prefixes (feat, fix, docs, chore, perf)
 - **No AI co-author lines** — do NOT add `Co-Authored-By` or any AI attribution to commit messages
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Evaluated on the [BEIR benchmark](https://github.com/beir-cellar/beir) — the s
 
 **Zero cloud required for search. Inference is optional.**
 
+### What's new in v0.27
+
+- **⚠️ Breaking: `Memory.search()` honors the instance collection even when it is `"default"`** — prior to v0.27, constructing `Memory(collection="default")` (explicit or implicit) and calling `search()` silently leaked across every collection in the database because of an internal shortcut. Writes always honored `"default"`, reads did not — a read/write asymmetry. The shortcut is gone. Callers relying on the old "search everywhere" behavior must now pass `collection=None` explicitly. Affects `search()`, `list()`, `get_document_chunks()`, and `miss_analysis()`. See CHANGELOG for migration.
+- **MCP tools accept RRF overrides** — `vstash_search` and `vstash_ask` now expose `vec_weight`, `fts_weight`, and `fts_only` parameters, mirroring the SDK surface added in v0.26. Claude Desktop and any MCP client can now pin RRF weights or force FTS-only retrieval on a per-call basis. Defensive type coercion handles JSON strings, rejects NaN/Inf, and short-circuits weights when `fts_only=true`.
+- **Cosine similarity 5–11× faster** — `math.sumprod` on Python 3.12+ with a fallback to `sum(map(operator.mul, ...))` on 3.10/3.11. `math.hypot(*vec)` replaces the generator-expression norm on all versions. `_cosine_sim` sits inside the MMR dedup hot path; searches with multi-chunk documents save ~20–25 ms per call.
+
 ### What's new in v0.26
 
 - **Per-call RRF weight overrides** — `Memory.search()` and `Memory.ask()` now accept `vec_weight` and `fts_weight` for single-query overrides of the hybrid-search mixing weights. `None` (default) keeps adaptive per-query RRF active. Typed `RRFWeightOutOfRangeError` rejects out-of-range values at the API boundary.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -85,9 +85,9 @@ Both `vstash_search` and `vstash_ask` expose three parameters for overriding the
 
 | Parameter | Type | Meaning |
 |---|---|---|
-| `vec_weight` | `float \| None` | Pin the RRF vector weight for this query (valid range `[0.0, 1.0]`). Overrides adaptive RRF. Pass together with `fts_weight`. |
-| `fts_weight` | `float \| None` | Pin the RRF FTS weight for this query. Same range. |
-| `fts_only` | `bool` | If `true`, skip the vector ANN scan entirely — no distance cutoff, no adaptive RRF, just FTS5 keyword matching. MMR dedup and context expansion still apply. |
+| `vec_weight` | `float \| None` | Pin the RRF vector weight for this query (valid range `[0.0, 1.0]`). Overrides adaptive RRF. May be passed alone — the store derives `fts_weight = 1.0 - vec_weight` when only one is provided. |
+| `fts_weight` | `float \| None` | Pin the RRF FTS weight. Same range and same alone-or-together behavior as `vec_weight`. |
+| `fts_only` | `bool` | If `true`, skip the vector ANN scan entirely — no distance cutoff, no adaptive RRF, just FTS5 keyword matching. MMR dedup and context expansion still apply. Takes precedence: when `fts_only=true`, any supplied `vec_weight` / `fts_weight` values are dropped before validation, so an invalid weight paired with `fts_only=true` will not cause the call to fail. |
 
 **When to use them:**
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -79,6 +79,37 @@ The relevance signal uses the best vector distance to estimate confidence:
 
 This works from the first search — no usage history or warm-up required.
 
+### Per-call RRF controls *(added in v0.27.0, issue #159)*
+
+Both `vstash_search` and `vstash_ask` expose three parameters for overriding the default hybrid-retrieval behavior on a per-call basis. All three default to `None` / `False` — if you omit them, adaptive RRF (the default pipeline) runs unchanged.
+
+| Parameter | Type | Meaning |
+|---|---|---|
+| `vec_weight` | `float \| None` | Pin the RRF vector weight for this query (valid range `[0.0, 1.0]`). Overrides adaptive RRF. Pass together with `fts_weight`. |
+| `fts_weight` | `float \| None` | Pin the RRF FTS weight for this query. Same range. |
+| `fts_only` | `bool` | If `true`, skip the vector ANN scan entirely — no distance cutoff, no adaptive RRF, just FTS5 keyword matching. MMR dedup and context expansion still apply. |
+
+**When to use them:**
+
+- **`fts_only=true`** — for debugging ranking (answers "is this a vector problem or an FTS problem?") and for queries containing literal terms that must match exactly (drug names, diagnostic codes, error strings, SKUs). Particularly useful with the clinical-domain weakness documented in `docs/embedding-models.md` for `paraphrase-multilingual-MiniLM-L12-v2`.
+- **`vec_weight=0.1, fts_weight=0.9`** — to bias a specific query toward keyword matching without disabling the vector path entirely. Adaptive RRF resumes on the next query with defaults.
+- **`vec_weight=0.9, fts_weight=0.1`** — inverse: bias toward semantic paraphrase when you know the exact term may not be in the corpus.
+
+**Type coercion note.** The MCP server accepts string values for these parameters (`"0.5"`, `"true"`, `"false"`, `"1"`, `"0"`) and coerces them internally, so clients that serialize JSON numbers or booleans as strings do not get a 422 at the tool boundary. An unparseable value surfaces as a structured `{"error": "..."}` response naming the offending field. If a caller supplies both `fts_only=true` and explicit weights, the weights are ignored and a pure FTS5 query runs.
+
+Example MCP call:
+
+```json
+{
+  "tool": "vstash_search",
+  "arguments": {
+    "query": "morphine contraindications",
+    "top_k": 5,
+    "fts_only": true
+  }
+}
+```
+
 ---
 
 ## API Key Configuration

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -206,6 +206,122 @@ class TestVstashSearch:
         result = json.loads(vstash_search("test"))
         assert "error" in result
 
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_forwards_rrf_weights_to_store(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """vstash_search MCP tool must forward vec_weight/fts_weight/fts_only
+        kwargs all the way to VstashStore.search (#159).
+
+        Spy on the store.search call and assert the exact kwargs arrive
+        with the coerced values. Mirrors the SDK spy test pattern from
+        test_search_forwards_rrf_weights_to_store in test_memory.py so
+        the two surfaces stay symmetric.
+        """
+        chunks = [_make_search_result("hit", "Doc1")]
+        mock_store.return_value.search.return_value = chunks
+        mock_store.return_value.expand_context.return_value = chunks
+        mock_store.return_value.last_best_distance = 0.5
+        mock_store.return_value.record_search_event.return_value = 1
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        vstash_search("test query", vec_weight=0.9, fts_weight=0.1, fts_only=False)
+
+        _, kwargs = mock_store.return_value.search.call_args
+        assert kwargs["vec_weight"] == 0.9
+        assert kwargs["fts_weight"] == 0.1
+        assert kwargs["fts_only"] is False
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_default_rrf_kwargs_are_none_and_false(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """Regression guard: omitting the new kwargs must forward None /
+        False to the store, NOT silently pinned defaults."""
+        chunks = [_make_search_result("hit", "Doc1")]
+        mock_store.return_value.search.return_value = chunks
+        mock_store.return_value.expand_context.return_value = chunks
+        mock_store.return_value.last_best_distance = 0.5
+        mock_store.return_value.record_search_event.return_value = 1
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        vstash_search("test query")
+
+        _, kwargs = mock_store.return_value.search.call_args
+        assert kwargs["vec_weight"] is None
+        assert kwargs["fts_weight"] is None
+        assert kwargs["fts_only"] is False
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_coerces_string_kwargs_from_mcp_client(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """MCP clients can send strings where floats/bools are expected.
+        vstash_search must coerce them defensively instead of 422'ing.
+
+        This is the defensive pattern documented in
+        _coerce_optional_float / _coerce_bool — mirrors the existing
+        ``top_k = int(top_k)`` / ``recency_boost = float(recency_boost)``
+        coercions elsewhere in this module.
+        """
+        chunks = [_make_search_result("hit", "Doc1")]
+        mock_store.return_value.search.return_value = chunks
+        mock_store.return_value.expand_context.return_value = chunks
+        mock_store.return_value.last_best_distance = 0.5
+        mock_store.return_value.record_search_event.return_value = 1
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        # Strings arriving through JSON-RPC boundaries.
+        vstash_search(
+            "test",
+            vec_weight="0.8",  # type: ignore[arg-type]
+            fts_weight="0.2",  # type: ignore[arg-type]
+            fts_only="true",  # type: ignore[arg-type]
+        )
+
+        _, kwargs = mock_store.return_value.search.call_args
+        assert kwargs["vec_weight"] == 0.8
+        assert kwargs["fts_weight"] == 0.2
+        assert kwargs["fts_only"] is True
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_rejects_unparseable_string_kwargs(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """Unparseable strings must surface as a structured MCP error,
+        not a 500 — the tool wraps the ValueError into _error()."""
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        result = json.loads(
+            vstash_search("test", vec_weight="not_a_number")  # type: ignore[arg-type]
+        )
+        assert "error" in result
+        assert "vec_weight" in result["error"]
+
+        result2 = json.loads(vstash_search("test", fts_only="maybe"))  # type: ignore[arg-type]
+        assert "error" in result2
+        assert "fts_only" in result2["error"]
+
 
 # ------------------------------------------------------------------ #
 # vstash_forget                                                        #
@@ -306,6 +422,70 @@ class TestVstashAsk:
         result = json.loads(vstash_ask("test"))
         assert "error" in result
         assert "not found" in result["error"]
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_ask_forwards_rrf_weights_and_fts_only(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """vstash_ask must forward vec_weight/fts_weight/fts_only to the
+        retrieval step (#159). Symmetric with the SDK ``Memory.ask()``
+        forwarding test.
+        """
+        chunks = [_make_search_result("context", "Doc1")]
+        store_inst = mock_store.return_value
+        store_inst.search.return_value = chunks
+        store_inst.last_best_distance = 0.5
+        store_inst.expand_context.return_value = chunks
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        with patch("vstash.chat.ask", return_value="answer"):
+            vstash_ask(
+                "query",
+                vec_weight=0.3,
+                fts_weight=0.7,
+                fts_only=False,
+            )
+
+        _, kwargs = store_inst.search.call_args
+        assert kwargs["vec_weight"] == 0.3
+        assert kwargs["fts_weight"] == 0.7
+        assert kwargs["fts_only"] is False
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_ask_coerces_string_kwargs(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """vstash_ask must defensively coerce string kwargs from MCP
+        clients the same way vstash_search does (#159)."""
+        chunks = [_make_search_result("context", "Doc1")]
+        store_inst = mock_store.return_value
+        store_inst.search.return_value = chunks
+        store_inst.last_best_distance = 0.5
+        store_inst.expand_context.return_value = chunks
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        with patch("vstash.chat.ask", return_value="answer"):
+            vstash_ask(
+                "query",
+                vec_weight="0.1",  # type: ignore[arg-type]
+                fts_weight="0.9",  # type: ignore[arg-type]
+                fts_only="TRUE",  # type: ignore[arg-type]
+            )
+
+        _, kwargs = store_inst.search.call_args
+        assert kwargs["vec_weight"] == 0.1
+        assert kwargs["fts_weight"] == 0.9
+        assert kwargs["fts_only"] is True
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -278,6 +278,12 @@ class TestVstashSearch:
         _coerce_optional_float / _coerce_bool — mirrors the existing
         ``top_k = int(top_k)`` / ``recency_boost = float(recency_boost)``
         coercions elsewhere in this module.
+
+        NOTE: weight coercion and fts_only coercion are tested
+        separately here because fts_only=True wins precedence and
+        zeros out the weights (see test_search_fts_only_ignores_
+        invalid_weights), so passing all three as strings in one
+        call would assert the wrong thing for the weight path.
         """
         chunks = [_make_search_result("hit", "Doc1")]
         mock_store.return_value.search.return_value = chunks
@@ -286,17 +292,21 @@ class TestVstashSearch:
         mock_store.return_value.record_search_event.return_value = 1
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
-        # Strings arriving through JSON-RPC boundaries.
+        # Weights as strings, fts_only omitted (default False).
         vstash_search(
             "test",
             vec_weight="0.8",  # type: ignore[arg-type]
             fts_weight="0.2",  # type: ignore[arg-type]
-            fts_only="true",  # type: ignore[arg-type]
         )
-
         _, kwargs = mock_store.return_value.search.call_args
         assert kwargs["vec_weight"] == 0.8
         assert kwargs["fts_weight"] == 0.2
+        assert kwargs["fts_only"] is False
+
+        # fts_only as a string, weights omitted.
+        mock_store.return_value.search.reset_mock()
+        vstash_search("test", fts_only="true")  # type: ignore[arg-type]
+        _, kwargs = mock_store.return_value.search.call_args
         assert kwargs["fts_only"] is True
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
@@ -321,6 +331,86 @@ class TestVstashSearch:
         result2 = json.loads(vstash_search("test", fts_only="maybe"))  # type: ignore[arg-type]
         assert "error" in result2
         assert "fts_only" in result2["error"]
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_rejects_nan_and_inf_weights(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """Review on #168: ``validate_search_input`` uses ``< 0.0`` /
+        ``> 1.0`` bounds which do not catch NaN or ±Inf. The MCP
+        coercion layer must reject non-finite floats before they reach
+        the validator — a NaN weight would otherwise propagate into
+        RRF scoring and produce NaN result scores.
+        """
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        for bad_value in ("nan", "NaN", "inf", "-inf", "Infinity"):
+            result = json.loads(
+                vstash_search("test", vec_weight=bad_value)  # type: ignore[arg-type]
+            )
+            assert "error" in result, f"expected error for vec_weight={bad_value!r}"
+            assert "vec_weight" in result["error"]
+            assert "non-finite" in result["error"], (
+                f"error message should name non-finite: {result['error']}"
+            )
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_search_fts_only_ignores_invalid_weights(
+        self,
+        mock_config: MagicMock,
+        mock_store: MagicMock,
+        mock_embed: MagicMock,
+    ) -> None:
+        """Precedence rule (documented in docs/mcp-server.md): when
+        ``fts_only=true``, ``vec_weight`` and ``fts_weight`` are
+        dropped before coercion and validation. A caller who sends
+        ``fts_only=true`` together with an invalid or out-of-range
+        weight should still get a successful FTS-only query.
+
+        Flagged in the #168 review — without this fix, the weight
+        coercion would run first and raise ``ValueError`` before
+        fts_only was even looked at.
+        """
+        chunks = [_make_search_result("hit", "Doc1")]
+        mock_store.return_value.search.return_value = chunks
+        mock_store.return_value.expand_context.return_value = chunks
+        mock_store.return_value.last_best_distance = 0.5
+        mock_store.return_value.record_search_event.return_value = 1
+        mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
+
+        # Every one of these combinations would fail coercion on its
+        # own but must succeed when paired with fts_only=true.
+        for bad_vec, bad_fts in [
+            ("not_a_number", None),
+            ("nan", None),
+            (None, "-inf"),
+            ("10.0", "5.0"),  # out of [0, 1] — but never reaches validator
+        ]:
+            mock_store.return_value.search.reset_mock()
+            result = json.loads(
+                vstash_search(
+                    "test",
+                    fts_only=True,
+                    vec_weight=bad_vec,  # type: ignore[arg-type]
+                    fts_weight=bad_fts,  # type: ignore[arg-type]
+                )
+            )
+            assert "error" not in result, (
+                f"fts_only=True should have dropped invalid weights "
+                f"vec_weight={bad_vec!r}, fts_weight={bad_fts!r}, "
+                f"but got {result}"
+            )
+            _, kwargs = mock_store.return_value.search.call_args
+            assert kwargs["fts_only"] is True
+            assert kwargs["vec_weight"] is None
+            assert kwargs["fts_weight"] is None
 
 
 # ------------------------------------------------------------------ #
@@ -466,7 +556,11 @@ class TestVstashAsk:
         mock_embed: MagicMock,
     ) -> None:
         """vstash_ask must defensively coerce string kwargs from MCP
-        clients the same way vstash_search does (#159)."""
+        clients the same way vstash_search does (#159).
+
+        Tested separately from fts_only because fts_only=True wins
+        precedence and zeros out the weights.
+        """
         chunks = [_make_search_result("context", "Doc1")]
         store_inst = mock_store.return_value
         store_inst.search.return_value = chunks
@@ -474,17 +568,23 @@ class TestVstashAsk:
         store_inst.expand_context.return_value = chunks
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
+        # Weights as strings, fts_only omitted.
         with patch("vstash.chat.ask", return_value="answer"):
             vstash_ask(
                 "query",
                 vec_weight="0.1",  # type: ignore[arg-type]
                 fts_weight="0.9",  # type: ignore[arg-type]
-                fts_only="TRUE",  # type: ignore[arg-type]
             )
-
         _, kwargs = store_inst.search.call_args
         assert kwargs["vec_weight"] == 0.1
         assert kwargs["fts_weight"] == 0.9
+        assert kwargs["fts_only"] is False
+
+        # fts_only as a string, weights omitted.
+        store_inst.search.reset_mock()
+        with patch("vstash.chat.ask", return_value="answer"):
+            vstash_ask("query", fts_only="TRUE")  # type: ignore[arg-type]
+        _, kwargs = store_inst.search.call_args
         assert kwargs["fts_only"] is True
 
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -536,6 +536,105 @@ class TestMemoryProjectScoping:
             # but the key is that project=None doesn't raise
             assert len(unscoped) >= len(scoped)
 
+    @requires_sqlite_vec
+    def test_search_auto_scopes_to_default_collection(self, tmp_path: Path) -> None:
+        """Regression guard for #165: instance collection='default' must be
+        honored on search(), not silently dropped.
+
+        Prior to the fix, `_resolve_collection` returned None whenever
+        the instance collection was the literal string "default",
+        treating it as a sentinel for "no filter". This created a
+        read/write asymmetry where writes scoped to "default" but
+        reads leaked across every collection. Downstream consumers
+        (engram's audit log) hit this as a silent data-leak bug.
+        """
+        db = tmp_path / "test.db"
+        with Memory(db=db, collection="default") as mem:
+            mem.remember("fact in default collection about wombats", title="t1")
+            mem.remember(
+                "audit row mentioning wombats elsewhere",
+                title="t2",
+                collection="other_coll",
+                layer="audit",
+            )
+
+            # search() with no arg must honor the instance default.
+            results = mem.search("wombats", top_k=5)
+            titles = sorted(r.title or "" for r in results)
+            assert titles == ["t1"], (
+                f"Memory(collection='default').search() leaked cross-collection "
+                f"rows: got titles={titles}, expected ['t1']. "
+                f"This is #165 — _resolve_collection no longer shortcuts 'default' to None."
+            )
+
+            # Explicit collection=None still gives cross-collection search.
+            unscoped = mem.search("wombats", top_k=5, collection=None)
+            unscoped_titles = sorted(r.title or "" for r in unscoped)
+            assert unscoped_titles == ["t1", "t2"], (
+                f"collection=None should return both rows; got {unscoped_titles}"
+            )
+
+            # Explicit collection='other_coll' scopes to just the audit row.
+            other = mem.search("wombats", top_k=5, collection="other_coll")
+            other_titles = sorted(r.title or "" for r in other)
+            assert other_titles == ["t2"], (
+                f"collection='other_coll' should return only t2; got {other_titles}"
+            )
+
+    @requires_sqlite_vec
+    def test_search_auto_scopes_to_custom_collection(self, tmp_path: Path) -> None:
+        """Memory(collection='my_coll').search() scopes to my_coll (#165).
+
+        This case worked before the #165 fix — the bug only triggered
+        when the instance collection was the literal 'default'. This
+        test documents the full symmetry so any future refactor of
+        _resolve_collection keeps both cases consistent.
+        """
+        db = tmp_path / "test.db"
+        with Memory(db=db, collection="my_coll") as mem:
+            mem.remember("fact in my_coll about cats", title="c1")
+            mem.remember("fact in other", title="c2", collection="other")
+
+            results = mem.search("cats", top_k=5)
+            titles = sorted(r.title or "" for r in results)
+            assert titles == ["c1"], (
+                f"Memory(collection='my_coll').search() scope failed; got {titles}"
+            )
+
+    @requires_sqlite_vec
+    def test_remember_and_search_use_same_collection_resolution(self, tmp_path: Path) -> None:
+        """Symmetry guard for #165: whatever collection remember() writes
+        to, search() without an explicit arg must read from the same one.
+
+        This is the deeper invariant that #165 exposed. Before the fix
+        it held for custom collections but broke for 'default'. Now it
+        holds for both.
+        """
+        for coll in ("default", "my_coll", "audit", "episodic"):
+            db = tmp_path / f"sym_{coll}.db"
+            with Memory(db=db, collection=coll) as mem:
+                # Use longer text — vstash drops sub-chunk-size fragments
+                # as "empty", which would mask the collection assertion.
+                mem.remember(
+                    f"distinctive marker text about kiwifruit biology "
+                    f"written in the {coll} collection for symmetry testing",
+                    title=f"m_{coll}",
+                )
+                # Also write to a sibling collection to rule out false positives.
+                mem.remember(
+                    f"unrelated sibling row about mountain hiking gear "
+                    f"written to other_{coll} as a cross-collection distractor",
+                    title=f"s_{coll}",
+                    collection=f"other_{coll}",
+                )
+
+                results = mem.search("kiwifruit biology", top_k=3)
+                titles = [r.title for r in results]
+                assert titles == [f"m_{coll}"], (
+                    f"Symmetry broken for collection={coll!r}: remember() "
+                    f"wrote to {coll!r} but search() returned {titles}."
+                )
+
 
 # ------------------------------------------------------------------ #
 # Memory.ask                                                           #

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -635,6 +635,52 @@ class TestMemoryProjectScoping:
                     f"wrote to {coll!r} but search() returned {titles}."
                 )
 
+    @requires_sqlite_vec
+    def test_list_auto_scopes_to_default_collection(self, tmp_path: Path) -> None:
+        """#166 review follow-up: the #165 fix touches every method that
+        calls ``_resolve_collection``, not only ``search()``. ``list()``
+        must also honor ``self._collection`` when it is the literal
+        ``"default"``.
+
+        Without this regression test, a future refactor that re-
+        introduces a ``!= "default"`` shortcut in ``_resolve_collection``
+        could silently break ``list()`` / ``get_document_chunks()`` /
+        ``miss_analysis()`` without any existing test catching it —
+        because all the search-centric tests go through ``search()``.
+        """
+        db = tmp_path / "test.db"
+        with Memory(db=db, collection="default") as mem:
+            mem.remember(
+                "fact stored in the default collection about kiwifruit biology",
+                title="default_row",
+            )
+            mem.remember(
+                "audit row stored in a separate collection about kiwifruit",
+                title="audit_row",
+                collection="audit",
+                layer="audit",
+            )
+
+            # list() without collection override must only return the
+            # document in the instance's default collection. Before the
+            # #165 fix, it would have leaked the audit row.
+            docs = mem.list()
+            titles = sorted(d.title or "" for d in docs)
+            assert titles == ["default_row"], (
+                f"Memory(collection='default').list() leaked cross-collection "
+                f"rows: got {titles}, expected ['default_row']. The #165 fix "
+                f"must apply to list() and all other _resolve_collection "
+                f"callers, not just search()."
+            )
+
+            # Explicit collection=None still returns everything — regression
+            # guard that the escape hatch is preserved for list() too.
+            all_docs = mem.list(collection=None)
+            all_titles = sorted(d.title or "" for d in all_docs)
+            assert all_titles == ["audit_row", "default_row"], (
+                f"list(collection=None) should return both rows; got {all_titles}"
+            )
+
 
 # ------------------------------------------------------------------ #
 # Memory.ask                                                           #

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -169,6 +169,68 @@ class TestStoreDeduplication:
         assert "Small Document" in titles
 
 
+class TestCosineSim:
+    """Unit tests for the pure-Python _cosine_sim helper.
+
+    Freezes the contract so that future micro-optimizations (e.g. the
+    v0.26 jump to math.sumprod + math.hypot on Python 3.12+) cannot
+    silently regress the numerical behavior or the edge-case handling.
+    """
+
+    def test_identical_vectors_return_one(self) -> None:
+        from vstash.store import _cosine_sim
+
+        v = [1.0, 2.0, 3.0, 4.0]
+        assert abs(_cosine_sim(v, v) - 1.0) < 1e-12
+
+    def test_orthogonal_vectors_return_zero(self) -> None:
+        from vstash.store import _cosine_sim
+
+        assert abs(_cosine_sim([1.0, 0.0, 0.0], [0.0, 1.0, 0.0])) < 1e-12
+
+    def test_opposite_vectors_return_negative_one(self) -> None:
+        from vstash.store import _cosine_sim
+
+        assert abs(_cosine_sim([1.0, 2.0, 3.0], [-1.0, -2.0, -3.0]) + 1.0) < 1e-12
+
+    def test_empty_vectors_return_zero(self) -> None:
+        """Regression guard: PR review on #149 flagged a false empty-vector
+        TypeError concern. Verify the actual behavior is a clean 0.0."""
+        from vstash.store import _cosine_sim
+
+        assert _cosine_sim([], []) == 0.0
+
+    def test_zero_vector_returns_zero(self) -> None:
+        from vstash.store import _cosine_sim
+
+        assert _cosine_sim([0.0, 0.0, 0.0], [1.0, 2.0, 3.0]) == 0.0
+        assert _cosine_sim([1.0, 2.0, 3.0], [0.0, 0.0, 0.0]) == 0.0
+        assert _cosine_sim([0.0, 0.0], [0.0, 0.0]) == 0.0
+
+    def test_matches_reference_formula_on_random_384d(self) -> None:
+        """Sanity check: compare against a naive reference implementation
+        on a random 384-dim vector pair (the bge-small embedding dim)."""
+        import math
+        import random
+
+        from vstash.store import _cosine_sim
+
+        random.seed(42)
+        a = [random.gauss(0, 1) for _ in range(384)]
+        b = [random.gauss(0, 1) for _ in range(384)]
+
+        # Naive reference
+        dot = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(x * x for x in b))
+        expected = dot / (norm_a * norm_b)
+
+        actual = _cosine_sim(a, b)
+        assert abs(actual - expected) < 1e-12, (
+            f"_cosine_sim disagrees with reference formula: actual={actual}, expected={expected}"
+        )
+
+
 class TestMMRDedup:
     """Test intra-document MMR diversity deduplication."""
 

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 from .memory import Memory
 from .models import ChunkInfo, DocumentInfo, ExplainInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -157,6 +157,82 @@ def _error(message: str) -> str:
 
 
 # ------------------------------------------------------------------ #
+# MCP type coercion helpers                                            #
+# ------------------------------------------------------------------ #
+#
+# MCP clients (Claude Desktop, some OpenAI-tool-calling wrappers, custom
+# JSON-RPC callers) are inconsistent about JSON types: a parameter declared
+# as ``bool`` may arrive as the string ``"true"``, a ``float | None``
+# parameter may arrive as the string ``"0.5"``.  Pydantic v2 in strict
+# mode rejects these, which would turn an otherwise-valid query into a
+# ``422 Unprocessable Entity`` at the MCP boundary and frustrate the user.
+#
+# The coercion helpers below mirror the existing defensive pattern used
+# elsewhere in this module (``top_k = int(top_k)``,
+# ``recency_boost=float(recency_boost)``) for the new RRF weight /
+# fts-only arguments added in #159.  They are permissive on input and
+# strict on output — if coercion fails, they raise ``ValueError`` with a
+# clear message naming the offending field, which ``vstash_search`` and
+# ``vstash_ask`` surface through ``_error``.
+
+
+def _coerce_optional_float(value: Any, field: str) -> float | None:
+    """Coerce an MCP-supplied value to ``float | None``.
+
+    ``None`` (omitted) and Python ``float``/``int`` pass through. Strings
+    like ``"0.5"`` are parsed. Anything else raises ``ValueError``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # bool is a subclass of int — reject explicitly so "True"/"False"
+        # sent as a bool doesn't silently become 1.0/0.0 as an RRF weight,
+        # which is almost certainly not what the caller meant.
+        msg = f"{field}: expected a float or None, got bool"
+        raise ValueError(msg)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or stripped.lower() in ("null", "none"):
+            return None
+        try:
+            return float(stripped)
+        except ValueError as exc:
+            msg = f"{field}: could not parse {value!r} as float"
+            raise ValueError(msg) from exc
+    msg = f"{field}: expected a float, None, or numeric string, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+def _coerce_bool(value: Any, field: str) -> bool:
+    """Coerce an MCP-supplied value to ``bool``.
+
+    Accepts Python bool, JSON strings ``"true"``/``"false"`` (case-insensitive),
+    and string aliases ``"1"``/``"0"``/``"yes"``/``"no"``. ``None`` becomes
+    ``False`` (the parameter default). Anything else raises ``ValueError``.
+    """
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        # Plain int from JSON — 0 = False, anything else = True.  Keeps
+        # parity with Python truthiness without silently accepting floats.
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ("true", "1", "yes", "on"):
+            return True
+        if lowered in ("false", "0", "no", "off", ""):
+            return False
+        msg = f"{field}: could not parse {value!r} as bool"
+        raise ValueError(msg)
+    msg = f"{field}: expected a bool or 'true'/'false' string, got {type(value).__name__}"
+    raise ValueError(msg)
+
+
+# ------------------------------------------------------------------ #
 # Tools                                                                #
 # ------------------------------------------------------------------ #
 
@@ -419,6 +495,9 @@ def vstash_ask(
     layer: str | None = None,
     added_after: str | None = None,
     added_before: str | None = None,
+    vec_weight: float | None = None,
+    fts_weight: float | None = None,
+    fts_only: bool = False,
 ) -> str:
     """Query vstash memory and get an LLM-generated answer with sources.
 
@@ -433,6 +512,13 @@ def vstash_ask(
         layer: If set, restrict search to documents with this layer tag.
         added_after: ISO date (e.g. '2024-01-15') — only documents added on or after.
         added_before: ISO date (e.g. '2024-06-01') — only documents added before.
+        vec_weight: Pin the RRF vector weight on the retrieval step. See
+            ``vstash_search`` for full semantics. ``None`` (default) uses
+            adaptive per-query RRF.
+        fts_weight: Pin the RRF FTS weight on the retrieval step. See
+            ``vstash_search``.
+        fts_only: If true, retrieve context using FTS5 only. See
+            ``vstash_search``.
 
     Returns:
         JSON string with answer text and source documents.
@@ -443,6 +529,12 @@ def vstash_ask(
         top_k = int(top_k)
         cfg = _get_config()
         store = _get_store()
+
+        # Defensive type coercion (MCP clients may send strings where
+        # floats/bools are expected).
+        vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
+        fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
+        fts_only_coerced = _coerce_bool(fts_only, "fts_only")
 
         # Embed query and search
         query_embedding = embed_query(query, cfg.embeddings.model)
@@ -455,6 +547,9 @@ def vstash_ask(
             layer=layer,
             added_after=added_after,
             added_before=added_before,
+            vec_weight=vec_weight_coerced,
+            fts_weight=fts_weight_coerced,
+            fts_only=fts_only_coerced,
         )
 
         if not chunks:
@@ -513,6 +608,9 @@ def vstash_search(
     added_after: str | None = None,
     added_before: str | None = None,
     mmr_lambda: float = 0.5,
+    vec_weight: float | None = None,
+    fts_weight: float | None = None,
+    fts_only: bool = False,
 ) -> str:
     """Search vstash memory without LLM — returns raw chunks with scores.
 
@@ -532,6 +630,20 @@ def vstash_search(
             recent chunks score higher. Use 0.5 for mild bias, 1.0 for strong.
         added_after: ISO date (e.g. '2024-01-15') — only documents added on or after.
         added_before: ISO date (e.g. '2024-06-01') — only documents added before.
+        mmr_lambda: Intra-document MMR diversity parameter (0.0=max diversity,
+            1.0=hard dedup). Default 0.5.
+        vec_weight: Pin the RRF vector weight for this query (overrides adaptive
+            RRF). Valid range [0.0, 1.0]. Pass None (default) for adaptive
+            per-query weighting. See vstash docs/embedding-models.md for the
+            use case (e.g. specialized-domain corpora where the vector
+            embedding is known to be diffuse).
+        fts_weight: Pin the RRF FTS weight. Same semantics and range as
+            vec_weight.
+        fts_only: If true, run FTS5 keyword search only — skip the vector ANN
+            scan, the distance cutoff, and adaptive RRF entirely. Useful for
+            debugging whether a retrieval miss is a vector problem or an FTS
+            problem, and for queries where the vector signal is known to be
+            unreliable. When true, vec_weight/fts_weight are ignored.
 
     Returns:
         JSON object with chunks array and relevance hint.
@@ -540,6 +652,13 @@ def vstash_search(
         top_k = int(top_k)
         cfg = _get_config()
         store = _get_store()
+
+        # Defensive type coercion — MCP clients can be inconsistent and may
+        # send JSON strings where booleans or floats are expected. Mirror the
+        # existing pattern used for top_k / recency_boost / mmr_lambda.
+        vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
+        fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
+        fts_only_coerced = _coerce_bool(fts_only, "fts_only")
 
         query_embedding = embed_query(query, cfg.embeddings.model)
         chunks: list[SearchResult] = store.search(
@@ -553,6 +672,9 @@ def vstash_search(
             added_after=added_after,
             added_before=added_before,
             mmr_lambda=float(mmr_lambda),
+            vec_weight=vec_weight_coerced,
+            fts_weight=fts_weight_coerced,
+            fts_only=fts_only_coerced,
         )
 
         if not chunks:

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import atexit
 import json
 import logging
+import math
 import threading
 from pathlib import Path
 from typing import Any
@@ -179,8 +180,13 @@ def _error(message: str) -> str:
 def _coerce_optional_float(value: Any, field: str) -> float | None:
     """Coerce an MCP-supplied value to ``float | None``.
 
-    ``None`` (omitted) and Python ``float``/``int`` pass through. Strings
-    like ``"0.5"`` are parsed. Anything else raises ``ValueError``.
+    ``None`` (omitted) and Python ``float``/``int`` pass through.  Strings
+    like ``"0.5"`` are parsed.  ``NaN`` and ``±Inf`` are rejected after
+    parsing because ``validate_search_input`` downstream uses ``< 0.0``
+    / ``> 1.0`` bounds which do not catch non-finite floats — without
+    this check a NaN weight would propagate all the way into RRF
+    scoring and yield NaN result scores.  Anything else raises
+    ``ValueError``.
     """
     if value is None:
         return None
@@ -191,26 +197,33 @@ def _coerce_optional_float(value: Any, field: str) -> float | None:
         msg = f"{field}: expected a float or None, got bool"
         raise ValueError(msg)
     if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
+        parsed = float(value)
+    elif isinstance(value, str):
         stripped = value.strip()
         if not stripped or stripped.lower() in ("null", "none"):
             return None
         try:
-            return float(stripped)
+            parsed = float(stripped)
         except ValueError as exc:
             msg = f"{field}: could not parse {value!r} as float"
             raise ValueError(msg) from exc
-    msg = f"{field}: expected a float, None, or numeric string, got {type(value).__name__}"
-    raise ValueError(msg)
+    else:
+        msg = f"{field}: expected a float, None, or numeric string, got {type(value).__name__}"
+        raise ValueError(msg)
+    if not math.isfinite(parsed):
+        msg = f"{field}: non-finite float value {parsed!r} is not allowed"
+        raise ValueError(msg)
+    return parsed
 
 
 def _coerce_bool(value: Any, field: str) -> bool:
     """Coerce an MCP-supplied value to ``bool``.
 
     Accepts Python bool, JSON strings ``"true"``/``"false"`` (case-insensitive),
-    and string aliases ``"1"``/``"0"``/``"yes"``/``"no"``. ``None`` becomes
-    ``False`` (the parameter default). Anything else raises ``ValueError``.
+    and string aliases ``"1"``/``"0"``/``"yes"``/``"no"``/``"on"``/``"off"``,
+    plus ``"none"``/``"null"`` (consistent with ``_coerce_optional_float``).
+    ``None`` becomes ``False`` (the parameter default).  Anything else
+    raises ``ValueError``.
     """
     if value is None:
         return False
@@ -224,7 +237,7 @@ def _coerce_bool(value: Any, field: str) -> bool:
         lowered = value.strip().lower()
         if lowered in ("true", "1", "yes", "on"):
             return True
-        if lowered in ("false", "0", "no", "off", ""):
+        if lowered in ("false", "0", "no", "off", "", "null", "none"):
             return False
         msg = f"{field}: could not parse {value!r} as bool"
         raise ValueError(msg)
@@ -531,10 +544,16 @@ def vstash_ask(
         store = _get_store()
 
         # Defensive type coercion (MCP clients may send strings where
-        # floats/bools are expected).
-        vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
-        fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
+        # floats/bools are expected). Resolve fts_only first so that
+        # fts_only=True short-circuits weight coercion — see
+        # vstash_search for the same precedence rule.
         fts_only_coerced = _coerce_bool(fts_only, "fts_only")
+        if fts_only_coerced:
+            vec_weight_coerced = None
+            fts_weight_coerced = None
+        else:
+            vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
+            fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
 
         # Embed query and search
         query_embedding = embed_query(query, cfg.embeddings.model)
@@ -592,6 +611,12 @@ def vstash_ask(
         return _error("vstash database not found. Ingest documents first with vstash_add.")
     except ConnectionError as exc:
         return _error(f"LLM backend error: {exc}")
+    except ValueError as exc:
+        # Input-validation errors (coercion failures, out-of-range
+        # weights, bad dates) are user mistakes, not server bugs —
+        # return a structured error without a stack trace. Same
+        # pattern as vstash_add / vstash_remember.
+        return _error(str(exc))
     except Exception as exc:
         logger.exception("vstash_ask failed")
         return _error(f"Query failed: {exc}")
@@ -656,9 +681,21 @@ def vstash_search(
         # Defensive type coercion — MCP clients can be inconsistent and may
         # send JSON strings where booleans or floats are expected. Mirror the
         # existing pattern used for top_k / recency_boost / mmr_lambda.
-        vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
-        fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
+        #
+        # Precedence (documented in docs/mcp-server.md): if fts_only is
+        # True, vec_weight and fts_weight are ignored. Resolve fts_only
+        # FIRST and short-circuit the weight coercion when it's on — that
+        # way a caller who sends an out-of-range or unparseable weight
+        # together with fts_only=True still gets a successful FTS-only
+        # query instead of a coercion-error bailout for an argument that
+        # was semantically meant to be ignored.
         fts_only_coerced = _coerce_bool(fts_only, "fts_only")
+        if fts_only_coerced:
+            vec_weight_coerced = None
+            fts_weight_coerced = None
+        else:
+            vec_weight_coerced = _coerce_optional_float(vec_weight, "vec_weight")
+            fts_weight_coerced = _coerce_optional_float(fts_weight, "fts_weight")
 
         query_embedding = embed_query(query, cfg.embeddings.model)
         chunks: list[SearchResult] = store.search(
@@ -713,6 +750,11 @@ def vstash_search(
 
     except FileNotFoundError:
         return _error("vstash database not found. Ingest documents first with vstash_add.")
+    except ValueError as exc:
+        # Input-validation errors (coercion failures, out-of-range
+        # weights, bad dates) are user mistakes, not server bugs —
+        # return a structured error without a stack trace.
+        return _error(str(exc))
     except Exception as exc:
         logger.exception("vstash_search failed")
         return _error(f"Search failed: {exc}")

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -704,23 +704,16 @@ class Memory:
     def _resolve_collection(self, override: object) -> str | None:
         """Resolve collection filter: explicit override > constructor default.
 
-        Uses the _UNSET sentinel to distinguish "not provided" from explicit
-        None.  Passing ``None`` explicitly clears the filter and searches
-        across every collection in the database.  Omitting the argument
-        honors ``self._collection`` — the same behavior writes get.
+        Uses the ``_UNSET`` sentinel to distinguish "not provided" from
+        explicit ``None``.  Passing ``None`` explicitly clears the
+        filter and searches across every collection in the database.
+        Omitting the argument honors ``self._collection`` — the same
+        behavior writes get.
 
-        Prior to v0.27 (#165) this method had a shortcut that returned
-        ``None`` whenever ``self._collection == "default"``, treating the
-        literal string ``"default"`` as if it were a sentinel for "no
-        filter".  That created a silent read/write asymmetry: writes
-        were scoped to ``"default"`` (because ``remember()`` and
-        ``add()`` honor ``self._collection`` directly) while reads
-        silently leaked across every collection in the database.  A
-        downstream caller that wrote audit rows to a second collection
-        would see those rows contaminate every subsequent ``search()``
-        call on the default collection.  The shortcut is removed — if
-        a caller wants cross-collection search they must ask for it
-        explicitly with ``collection=None``.
+        See #165 for the bug history: prior to v0.27 this method had
+        a ``!= "default"`` shortcut that silently converted the
+        instance collection to ``None`` for reads, breaking symmetry
+        with writes.  That shortcut is removed.
         """
         if override is not _UNSET:
             return override  # type: ignore[return-value]

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -704,13 +704,27 @@ class Memory:
     def _resolve_collection(self, override: object) -> str | None:
         """Resolve collection filter: explicit override > constructor default.
 
-        Uses the _UNSET sentinel to distinguish "not provided" from explicit None.
-        Passing None explicitly clears the filter (cross-collection search).
+        Uses the _UNSET sentinel to distinguish "not provided" from explicit
+        None.  Passing ``None`` explicitly clears the filter and searches
+        across every collection in the database.  Omitting the argument
+        honors ``self._collection`` — the same behavior writes get.
+
+        Prior to v0.27 (#165) this method had a shortcut that returned
+        ``None`` whenever ``self._collection == "default"``, treating the
+        literal string ``"default"`` as if it were a sentinel for "no
+        filter".  That created a silent read/write asymmetry: writes
+        were scoped to ``"default"`` (because ``remember()`` and
+        ``add()`` honor ``self._collection`` directly) while reads
+        silently leaked across every collection in the database.  A
+        downstream caller that wrote audit rows to a second collection
+        would see those rows contaminate every subsequent ``search()``
+        call on the default collection.  The shortcut is removed — if
+        a caller wants cross-collection search they must ask for it
+        explicitly with ``collection=None``.
         """
         if override is not _UNSET:
             return override  # type: ignore[return-value]
-        # Return None (no filter) if default is "default" — search everywhere
-        return self._collection if self._collection != "default" else None
+        return self._collection
 
     def _resolve_project(self, override: object) -> str | None:
         """Resolve project filter: explicit override > constructor default.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import math
+import operator
 import sqlite3
 import struct
 import time
@@ -166,9 +167,9 @@ def _deserialize(data: bytes) -> list[float]:
 
 def _cosine_sim(a: list[float], b: list[float]) -> float:
     """Cosine similarity between two vectors. Returns value in [-1, 1]."""
-    dot = sum(x * y for x, y in zip(a, b))
-    norm_a = math.sqrt(sum(x * x for x in a))
-    norm_b = math.sqrt(sum(x * x for x in b))
+    dot = sum(map(operator.mul, a, b))
+    norm_a = math.hypot(*a)
+    norm_b = math.hypot(*b)
     if norm_a < 1e-9 or norm_b < 1e-9:
         return 0.0
     return dot / (norm_a * norm_b)

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -165,9 +165,36 @@ def _deserialize(data: bytes) -> list[float]:
     return list(struct.unpack(f"{count}f", data))
 
 
+# Pick the fastest pure-Python dot product available on this
+# interpreter.  `math.sumprod` (Python 3.12+) is a single C-level loop
+# tuned for dot products and is ~3x faster than `sum(map(operator.mul,
+# a, b))` on 384-dim vectors.  For Python 3.10/3.11 (which we still
+# support, per pyproject.toml requires-python = ">=3.10"), fall back to
+# the map+operator path — still ~3x faster than the original generator
+# expression.  The selection happens once at module load; the hot path
+# pays zero overhead for the check.
+try:
+    _dot_product = math.sumprod  # Python 3.12+
+except AttributeError:
+
+    def _dot_product(a: list[float], b: list[float]) -> float:
+        return sum(map(operator.mul, a, b))
+
+
 def _cosine_sim(a: list[float], b: list[float]) -> float:
-    """Cosine similarity between two vectors. Returns value in [-1, 1]."""
-    dot = sum(map(operator.mul, a, b))
+    """Cosine similarity between two vectors. Returns value in [-1, 1].
+
+    Uses ``math.sumprod`` on Python 3.12+ and ``sum(map(operator.mul,
+    ...))`` as a fallback, combined with ``math.hypot(*vec)`` for the
+    L2 norm.  Both branches route through C-level stdlib loops and
+    avoid the Python-bytecode overhead of generator expressions.
+
+    Returns 0.0 when either input is an empty vector or a zero
+    vector (the existing guard catches these via the ``norm < 1e-9``
+    check — ``math.hypot()`` with no arguments returns 0.0 in
+    Python 3.8+, and ``math.sumprod([], [])`` returns 0).
+    """
+    dot = _dot_product(a, b)
     norm_a = math.hypot(*a)
     norm_b = math.hypot(*b)
     if norm_a < 1e-9 or norm_b < 1e-9:


### PR DESCRIPTION
## Release v0.27.0

Three changes since v0.26.0, one of them a **breaking behavioral change** that fixes a silent data-leak bug.

## ⚠️ Breaking change

- **\`Memory.search()\` now honors the instance collection even when it is the literal \`\"default\"\`** (#165, PR #166). Pre-v0.27, \`Memory(collection=\"default\").search(\"x\")\` silently searched **every collection** in the database because \`_resolve_collection\` had a \`!= \"default\"\` shortcut that treated the literal string as a sentinel for \"no filter\". Writes always honored \`\"default\"\`, reads did not — a read/write asymmetry that engram hit as a silent cross-collection leak into its audit log. The shortcut is removed. Callers relying on the old \"search everywhere\" behavior must now pass \`collection=None\` explicitly.

    Migration:
    \`\`\`python
    # old (implicit):
    mem = Memory(db=...)
    mem.search(\"x\")

    # new (explicit, preserves old behavior):
    mem = Memory(db=...)
    mem.search(\"x\", collection=None)
    \`\`\`

    Affects \`search()\`, \`list()\`, \`get_document_chunks()\`, and \`miss_analysis()\` — every method that calls \`_resolve_collection\`.

## Added

- **MCP RRF passthrough** (#159, PR #168) — \`vstash_search\` and \`vstash_ask\` now expose \`vec_weight\`, \`fts_weight\`, and \`fts_only\` parameters. Defensive type coercion for JSON strings (\`\"0.5\"\`, \`\"true\"\`), NaN/Inf rejection, and \`fts_only\` precedence short-circuit (an invalid weight paired with \`fts_only=true\` no longer fails the call).
- **\`docs/mcp-server.md\`** — new \"Per-call RRF controls\" section with parameter table, use cases, and coercion rules.

## Performance

- **\`_cosine_sim\` 5–11× faster** (#149, PR #149) — version-gated dispatch using \`math.sumprod\` on Python 3.12+ with a fallback to \`sum(map(operator.mul, ...))\` on 3.10/3.11. \`math.hypot(*vec)\` replaces generator-expression norms on all versions. Inside the triple-nested loop of \`_mmr_dedup\`, this saves ~20–25 ms per search on corpora where MMR fires with multi-chunk documents. Credit to @google-labs-jules for the original insight; the \`math.sumprod\` refinement was added on top after benchmarking alternatives.

## PRs merged for this release

| PR | Issue | Summary |
|---|---|---|
| #149 | — | cosine speedup + version-gated \`math.sumprod\` |
| #166 | #165 | **Breaking**: collection scoping fix (\`\"default\"\` shortcut removed) |
| #168 | #159 | MCP RRF passthrough with defensive type coercion |

## Test plan
- [x] \`pytest tests/test_memory.py::TestMemoryProjectScoping tests/test_store.py::TestAdaptiveRRF tests/test_store.py::TestCosineSim tests/test_mcp.py::TestVstashSearch tests/test_mcp.py::TestVstashAsk -q\` — 46/46 pass
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] Version bumped in \`vstash/__init__.py\` (0.26.0 → 0.27.0)
- [x] CHANGELOG.md updated with breaking change block prominently at top
- [x] README.md \"What's new\" section added
- [x] CLAUDE.md version refs updated

## Post-merge steps
1. Tag \`v0.27.0\` on main.
2. GitHub Release (triggers \`publish.yml\` → PyPI via OIDC).
3. Sync \`develop\` back to match \`main\`.

## Follow-ups for v0.28 / later
- #157 — Elevate \`miss_analysis()\` (CLI \`vstash why\` + web debug + auto-log). The big one. Deferred until post-hackathon.
- #154 — Grid experiment for \`mmr_lambda\` default on focused-document corpora. Research, not implementation.
- #153 — MMR single-chunk drop. Re-opened awaiting a real reproducer.
- **Architectural**: consider migrating the Memory constructor default \`collection: str = \"default\"\` → \`collection: str | None = None\`, so the string \`\"default\"\` stops being an implicit sentinel entirely. Breaking, deferred to a future major bump.