### PR TITLE
🧹 [code health improvement] Remove unused import get_language in code_split.py

### DIFF
--- a/vstash/code_split.py
+++ b/vstash/code_split.py
@@ -22,7 +22,7 @@ _HAS_TREE_SITTER = False
 _HAS_PARSO = False
 
 try:
-    from tree_sitter_language_pack import get_language, get_parser  # noqa: F401
+    from tree_sitter_language_pack import get_parser  # noqa: F401
 
     _HAS_TREE_SITTER = True
 except ImportError:


### PR DESCRIPTION
🎯 **What:** Removed unused `get_language` import from `vstash/code_split.py` since it was never being used.
💡 **Why:** Having an unused import adds unnecessary clutter and brings dependencies into the file namespace that are never leveraged, improving overall clarity and maintainability.
✅ **Verification:** Ran `ruff check .` and tests (`pytest tests/test_code_split.py`). The code correctly handles syntax checking with the unused item successfully removed without causing problems.
✨ **Result:** Improved code clarity by stripping an unnecessary variable import.

---
*PR created automatically by Jules for task [3103909149882011581](https://jules.google.com/task/3103909149882011581) started by @stffns*