### PR TITLE
feat: expose added_at on SearchResult

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -756,6 +756,21 @@ class TestAddDocumentsBatch:
         assert sample_store.stats().documents == initial_count
 
 
+class TestSearchResultAddedAt:
+    """Tests for added_at field on SearchResult."""
+
+    def test_search_result_has_added_at(self, populated_store: VstashStore) -> None:
+        """Search results should include the document's added_at timestamp."""
+        dim = populated_store.embedding_dim
+        emb = [0.1] * dim
+        results = populated_store.search(query_embedding=emb, query_text="Python", top_k=3)
+        assert len(results) > 0
+        for r in results:
+            assert r.added_at is not None
+            # Should be an ISO timestamp string
+            assert "T" in r.added_at or "-" in r.added_at
+
+
 class TestSearchTelemetry:
     """Tests for search event telemetry (discard tracking)."""
 

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -87,6 +87,7 @@ class SearchResult(BaseModel):
     explain: ExplainInfo | None = Field(
         default=None, description="Diagnostic breakdown (when explain=True)"
     )
+    added_at: str | None = Field(default=None, description="ISO timestamp of document ingestion")
 
 
 class DocumentInfo(BaseModel):

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1348,7 +1348,7 @@ class VstashStore:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -1369,7 +1369,7 @@ class VstashStore:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -1511,7 +1511,7 @@ class VstashStore:
                 fts_rows = self._conn.execute(
                     f"""
                     SELECT c.id, c.text, d.title, d.path, c.seq,
-                           rank as fts_rank
+                           rank as fts_rank, d.added_at
                     FROM fts_chunks f
                     JOIN chunks c ON c.id = f.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -1614,6 +1614,7 @@ class VstashStore:
                     "path": row["path"],
                     "chunk": row["seq"],
                     "rrf": vec_contrib,
+                    "added_at": row["added_at"],
                 }
                 if explain:
                     _explain_rrf_vec[chunk_id] = vec_contrib
@@ -1648,6 +1649,7 @@ class VstashStore:
                         "path": row["path"],
                         "chunk": row["seq"],
                         "rrf": fts_contribution,
+                        "added_at": row["added_at"],
                     }
                     if explain:
                         _explain_rrf_fts[chunk_id] = fts_contribution
@@ -1825,6 +1827,7 @@ class VstashStore:
                     chunk=int(r["chunk"]),
                     score=round(float(r["rrf"]), 6),
                     explain=_explain_map.get(int(r["id"])) if explain else None,
+                    added_at=r.get("added_at"),
                 )
                 for r in ranked
             ]


### PR DESCRIPTION
## Summary
- Add `added_at: str | None` field to `SearchResult` model.
- Wire `d.added_at` through all 3 retrieval paths (sqlite-vec, snapvec, FTS5) and the RRF merge.
- Enables temporal reranking by downstream consumers (engram, MedLocal) without tags.

## Test plan
- [x] New test `TestSearchResultAddedAt::test_search_result_has_added_at`
- [x] 174 existing tests pass
- [x] `ruff check` + `ruff format`

Partially addresses #172.