### PR TITLE
📝 docs: add development transparency disclosure (README, paper, CONTRIBUTORS)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,63 @@
+# Contributors
+
+## Human
+
+**Jayson Steffens** ([@stffns](https://github.com/stffns)) is the
+sole human contributor. The project lead, research direction,
+benchmark design, release gatekeeping, scientific claims, and the
+final word on every design decision belong to him. His professional
+background is in QA engineering. All commits in this repository are
+authored by him, and the legal responsibility for the code rests
+with him.
+
+## AI assistants used in development
+
+vstash uses AI tooling in its development workflow. This section
+documents what, how, and under what constraints, in the spirit of
+the transparency standards documented in `docs/observability.md`
+applied to the development process itself.
+
+### Claude (Anthropic)
+
+Used for: code generation, refactoring, test writing, documentation,
+responding to automated code review, debugging, and conversational
+design exploration. Long-form technical writing in this repository,
+including sections of `paper/vstash-paper.md`, `CHANGELOG.md`
+entries, and docs under `docs/`, was assisted by Claude.
+
+Not used for: design decisions, algorithm selection, benchmark
+methodology design, or release go/no-go judgment. Those are made by
+the human contributor after reviewing proposals.
+
+Constraint: per the project's internal no-AI-coauthor rule, Claude is
+never listed as commit co-author. The commit history accurately
+reflects the human contributor as author of record.
+
+### Jules (Google)
+
+Automated code agent used to surface performance optimization
+opportunities on hot paths. Example contributions: PR #149 (cosine
+similarity optimization, 5 to 11x speedup depending on Python
+version), PR #167 (MMR `norm_score` hoisting, ~27% reduction in
+inner loop time on the benchmark case). Jules-opened PRs are
+reviewed, refined, and verified before merge. No automatic merging
+of Jules output.
+
+### Gemini Code Assist and GitHub Copilot
+
+Automated code review on every PR. Their feedback is treated as
+input, not authority. Reviewer claims are verified against the
+actual codebase before being acted on. Notable instance: the review
+of PR #149 incorrectly asserted that `math.hypot(*a)` was slower
+than `sum(map(operator.mul, a, a))` due to argument unpacking
+overhead. A direct benchmark disproved the claim, and the PR kept
+the `math.hypot` approach (see PR #149 discussion).
+
+## Why this file exists
+
+Transparency about tool use should not be shameful, and it should
+not be used as a marketing hook either. Readers can judge the work
+on its merits by running the benchmarks in `experiments/`. This
+file is here so anyone who asks "was AI used in building this?"
+gets an honest, specific answer without having to infer it from
+the commit history.

--- a/README.md
+++ b/README.md
@@ -401,6 +401,27 @@ Run all experiments: `python -m experiments.run_all`
 
 ---
 
+## Development transparency
+
+vstash is developed by [Jayson Steffens](https://github.com/stffns) as
+the sole human contributor. Code generation, refactoring, and
+documentation were assisted by [Claude](https://www.anthropic.com/)
+(Anthropic). Automated optimization passes on performance hot paths
+are occasionally surfaced by Google's [Jules](https://jules.google/)
+code agent, and PR review is cross-checked by GitHub Copilot and
+Gemini Code Assist.
+
+All design decisions, algorithm choices, benchmark methodology, and
+release gatekeeping are authored and verified by the human
+contributor. Every performance claim in this repository is
+reproducible from the scripts in `experiments/`. The fastest way to
+evaluate the work is to run them.
+
+See [`CONTRIBUTORS.md`](CONTRIBUTORS.md) for a detailed breakdown of
+how each AI tool is used and what it is not used for.
+
+---
+
 ## License
 
 MIT

--- a/paper/vstash-paper.md
+++ b/paper/vstash-paper.md
@@ -771,6 +771,36 @@ The system ships with 16 MCP tools, a Python SDK, CLI, and Claude Code hook inte
 
 ---
 
+## Acknowledgments
+
+vstash is built on the work of several open-source projects whose
+quality directly enables this system: **sqlite-vec** (Alex Garcia)
+for the ANN index, **FastEmbed** (Qdrant) for the ONNX embedding
+runtime, **sentence-transformers** and **BAAI** for the embedding
+models evaluated, **tree-sitter** and **parso** for the code-aware
+chunking backends, and **SQLite/FTS5** for the keyword retrieval
+substrate. The BEIR evaluation suite (Thakur et al., 2021) provided
+the primary external benchmark against which the retrieval pipeline
+was tuned.
+
+Development of the vstash codebase was assisted by **Claude**
+(Anthropic) for code generation, refactoring, documentation, and
+responding to automated code review. All design decisions, algorithm
+choices, benchmark methodology, statistical caveats (§5.2, §8.4), and
+the negative results documented in §4 and §8.10 were authored and
+verified by the human contributor. The decision to publish the
+frequency+decay negative result rather than quietly remove it was
+made by the author in line with the scientific norm of reporting
+approaches that did not work.
+
+All experiments in this paper are reproducible from scripts in the
+project's `experiments/` directory. Benchmark numbers and figures
+were re-run against HEAD prior to each release, and the regression
+suite in `tests/test_beir_regression.py` prevents silent drift on
+the BEIR baselines.
+
+---
+
 ## References
 
 1. Cormack, G. V., Clarke, C. L. A., & Buttcher, S. (2009). Reciprocal rank fusion outperforms condorcet and individual rank learning methods. *SIGIR*.


### PR DESCRIPTION
Add explicit disclosure of AI-assisted development to three places, each calibrated for its audience.

## What changes

**1. `README.md`** — new "Development transparency" section before License.
One-paragraph factual note for casual readers, identifying the sole human contributor, the AI tools used, and the scope of what is and is not AI-assisted. Points at `CONTRIBUTORS.md` for the detailed breakdown.

**2. `paper/vstash-paper.md`** — new Acknowledgments section before References.
Formal disclosure for the academic / hackathon audience. Credits the open-source projects vstash depends on (sqlite-vec, FastEmbed, sentence-transformers, BAAI, tree-sitter, parso, SQLite/FTS5, BEIR), which was the larger attribution gap this addresses. Then discloses AI assistance for code and writing, reserving design decisions, benchmark methodology, statistical caveats, and the negative-result publication call as author-authored. Closes with a reproducibility statement.

**3. `CONTRIBUTORS.md`** — new file at repo root.
Longer reference document for anyone who wants the full picture. Documents each AI tool separately (Claude, Jules, Gemini Code Assist + GitHub Copilot), what each is used for and what each is not used for, and cites the PR #149 incident where a reviewer claim was empirically disproved as evidence that reviewer output is verified rather than accepted blindly.

## Tone

Factual across all three. No apology, no marketing, no pro-AI or anti-AI rhetoric. The operative argument that appears in all three places is "run the benchmarks in `experiments/` to evaluate the work on its merits", which moves the conversation from process to outcome.

## Scope

This PR only adds the disclosure sections. Existing em dashes and other stylistic content in README and paper are left untouched to keep the change scoped. If a style sweep is wanted, it should be a separate PR.

## Test plan
- [x] `git diff` scan confirms zero em dashes in new content.
- [x] Cross-links (README to CONTRIBUTORS.md, CONTRIBUTORS.md self-contained) render correctly.
- [x] PR #149 citation in CONTRIBUTORS.md references a real merged PR that demonstrates the pattern described.