### PR TITLE
🧹 chore: remove dead `final_score` references in _mmr_dedup (#153 audit cleanup)

### DIFF
--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1677,7 +1677,7 @@ class VstashStore:
                     title=str(r["title"]),
                     path=str(r["path"]),
                     chunk=int(r["chunk"]),
-                    score=round(float(r.get("final_score", r["rrf"])), 6),
+                    score=round(float(r["rrf"]), 6),
                     explain=_explain_map.get(int(r["id"])) if explain else None,
                 )
                 for r in ranked
@@ -2161,8 +2161,13 @@ class VstashStore:
 
         # --- Greedy MMR selection ---
         # Normalise scores to [0, 1] for MMR balancing.
-        score_key = "final_score" if "final_score" in ranked[0] else "rrf"
-        scores = [float(r[score_key]) for r in ranked]
+        #
+        # All current RRF / fusion paths store the score under the
+        # "rrf" key. The old scoring pipeline used "final_score" and
+        # was removed in v0.18.0 (#109); the dead fallback it left
+        # behind here was a maintenance liability that made this loop
+        # harder to reason about during the #153 audit. Removed.
+        scores = [float(r["rrf"]) for r in ranked]
         s_min, s_max = min(scores), max(scores)
         s_range = s_max - s_min if s_max > s_min else 1.0
 
@@ -2178,7 +2183,7 @@ class VstashStore:
 
             for idx in remaining:
                 r = ranked[idx]
-                norm_score = (float(r[score_key]) - s_min) / s_range
+                norm_score = (float(r["rrf"]) - s_min) / s_range
                 doc_key = str(r["path"])
 
                 # Diversity penalty: only against same-document selections.


### PR DESCRIPTION
Cleanup surfaced by the second-pass audit of \`_mmr_dedup\` for #153.

## The dead code

Two references to \`\"final_score\"\` as a dict key that haven't been live since the frequency+decay scoring pipeline was removed in v0.18.0 (#109):

1. \`vstash/store.py:1680\` — \`r.get(\"final_score\", r[\"rrf\"])\` in the result-building step.
2. \`vstash/store.py:2164-2165\` — \`score_key = \"final_score\" if \"final_score\" in ranked[0] else \"rrf\"\` in \`_mmr_dedup\`, plus its use at \`store.py:2186\` inside the greedy loop.

## Why it mattered

During the #153 audit I had to spend time verifying that \`\"final_score\"\` couldn't sneak into the scored rows somewhere and produce a negative \`norm_score\`, which would have been a theoretical way to break the single-chunk-doc safety invariant the audit was checking.

Grepping confirmed no current code path writes \`\"final_score\"\`:
- RRF fusion (\`store.py:1470, 1493, 1504\`) writes \`\"rrf\"\`
- Recency boost post-processing (\`1567\`) updates \`\"rrf\"\`
- Sort steps (\`1511, 1569\`) key off \`\"rrf\"\`

So the fallback was unreachable dead code that made the MMR loop harder to reason about for no benefit.

## What changes

- \`store.py:1680\`: \`r.get(\"final_score\", r[\"rrf\"])\` → \`r[\"rrf\"]\`
- \`store.py:2164\`: removed the \`score_key\` variable, replaced with a comment explaining why \`\"final_score\"\` no longer exists
- \`store.py:2186\`: \`r[score_key]\` → \`r[\"rrf\"]\`

With this cleanup, the score key in MMR is unambiguously \`\"rrf\"\`, which makes the #153 audit conclusion (\"single-chunk docs cannot produce negative mmr_score\") provable at a glance instead of requiring a search across the file.

## Non-changes

This PR does **not** attempt to fix #153 itself. The audit concluded that \`_mmr_dedup\` is mathematically correct for single-chunk docs:

- A single-chunk doc has \`doc_key not in selected_embs_by_doc\` until it is itself selected, so \`max_sim = 0.0\` always.
- Therefore \`mmr_score = λ * norm_score - (1 - λ) * 0 = λ * norm_score ≥ 0\`.
- Therefore the \`best_mmr < 0\` break condition cannot fire on a single-chunk doc.
- The observed msdlocal symptom is almost certainly caused by a different pipeline stage (distance cutoff, FTS miss, RRF \`is_fts_top\` gate) and will be diagnosable via \`vstash why\` once #157 ships.

#153 remains open pending a concrete reproducer. I'll post the full audit conclusion on that issue separately.

## Test plan
- [x] \`pytest tests/test_store.py::TestMMRDedup tests/test_store.py::TestCosineSim tests/test_store.py::TestAdaptiveRRF tests/test_robustness.py::TestMmrFallback -q\` — 28/28 pass
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] No behavior change: the score key was \`\"rrf\"\` at runtime before this PR too. The only difference is that now it's statically obvious.