### PR TITLE
feat: expose collection, tags, layer on SearchResult + fix embedder provenance

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -770,6 +770,35 @@ class TestSearchResultAddedAt:
             # Should be an ISO timestamp string
             assert "T" in r.added_at or "-" in r.added_at
 
+    def test_search_result_has_collection(self, populated_store: VstashStore) -> None:
+        """Search results should include the document's collection."""
+        dim = populated_store.embedding_dim
+        emb = [0.1] * dim
+        results = populated_store.search(query_embedding=emb, query_text="Python", top_k=3)
+        assert len(results) > 0
+        for r in results:
+            assert r.collection is not None
+
+    def test_search_result_metadata_with_tags(self, sample_store: VstashStore) -> None:
+        """Search results should expose tags and layer when set."""
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/test/tagged.md",
+            title="Tagged Doc",
+            chunks=["Document with tags and layer metadata"],
+            embeddings=[[0.5] * dim],
+            source_type="markdown",
+            tags="topic:test,category:demo",
+            layer="semantic",
+        )
+        emb = [0.5] * dim
+        results = sample_store.search(query_embedding=emb, query_text="tags layer", top_k=3)
+        tagged = [r for r in results if r.path == "/test/tagged.md"]
+        assert len(tagged) == 1
+        assert tagged[0].tags == "topic:test,category:demo"
+        assert tagged[0].layer == "semantic"
+        assert tagged[0].collection == "default"
+
 
 class TestSearchTelemetry:
     """Tests for search event telemetry (discard tracking)."""

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -109,16 +109,16 @@ class Memory:
         )
         # Silent killer defense: warn if the DB was built with a
         # different embedding model or a fastembed version that changed
-        # pooling semantics (#132 follow-up).  Only warn for non-empty
-        # stores — an empty DB has nothing to mismatch.  Wrapped in
-        # try/except so mocked stores in tests (MagicMock) don't trip.
+        # pooling semantics (#132 follow-up).  Always run — on fresh
+        # stores this stamps embedding_model into store_meta so future
+        # opens can detect drift.  Wrapped in try/except so mocked
+        # stores in tests (MagicMock) don't trip.
         import logging as _logging
 
         try:
-            if self._store.stats().chunks > 0:
-                drift_msg = self._store.check_embedding_drift(self._cfg.embeddings.model)
-                if drift_msg:
-                    _logging.getLogger("vstash").warning(drift_msg)
+            drift_msg = self._store.check_embedding_drift(self._cfg.embeddings.model)
+            if drift_msg:
+                _logging.getLogger("vstash").warning(drift_msg)
         except (TypeError, AttributeError):
             # Mocked store or unusual state — skip the check.
             pass

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -88,6 +88,9 @@ class SearchResult(BaseModel):
         default=None, description="Diagnostic breakdown (when explain=True)"
     )
     added_at: str | None = Field(default=None, description="ISO timestamp of document ingestion")
+    collection: str | None = Field(default=None, description="Named collection")
+    tags: str | None = Field(default=None, description="Comma-separated tags from frontmatter")
+    layer: str | None = Field(default=None, description="Layer/category from frontmatter")
 
 
 class DocumentInfo(BaseModel):

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1397,7 +1397,7 @@ class VstashStore:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -1418,7 +1418,7 @@ class VstashStore:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -1560,7 +1560,7 @@ class VstashStore:
                 fts_rows = self._conn.execute(
                     f"""
                     SELECT c.id, c.text, d.title, d.path, c.seq,
-                           rank as fts_rank, d.added_at
+                           rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
                     FROM fts_chunks f
                     JOIN chunks c ON c.id = f.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -1664,6 +1664,9 @@ class VstashStore:
                     "chunk": row["seq"],
                     "rrf": vec_contrib,
                     "added_at": row["added_at"],
+                    "collection": row["collection"],
+                    "tags": row["tags"],
+                    "layer": row["layer"],
                 }
                 if explain:
                     _explain_rrf_vec[chunk_id] = vec_contrib
@@ -1699,6 +1702,9 @@ class VstashStore:
                         "chunk": row["seq"],
                         "rrf": fts_contribution,
                         "added_at": row["added_at"],
+                        "collection": row["collection"],
+                        "tags": row["tags"],
+                        "layer": row["layer"],
                     }
                     if explain:
                         _explain_rrf_fts[chunk_id] = fts_contribution
@@ -1877,6 +1883,9 @@ class VstashStore:
                     score=round(float(r["rrf"]), 6),
                     explain=_explain_map.get(int(r["id"])) if explain else None,
                     added_at=r.get("added_at"),
+                    collection=r.get("collection"),
+                    tags=r.get("tags"),
+                    layer=r.get("layer"),
                 )
                 for r in ranked
             ]


### PR DESCRIPTION
## Summary
Two issues in one PR:

**#172**: `collection`, `tags`, `layer` now flow through SearchResult from all 3 retrieval paths. Downstream consumers (Merken, MedLocal) can reason about hit metadata without calling `list()` separately.

**#173**: Remove `chunks > 0` guard on `check_embedding_drift()` in `Memory.__init__`. Fresh stores now stamp `embedding_model` into `store_meta` immediately.

Closes #172, closes #173.

## Test plan
- [x] New test: `test_search_result_has_collection`
- [x] New test: `test_search_result_metadata_with_tags` (tags + layer + collection)
- [x] 108 tests pass
- [x] `ruff check` + `ruff format`