### PR TITLE
🧹 Remove obsolete comment about #160 from store.py

### DIFF
--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1422,12 +1422,6 @@ class VstashStore:
             # and the relevance-tier signal correctly reports "low"
             # instead of carrying a stale high-confidence distance.
             #
-            # Note: when #160 (explicit ``fts_only``) lands, the vector
-            # path is bypassed upstream and ``vec_rows`` starts empty;
-            # this fallback block then becomes a no-op counter bump
-            # for that mode, which is accurate — the caller asked for
-            # FTS-only and got FTS-only.  Re-add an ``and not fts_only``
-            # guard at rebase time if the double-record becomes noisy.
             # First, always reset ``last_best_distance`` when vec_rows
             # is empty — whether or not there are FTS results. Without
             # this, a query where both pools are empty (e.g. corpus


### PR DESCRIPTION
🎯 **What:** Removed the obsolete `# Note: when #160...` comments from `vstash/store.py`.
💡 **Why:** The comment explains old logic about when `#160` lands, cluttering the code and making it harder to read. Removing it simplifies the source file while retaining the more relevant rationale for resetting `last_best_distance`.
✅ **Verification:** Verified that linting passes (`ruff check .`) and that tests still pass (`python -m pytest tests/`). Since it is only a comment change, functionality remains identical.
✨ **Result:** Improved code readability and maintainability by removing outdated explanatory documentation in the code itself.

---
*PR created automatically by Jules for task [7948197551084192992](https://jules.google.com/task/7948197551084192992) started by @stffns*