### PR TITLE
fix: content hash for federated_search RRF fusion key

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -466,6 +466,60 @@ class TestFederatedSearch:
         expected = 1.0 / k  # rank 0, single profile
         assert abs(results[0][1].score - expected) < 1e-6
 
+    def test_rrf_does_not_fuse_divergent_long_chunks(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Two chunks sharing (path, seq) but with different content past the
+        first 64 characters must not be fused by the RRF key. Regression guard
+        for the PR #70 review comment on profile.federated_search: the prior
+        implementation used result.text[:64] as a content discriminator, which
+        collides when chunks diverge after the prefix window.
+        """
+        from vstash.store import VstashStore
+
+        profiles_dir = tmp_path / "profiles"
+        default_db = tmp_path / "memory.db"
+        monkeypatch.setattr("vstash.profile.PROFILES_DIR", profiles_dir)
+        monkeypatch.setattr("vstash.profile.DEFAULT_DB", default_db)
+        monkeypatch.setattr("vstash.profile._find_local_db", lambda: None)
+
+        dim = 384
+        embedding = [0.3] * dim
+        shared_prefix = "x" * 70 + " "  # 71 chars — identical in first 64
+        chunk_a = shared_prefix + "alpha tail content"
+        chunk_b = shared_prefix + "bravo tail content"
+
+        # Same path + seq 0 in two different profiles, with divergent content
+        # past the first 64 characters.
+        specs = [
+            (default_db, chunk_a),
+            (profiles_dir / "mirror" / "memory.db", chunk_b),
+        ]
+        for db_path_val, text in specs:
+            db_path_val.parent.mkdir(parents=True, exist_ok=True)
+            store = VstashStore(str(db_path_val), embedding_dim=dim)
+            store.add_document(
+                path="/clash.md",
+                title="Clash",
+                chunks=[text],
+                embeddings=[embedding],
+                source_type="markdown",
+            )
+            store.close()
+
+        results = federated_search(
+            query_embedding=embedding,
+            query_text="tail content",
+            embedding_dim=dim,
+            top_k=5,
+        )
+
+        # Both divergent chunks must survive the RRF merge as separate results.
+        texts = {r[1].text for r in results}
+        assert chunk_a in texts
+        assert chunk_b in texts
+        assert len([r for r in results if r[1].path == "/clash.md"]) == 2
+
 
 # ------------------------------------------------------------------ #
 # Active profile info — validation                                    #

--- a/vstash/profile.py
+++ b/vstash/profile.py
@@ -13,6 +13,7 @@ Resolution order (highest priority first):
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import re
@@ -351,9 +352,12 @@ def federated_search(
         # Results are already ranked by score within each profile
         for rank, (pname, result) in enumerate(group_list):
             # Key excludes profile — identical chunks get fused across profiles.
-            # Include text prefix to distinguish different content at same path+seq
-            # (e.g., same path ingested into different collections with different content).
-            key = (result.path, result.chunk, result.text[:64])
+            # A full-content blake2b digest discriminates different chunks that
+            # share (path, seq) (e.g., same path ingested into different
+            # collections with different content). A prefix-only discriminator
+            # would collide when chunks diverge after the prefix window.
+            content_digest = hashlib.blake2b(result.text.encode("utf-8"), digest_size=16).digest()
+            key = (result.path, result.chunk, content_digest)
             rrf_scores[key] = rrf_scores.get(key, 0) + 1.0 / (k + rank)
             if key not in result_map:
                 result_map[key] = (pname, result)


### PR DESCRIPTION
## Summary
- Replace `result.text[:64]` prefix with a `blake2b(digest_size=16)` of the full chunk text in the `federated_search` RRF fusion key.
- Prevents collisions when two chunks at the same `(path, seq)` across profiles share a prefix but diverge later.
- Adds a regression test with a 71-character shared prefix and divergent tails.

## Why
Pre-existing review comment on stffns/vstash#70 against `profile.py`: the prefix discriminator fuses distinct chunks into one result whenever they happen to share their first 64 characters.

## Test plan
- [x] `pytest tests/test_profile.py -q` (51 passed)
- [x] `pytest tests/test_profile.py tests/test_store.py tests/test_journal.py tests/test_get_chunk.py tests/test_store_helpers.py tests/test_cli_commands.py tests/test_mcp.py tests/test_ingest.py tests/test_robustness.py -q` (345 passed)
- [x] `ruff check` + `ruff format --check`