### PR TITLE
docs: full paper restructure for arXiv submission

### DIFF
--- a/paper/vstash-paper.md
+++ b/paper/vstash-paper.md
@@ -7,749 +7,152 @@
 
 ## Abstract
 
-We present **vstash**, a local-first document memory system that combines vector similarity search with full-text keyword matching via Reciprocal Rank Fusion (RRF) and adaptive per-query IDF weighting. All data resides in a single SQLite file using `sqlite-vec` for approximate nearest neighbor search and FTS5 for keyword matching — no cloud services, no external databases. (An optional `snapvec` backend adds a compressed ANN sidecar file.)
+We present **vstash**, a local-first document memory system that combines vector similarity search with full-text keyword matching via Reciprocal Rank Fusion (RRF) and adaptive per-query IDF weighting. All data resides in a single SQLite file using sqlite-vec for approximate nearest neighbor search and FTS5 for keyword matching.
 
-We make seven empirical contributions plus one negative result, complemented by three substrate-level engineering contributions introduced in v0.20–v0.25 that harden the system as a production-grade memory substrate for LLM agents: **(A)** integrity & recovery (idempotent re-ingest, invariant checks, and FTS5 rebuild), **(B)** explicit contracts with schema versioning and forward-compatible config, and **(C)** operational observability (in-process metrics registry, slow query log, and `miss_analysis` for ranking debugging). **(1)** A *distance-based relevance signal* using the cosine distance of the best vector match, validated on ~47,000 queries across 5 BEIR datasets as an effective off-topic detector (F1 = 0.856-0.996 cross-domain) with no scoring dependency or warm-up period. **(2)** Intra-document MMR deduplication that improves result diversity from ~3.2 to 5.0 unique documents per top-5 while simultaneously improving NDCG@5 from 0.814 to 0.829, and — unlike hard per-document dedup — allows semantically diverse sections from the same long document to surface. **(3)** Context expansion that retrieves adjacent chunks (±1 window) for 2.64× richer LLM context at +0.12 ms cost. **(4)** Hybrid code-aware chunking with a 3-tier splitting pipeline — tree-sitter AST (25+ languages), parso AST (Python), and regex fallback (6 languages) — that preserves function-level semantic coherence with graceful degradation. **(5)** Adaptive RRF weighting using per-query IDF analysis: rare/technical terms boost keyword weight, common terms boost vector weight, and long queries (>50 words) relax the distance cutoff. On 5 BEIR datasets, adaptive RRF improves NDCG@10 on all 5 vs fixed weights (up to +21.4% on ArguAna via cutoff adaptation), achieving NDCG@10 = 0.7263 on SciFact with BGE-small (384d) — surpassing ColBERTv2 (0.693) by 4.8%. **(6)** A rigorous evaluation of three post-RRF enhancement strategies — frequency+decay scoring, history-augmented recall, and cross-encoder reranking — all of which failed to improve NDCG on BEIR datasets. **(7)** An embedding model comparison: EmbeddingGemma-300m (768d) improves SciFact to 0.7801 (+7.4%) but degrades SciDocs (-12.2%) and FiQA (-9.6%), demonstrating that model choice is domain-dependent. **(8)** *Self-supervised embedding refinement via hybrid retrieval disagreement*: 82% of queries produce top-5 disagreement between vector and FTS signals. Fine-tuning BGE-small (33M params) with MultipleNegativesRankingLoss on 76K disagreement triples improves NDCG on all 5 BEIR datasets (up to +19.5%), surpassing ColBERTv2 (110M params) on 3/5 datasets with zero human labels. The model is published as `Stffens/bge-small-rrf-v2` on HuggingFace.
+We make four primary contributions. **(1)** Adaptive RRF with per-query IDF weighting improves NDCG@10 on all 5 BEIR datasets versus fixed weights (up to +21.4% on ArguAna), achieving 0.7263 on SciFact with BGE-small (384d). **(2)** Self-supervised embedding refinement via hybrid retrieval disagreement: 82% of queries produce top-5 disagreement between vector and FTS signals; fine-tuning BGE-small (33M params) with MultipleNegativesRankingLoss on 76K disagreement triples improves NDCG on all 5 BEIR datasets (up to +19.5%), surpassing published baselines for ColBERTv2 (110M params) on 3 of 5 datasets with zero human labels. **(3)** A negative result on post-RRF scoring: frequency+decay reranking, history-augmented recall, and cross-encoder reranking all failed to improve NDCG, leading to their removal. **(4)** A production-grade memory substrate with integrity checking, schema versioning, ranking diagnostics, and a distance-based relevance signal validated on approximately 47,000 queries.
 
-We evaluate on five BEIR benchmarks (SciFact, NFCorpus, FiQA, SciDocs, ArguAna) plus domain-specific corpora up to 50,000 chunks. With the self-tuned embedding model and adaptive RRF, vstash surpasses ColBERTv2 (110M params) on 3/5 BEIR datasets using a 33M parameter model fine-tuned with zero human labels. Search latency remains 20.9 ms median at 50K chunks with stable NDCG. The system ships with ~750 tests, 16 MCP tools, a Python SDK, CLI (including `vstash retrain` for self-supervised fine-tuning), and reproducible experiment scripts. All code, data, and the fine-tuned model are open-source.
+Search latency remains 20.9 ms median at 50K chunks with stable NDCG. The fine-tuned model is published as `Stffens/bge-small-rrf-v2` on HuggingFace. All code, data, and experiments are open-source.
 
 ---
 
-## 1. Introduction
+## 1  Introduction
 
-Large language model (LLM) agents increasingly require persistent memory — the ability to store, retrieve, and prioritize information across sessions. While cloud-hosted vector databases (Pinecone, Weaviate, Chroma) serve this need at scale, many use cases demand *local-first* operation: developer tooling, personal knowledge management, privacy-sensitive workflows, and offline agents.
+Large language model agents increasingly require persistent memory -- the ability to store, retrieve, and prioritize information across sessions. While cloud-hosted vector databases serve this need at scale, many use cases demand local-first operation: developer tooling, personal knowledge management, privacy-sensitive workflows, and offline agents.
 
 Existing local solutions face three gaps:
 
-1. **Retrieval quality.** Pure vector search misses exact keywords (error codes, proper names); pure keyword search misses semantic paraphrases. Hybrid fusion helps, but combining scores from incompatible distributions (cosine distance vs. BM25 rank) is non-trivial.
+**Retrieval quality.** Pure vector search misses exact keywords (error codes, proper names); pure keyword search misses semantic paraphrases. Hybrid fusion helps, but combining scores from incompatible distributions (cosine distance vs. BM25 rank) is non-trivial.
 
-2. **Temporal awareness.** Documents accessed yesterday should rank differently from documents untouched for months. Most RAG systems treat all chunks equally regardless of usage history.
+**Temporal awareness.** Documents accessed yesterday should rank differently from documents untouched for months. Most RAG systems treat all chunks equally regardless of usage history.
 
-3. **Confidence estimation.** When every query returns results with uniformly high scores, the system cannot distinguish "I found something relevant" from "I returned the least irrelevant thing I have."
+**Confidence estimation.** When every query returns results with uniformly high scores, the system cannot distinguish "I found something relevant" from "I returned the least irrelevant thing I have."
 
-We introduce **vstash**, a single-file system built on SQLite that addresses all three gaps. Our key insight is that *adaptive RRF fusion* — adjusting vector/keyword weights per query using IDF analysis — combined with MMR deduplication and distance-based relevance signaling, produces retrieval quality that surpasses published baselines including ColBERTv2 on SciFact.
+We introduce **vstash**, a single-file system built on SQLite that addresses all three gaps. Our key insight is that adaptive RRF fusion -- adjusting vector and keyword weights per query using IDF analysis -- combined with MMR deduplication and distance-based relevance signaling, produces retrieval quality that surpasses published baselines on standard benchmarks.
 
 ### Contributions
 
-- A **negative result on post-RRF scoring**: frequency+decay reranking, history-augmented recall, and off-the-shelf cross-encoder reranking all failed to improve NDCG on BEIR datasets, leading to their removal in favor of a simpler pipeline (§8.10).
-- A **distance-based relevance signal** using the best vector match distance, validated on ~47,000 queries across 5 BEIR datasets as an effective off-topic detector (F1 = 0.856-0.996 cross-domain). Works from the first search with no scoring dependency (§5).
-- **Intra-document MMR deduplication** that prevents a single document from flooding top-*k* while allowing semantically diverse sections from the same document to surface, improving diversity (5.0 unique docs per top-5) and NDCG@5 (+1.8%) (§3.4).
-- **Context expansion** via adjacent chunk retrieval for 2.64× richer LLM context at negligible latency cost (§3.5).
-- **Hybrid code-aware chunking** with a 3-tier splitting pipeline — tree-sitter AST (25+ languages), parso AST (Python), and regex fallback (6 languages) — with graceful degradation and decorator attachment (§6).
-- An **open-source system** with CLI, Python SDK, 16-tool MCP server for LLM agent integration, multi-profile support, cross-session journal memory, and reproducible experiment scripts (§3).
-- **Integrity & recovery** (v0.24): idempotent re-ingest via `doc_completeness` classification (missing/partial/complete), a five-invariant `integrity_check` (chunk_count parity, vec/snapvec parity, FTS5 parity, orphan chunks, SQLite `PRAGMA integrity_check`), and `integrity_repair` with collection-scoped recovery and FTS5 `rebuild`. Exposed via `vstash check [--repair] [--json]` (§3.9).
-- **Explicit contracts and schema versioning** (v0.25): a `SCHEMA_VERSION` constant with a `KNOWN_SCHEMA_VERSIONS` set, `SchemaVersionError` on unknown versions, concurrent-safe stamping (`INSERT OR IGNORE`), forward-compatible top-level config keys (warn-on-unknown instead of hard-fail), and documented score-comparability semantics in `SearchResult` (§3.10).
-- **Operational observability** (v0.21–v0.22): an in-process metrics registry, per-stage instrumentation, a slow query log, explicit limits validation at public API boundaries (`LimitsConfig` with seven knobs, `LimitError` hierarchy), and a ranking `miss_analysis()` API that traces where an expected document was eliminated in the pipeline and returns rule-based suggestions (§3.11).
+Our primary contributions are: (1) adaptive RRF with IDF-based per-query weight adjustment, validated on 5 BEIR datasets; (2) a self-supervised embedding refinement method exploiting vector/FTS disagreement, yielding a 33M parameter model that surpasses published baselines for ColBERTv2 on 3 of 5 datasets with zero human labels; (3) a documented negative result showing that post-RRF scoring strategies (frequency+decay, history-augmented recall, cross-encoder reranking) fail to improve retrieval quality; and (4) a production-grade substrate with integrity checking, schema versioning, and ranking diagnostics.
+
+Secondary contributions include intra-document MMR deduplication (+1.8% NDCG@5), context expansion (2.64x richer LLM context at +0.12 ms), a distance-based relevance signal (F1 = 0.856-0.996 cross-domain on BEIR), hybrid code-aware chunking with a 3-tier splitting pipeline, and a `vstash retrain` CLI command that enables users to fine-tune embeddings on their own corpora using the same disagreement signal.
 
 ---
 
-## 2. Related Work
+## 2  Related Work
 
-**Memory for LLM agents.** MemGPT [Packer et al., 2023] introduced virtual context management with explicit memory tiers. Mem0 [Chadha et al., 2025] and Memoria [2025] provide production-ready memory layers with cloud backends. A-MEM [2025] uses agentic self-organization. Unlike these systems, vstash operates entirely locally with zero cloud dependencies.
+**Memory for LLM agents.** MemGPT (Packer et al., 2023) introduced virtual context management with explicit memory tiers. Mem0 (Chadha et al., 2025) and Memoria (2025) provide production-ready memory layers with cloud backends. A-MEM (2025) uses agentic self-organization. Unlike these systems, vstash operates entirely locally with zero cloud dependencies.
 
-**Hybrid retrieval.** Reciprocal Rank Fusion (RRF) [Cormack et al., 2009] merges ranked lists without requiring comparable scores. Ma et al. [2024] showed RRF outperforms learned re-rankers on out-of-domain data. Our contribution is the post-RRF normalization step that enables fusion with frequency-based signals.
+**Local-first agent memory.** Several concurrent projects share vstash's SQLite + hybrid search architecture: palinode (git-native markdown + sqlite-vec + RRF), cpersona (MCP server with 3-strategy RRF), agentmem (FTS5 + vector with adaptive ranking), and sqlite-memory (FTS5 + vector with offline sync). None publish formal NDCG evaluations on standard benchmarks. neo4j-labs/agent-memory takes an orthogonal approach with graph-native entity extraction and temporal knowledge graphs, targeting relational queries rather than dense retrieval.
 
-**Temporal decay in memory.** The Ebbinghaus forgetting curve [1885] inspires exponential decay models. Zep [2025] uses temporal knowledge graphs; MaRS [2025] models cognitive forgetting. PAM [2026] exploits temporal co-occurrence. We explored decay directly in the scoring formula (§4) but found it did not improve retrieval quality on real benchmarks. In v0.19, we introduced an opt-in temporal recency boost as a simpler alternative.
+**Hybrid retrieval.** Reciprocal Rank Fusion (Cormack et al., 2009) merges ranked lists without requiring comparable scores. Ma et al. (2024) showed RRF outperforms learned re-rankers on out-of-domain data. Our contribution is adaptive per-query weight adjustment using IDF analysis, not explored in prior RRF work.
 
-**Code-aware chunking.** Tree-sitter-based approaches parse full ASTs but require language grammars. Our hybrid 3-tier approach uses tree-sitter when available (25+ languages via optional dependency), parso for Python (base dependency), and regex at column 0 as a fallback — providing graceful degradation from full AST precision to pattern-based detection without hard dependencies.
+**Temporal decay in memory.** The Ebbinghaus forgetting curve (1885) inspires exponential decay models. Zep (2025) uses temporal knowledge graphs; MaRS (2025) models cognitive forgetting. We explored decay directly in the scoring formula but found it did not improve retrieval quality on benchmarks (Section 6).
 
 ---
 
-## 3. System Architecture
+## 3  System Architecture
+
+vstash stores all data in a single SQLite database using WAL mode for concurrent read safety. The database contains five core tables: *documents* (metadata, hierarchical tags, source type), *chunks* (text segments with sequence numbers and access counters), *vec_chunks* (sqlite-vec virtual table for ANN search, 384-dim float vectors), *fts_chunks* (FTS5 virtual table with Porter stemming), and *journal_entries* (append-only cross-session memory for agents).
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                        INGESTION                                │
-│  PDF/DOCX/URL/Code ──► MarkItDown ──► Chunking ──► FastEmbed   │
-│                          parse      (3-tier code    (ONNX,      │
-│                                      or semantic)   384-dim)    │
-└──────────────────────────────┬──────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    SQLite (WAL mode)                             │
-│  ┌────────────┐  ┌────────────┐  ┌──────────┐  ┌────────────┐  │
-│  │ documents  │  │   chunks   │  │vec_chunks│  │ fts_chunks │  │
-│  │ metadata,  │  │ text, seq, │  │sqlite-vec│  │  FTS5 +    │  │
-│  │ tags, path │  │ access_cnt │  │  ANN idx │  │  Porter    │  │
-│  └────────────┘  └────────────┘  └──────────┘  └────────────┘  │
-│  ┌──────────────────┐  ┌──────────────────────────────────────┐ │
-│  │ journal_entries  │  │ profiles (multi-DB isolation)        │ │
-│  │ cross-session    │  │ named DBs with federated search     │ │
-│  │ agent memory     │  │ across profiles                     │ │
-│  └──────────────────┘  └──────────────────────────────────────┘ │
-└──────────────────────────────┬──────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                        RETRIEVAL                                │
-│  Query ──► Embed ──┬──► Vector ANN ──┐                          │
-│                    │                 ├──► RRF Fusion             │
-│                    └──► FTS5 BM25 ───┘        │                 │
-│                                               ▼                 │
-│                                    Recency Boost (opt-in, §4)   │
-│                                               │                 │
-│                                               ▼                 │
-│                                    MMR Dedup (§3.4)              │
-│                                               │                 │
-│                                               ▼                 │
-│                                    Distance Relevance Signal     │
-│                                    (high/medium/low, §5)        │
-│                                               │                 │
-│                                               ▼                 │
-│                                    Context Expansion (±1, §3.5)  │
-│                                                                  │
-│  Direct Access: get_chunk(id) — O(1) PK lookup (§3.6)           │
-└──────────────────────────────┬──────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      INTERFACES                                 │
-│   CLI    │  Python SDK  │  MCP Server (16 tools)│ Claude Hook  │
-│ (search, │ (Memory()    │ (search, add, ask,    │ (auto-inject │
-│  ask,    │  .search()   │  remember, get_chunk, │  on knowledge│
-│  chat,   │  .get_chunk()│  journal, forget,     │  questions)  │
-│  journal)│  .journal()) │  list, stats, export) │              │
-└─────────────────────────────────────────────────────────────────┘
+                        INGESTION
+  PDF/DOCX/URL/Code --> MarkItDown --> Chunking --> FastEmbed
+                          parse      (3-tier code    (ONNX,
+                                      or semantic)   384-dim)
+                               |
+                               v
+                    SQLite (WAL mode)
+  documents | chunks | vec_chunks (ANN) | fts_chunks (FTS5)
+  journal_entries | profiles (multi-DB isolation)
+                               |
+                               v
+                        RETRIEVAL
+  Query --> Embed --+--> Vector ANN --+
+                    |                 +--> RRF Fusion
+                    +--> FTS5 BM25 ---+        |
+                                    Recency Boost (opt-in) -->
+                                    MMR Dedup -->
+                                    Distance Signal -->
+                                    Context Expansion (+/-1)
+                               |
+                               v
+   CLI  |  Python SDK  |  MCP Server (16 tools)  |  Claude Hook
 ```
-*Figure 1: vstash architecture (v0.25). All data resides in a single SQLite file per profile (with an optional `.snpv` sidecar when using the snapvec backend). The retrieval pipeline applies adaptive RRF fusion (IDF-weighted), optional recency boost, intra-document MMR deduplication, a distance-based relevance signal, and context expansion. Multi-profile support enables isolated databases with federated search across profiles.*
+*Figure 1: vstash architecture.*
 
-vstash stores all data in a single SQLite database using WAL mode for concurrent read safety:
+### 3.1  Ingestion
 
-- **Documents table** — metadata, hierarchical tags (project, layer, collection), source type.
-- **Chunks table** — text segments with sequence numbers, access counters, and timestamps.
-- **vec_chunks** — `sqlite-vec` virtual table for approximate nearest neighbor search (384-dim float vectors from BAAI/bge-small-en-v1.5).
-- **fts_chunks** — FTS5 virtual table with Porter stemming for keyword matching.
-- **search_events** — telemetry table recording query, distance, relevance tier, and dismiss flag for real-world signal validation (pruned to 1,000 entries).
-- **journal_entries** — append-only cross-session memory for LLM agents (text, tags, timestamps).
+Documents are parsed via MarkItDown (PDF, DOCX, HTML, URLs) or read directly (code files). Text is split into chunks using semantic chunking or code-aware chunking (Appendix B) depending on source type. Chunks are embedded using FastEmbed (ONNX Runtime, BAAI/bge-small-en-v1.5) at approximately 700 chunks per second on CPU. Batch ingestion via `add_documents_batch()` amortizes transaction overhead for bulk loading.
 
-### 3.1 Ingestion Pipeline
+### 3.2  Hybrid Search with RRF
 
-Documents are parsed via MarkItDown (PDF, DOCX, HTML, URLs) or read directly (code files). Text is split into chunks using either semantic chunking (§6) or code-aware chunking depending on source type. Chunks are embedded using FastEmbed (ONNX Runtime) at ~700 chunks/s on CPU.
-
-### 3.2 Hybrid Search with RRF
-
-Given a query *q*, we retrieve candidates from both indexes:
+Given a query *q*, we retrieve candidates from both indexes and fuse via Reciprocal Rank Fusion:
 
 ```
 RRF(c) = w_v / (k + r_v(c)) + w_f / (k + r_f(c))
 ```
 
-where *r_v(c)* and *r_f(c)* are the ranks of chunk *c* in vector and FTS5 results respectively, *k = 60*, and weights *w_v = 0.6*, *w_f = 0.4*.
+where *r_v(c)* and *r_f(c)* are the ranks of chunk *c* in vector and FTS5 results respectively, *k = 60*, and default weights *w_v = 0.6*, *w_f = 0.4*. These weights are overridden by adaptive IDF weighting (Section 4). Each query word is individually double-quoted and joined with OR, preventing FTS5 Boolean operator injection.
 
-**FTS5 safety.** Each query word is individually double-quoted and joined with OR, preventing FTS5 Boolean operator injection (NEAR, NOT) while allowing keyword-level matching instead of exact-phrase. Internal quotes are escaped by doubling.
+### 3.3  Intra-Document MMR Deduplication
 
-### 3.3 LLM Agent Integration
-
-vstash integrates with LLM agents through three interfaces:
-
-**MCP Server.** Exposes 16 tools via the Model Context Protocol: search, add, ask, remember (direct text ingestion), get_chunk (O(1) chunk retrieval by ID), get_document_chunks (full document reconstruction), list, stats, forget, collections, export, job status, and four journal tools (save, recall, log, prune). The server includes LLM-facing instructions that guide clients on when to use (knowledge questions) and when to skip (action commands) memory tools. Search results include the relevance signal, enabling clients to filter noise.
-
-**Claude Code Hook.** A `UserPromptSubmit` hook that auto-injects vstash context on knowledge questions. A pattern-based filter distinguishes knowledge questions from action commands (commit, merge, push), achieving 17/17 accuracy on our test set.
-
-**Python SDK.** A `Memory` class with context manager protocol for programmatic integration into agent frameworks. Methods include `search()`, `ask()`, `add()`, `remember()`, `get_chunk()`, `get_chunks()`, `journal_save()`, `journal_recall()`, and full document management.
-
-### 3.4 Intra-Document MMR Deduplication
-
-After RRF ranking (and optional recency boost), multiple chunks from the same document often cluster in the top-*k*. This floods results with redundant content and reduces diversity.
-
-Our initial approach used hard per-document deduplication — keeping only the highest-scoring chunk per document path. This improved diversity from ~3.2 to 5.0 unique documents per top-5 and NDCG@5 from 0.814 to 0.829. However, hard dedup discards *all* secondary chunks from a document, even when they cover semantically distinct topics (e.g., different chapters of a textbook).
-
-We replace hard dedup with **intra-document Maximal Marginal Relevance (MMR)**, which allows multiple chunks from the same document when they are semantically diverse:
+After RRF ranking, multiple chunks from the same document often cluster in the top-*k*. We apply intra-document Maximal Marginal Relevance:
 
 ```
-MMR(c) = λ · norm_score(c) - (1 - λ) · max_{s ∈ S_d} cos_sim(emb(c), emb(s))
+MMR(c) = L * norm_score(c) - (1 - L) * max_{s in S_d} cos_sim(emb(c), emb(s))
 ```
 
-where *S_d* is the set of already-selected chunks from the same document *d*, and *λ* controls the relevance/diversity trade-off (default 0.5). Chunks from *different* documents compete purely on score — no cross-document penalty is applied.
+where *S_d* is the set of already-selected chunks from the same document *d*, and *L = 0.5*. Chunks from different documents compete purely on score. When the best remaining candidate has negative MMR, selection stops. This improves diversity from approximately 3.2 to 5.0 unique documents per top-5 while improving NDCG@5 from 0.814 to 0.829 (+1.8%).
 
-**Key design decisions:**
+### 3.4  Context Expansion
 
-1. **Intra-document only.** Cross-document MMR would penalize topically similar but independently authored documents. By restricting the diversity penalty to same-document chunks, we preserve the original dedup benefit (no single document floods results) while allowing genuinely diverse sections through.
-2. **Negative MMR cutoff.** When the best remaining candidate has negative MMR (redundancy penalty exceeds relevance), selection stops. This prevents filling top-*k* with diminishing-value duplicates.
-3. **Selective embedding fetch.** Embeddings are retrieved from `vec_chunks` only for documents with multiple candidates in the pool (~0.33 ms for 50 embeddings), avoiding unnecessary I/O for the common case of unique documents.
+A single chunk (approximately 250 tokens) provides insufficient context for LLM answer generation. We expand each search result by fetching adjacent chunks (+/-1 by sequence number within the same document). Default window *w = 1* yields 2.64x more text per result at +0.12 ms overhead.
 
-### Table 0: Effect of document deduplication (24 papers, 786 chunks)
+### 3.5  Interfaces
 
-| Metric | Before | Hard dedup | MMR dedup |
-|--------|:------:|:----------:|:---------:|
-| NDCG@5 | 0.814 | **0.829** (+1.8%) | **0.829** (+1.8%) |
-| Unique docs per top-5 | ~3.2 | **5.0** | **5.0** |
-| Multi-section coverage | n/a | 1 chunk/doc | diverse chunks/doc |
+vstash integrates with LLM agents through three interfaces: a 16-tool MCP server, a Claude Code hook for automatic context injection on knowledge questions, and a Python SDK with context manager protocol. Details are provided in Appendix D.
 
-On short documents (papers, notes), MMR produces identical results to hard dedup — similarity between chunks from the same short document is high, so only one passes. On long multi-section documents, MMR surfaces distinct sections that hard dedup would discard.
+### 3.6  Relevance Signal via Vector Distance
 
-### 3.5 Context Expansion
+A retrieval system that always returns results -- even for off-topic queries -- must provide a confidence signal. We evaluated score spread (max - min of top-*k* scores) and the cosine distance of the best vector match. Score spread requires scoring warm-up and produces complete class overlap (F1 = 0.667); vector distance works from the first search with zero class overlap (F1 = 0.952).
 
-A single chunk (~250 tokens) provides insufficient context for LLM answer generation. We expand each search result by fetching adjacent chunks (±*w* by sequence number within the same document) and concatenating their text:
+**Table 1: Relevance signal comparison (10 relevant + 10 irrelevant queries)**
 
-```
-expanded_text(c) = concat(text(c - w), ..., text(c), ..., text(c + w))
-```
+| Signal | Relevant avg | Irrelevant avg | Class overlap | F1 |
+|--------|:---:|:---:|:---:|:---:|
+| Score spread (best config) | 0.305 | 0.245 | 10/10 (complete) | 0.667 |
+| **Vector distance** | **0.594** | **0.978** | **0/10 (none)** | **0.952** |
 
-Default *w = 1* yields 2.64× more text per result at +0.12 ms overhead. This is applied in all LLM-facing interfaces (ask, chat, MCP) but not in raw search, where chunk-level granularity is preserved.
+The distance signal was validated on 5 BEIR benchmarks using cross-domain queries (approximately 47,000 queries total). It achieves F1 = 0.996 on cross-domain queries (ArguAna) but degrades to F1 = 0.472 on intra-domain queries (NFCorpus), establishing it as an effective off-topic detector rather than a universal relevance classifier. We implement a three-tier system: distance <= 0.95 (high confidence), 0.95-0.98 (medium, with uncertainty indicator), and > 0.98 (low, with explicit warning).
 
-### 3.6 Direct Chunk Access
+**Table 2: Distance-based relevance signal on BEIR**
 
-Search results include a `chunk_id` (the database row ID) that enables O(1) retrieval of individual chunks without re-running a search. The `get_chunk(id)` and `get_chunks(ids)` APIs perform primary key lookups with a JOIN to the documents table, returning chunk text, metadata, and source document information. Batch requests are automatically batched at 900 IDs per SQL statement to respect SQLite's `SQLITE_LIMIT_VARIABLE_NUMBER` (default 999).
+| Dataset | Rel queries | Irrel queries | Best threshold | F1 |
+|---------|:---:|:---:|:---:|:---:|
+| ArguAna | 1,406 | 9,999 | 0.65 | **0.996** |
+| SciDocs | 1,000 | 9,999 | 0.71 | **0.856** |
+| FiQA | 648 | 6,752 | 0.71 | **0.763** |
+| SciFact | 300 | 9,999 | 0.71 | **0.598** |
+| NFCorpus | 323 | 9,999 | 0.76 | **0.472** |
 
-This API enables downstream applications to pin specific chunks for later use — e.g., a spaced repetition system can store chunk IDs as stable references to knowledge atoms. Chunk IDs are stable for the lifetime of the current index; re-ingesting a document invalidates prior IDs.
+### 3.7  Production Substrate
 
-### 3.7 Multi-Profile Support
-
-vstash supports multiple named profiles, each backed by an isolated SQLite database. Profiles are resolved via a chain: explicit `--profile` flag → `VSTASH_PROFILE` environment variable → `default` profile. Each profile has its own document collection, search index, and access history.
-
-**Federated search** queries across all profiles in parallel and merges results via RRF fusion with cross-profile deduplication. The fusion key `(path, chunk_seq, text[:64])` prevents identical content in different profiles from duplicating in results while distinguishing genuinely different content at the same path and sequence number.
-
-### 3.8 Cross-Session Journal
-
-The journal subsystem provides lightweight, append-only memory for LLM agents. Unlike document ingestion (which chunks, embeds, and indexes), journal entries are stored as single text records with timestamps and optional tags. The API supports four operations: `save` (append), `recall` (semantic search over entries), `log` (chronological listing), and `prune` (remove entries older than a threshold).
-
-Journal entries are designed for ephemeral cross-session context: action items, decisions, meeting notes, and observations that an agent needs to recall in future sessions but that don't warrant full document ingestion. Transcript parsing automatically extracts structured entries from conversation logs.
-
-### 3.9 Integrity and Recovery (v0.24)
-
-A memory substrate must be honest about what survived a crash. Partial ingests, aborted writes, and corrupted virtual tables are realities of long-running SQLite workloads; silently returning stale or missing chunks is worse than raising a clear error.
-
-**Idempotent ingest.** `VstashStore.doc_completeness(path, collection="default")` classifies a document path *within a specific collection* as:
-
-- **missing** — no row in `documents` for `(collection, path)`.
-- **partial** — the document row exists but `chunk_count` disagrees with the actual `chunks` row count or with `vec_chunks` parity, indicating an interrupted ingest.
-- **complete** — all parities hold.
-
-The `collection` parameter is load-bearing: the same path can be ingested into multiple collections (each gets its own `doc_id = sha256(collection:path)`), and a partial copy in one collection must not mark a sibling collection's complete copy as healable. `ingest()` consults this classification: *complete* documents are skipped (a re-ingest is a no-op), *partial* documents are dropped via a collection-scoped `delete_document(path, collection=...)` and re-ingested from scratch, and *missing* documents ingest normally. Re-running the same `vstash add <path>` is therefore safe and does not duplicate data across collections.
-
-**Integrity check.** `VstashStore.integrity_check()` runs five invariants over the store:
-
-1. **chunk_count parity** — `documents.chunk_count` matches `COUNT(*)` in `chunks` grouped by `doc_id`.
-2. **vec/snapvec parity** — every `chunks.id` has a corresponding row in `vec_chunks` (or the active `snapvec` backend).
-3. **fts_index integrity** — the `fts_chunks` FTS5 virtual table passes the built-in FTS5 `integrity-check` command (which actually scans the index for drift, unlike a naive `COUNT(*)` comparison against a `content=chunks` table — that was the subtly wrong check in v0.24.0, corrected in v0.24.1).
-4. **orphan chunks** — no `chunks` row points at a missing `doc_id`.
-5. **SQLite PRAGMA integrity_check** — delegates to the engine for page-level corruption detection.
-
-Results are returned as a `list[IntegrityCheck]` (one Pydantic model per invariant) and can be rendered as a rich table or JSON.
-
-**Integrity repair.** `VstashStore.integrity_repair()` restores invariants without destroying user data: it recomputes `chunk_count` from the ground truth for every affected document, rebuilds `fts_chunks` via the FTS5 `rebuild` incantation, and deletes orphan `chunks` rows along with their `vec_chunks` companions. Repair is **profile-scoped** (it operates over the whole profile database, not per-collection) — the collection-aware surface in v0.24 lives one layer up, at the *recovery* path during `ingest()`: `delete_document(path, collection=...)` makes sure that repairing a partial ingest in one collection cannot wipe a sibling collection's complete copy of the same path (this was the primary v0.24.1 hotfix, alongside the FTS5 invariant correction above).
-
-**CLI surface.** All of the above is exposed via `vstash check [--repair] [--json]`, which is the recommended first step after any unclean shutdown, power loss, or cross-device copy of a profile database.
-
-### 3.10 Explicit Contracts and Schema Versioning (v0.25)
-
-Early versions of vstash treated schema evolution implicitly: a newer binary would silently read older databases. This works until it doesn't — a future breaking change could corrupt user data with no warning. v0.25 makes every load-bearing contract explicit.
-
-**Schema version.** A `SCHEMA_VERSION` constant in `vstash/store.py` is stamped into the `store_meta` table (keys: `schema_version`, `vstash_version`) at database creation, alongside the vstash version that created it. A `KNOWN_SCHEMA_VERSIONS` set declares which on-disk versions the current build can safely open. On every `open()`:
-
-- **Fresh databases** are stamped with the current version via `INSERT OR IGNORE` — tolerating concurrent first-opens across threads or processes without races (v0.25.0 hotfix).
-- **Legacy, unstamped databases** are re-stamped as `v1` and carry on.
-- **Unknown future versions** (database declares a version not in `KNOWN_SCHEMA_VERSIONS`) raise `SchemaVersionError` rather than silently degrading.
-- **The recorded vstash version is refreshed on every open**, so `vstash check` and support diagnostics always reflect the last binary that touched the file.
-
-**Forward-compatible config.** `VstashConfig` (Pydantic v2) now allows **unknown top-level keys** with a one-time warning, so a user running an older vstash against a newer-format `vstash.toml` is not hard-blocked. Nested sections keep strict validation — typos inside a known section like `[scoring]` or `[limits]` are still caught, so the laxity only covers genuine forward-compatibility, not drift within documented sections.
-
-**Score-comparability semantics.** `SearchResult.score` is now documented explicitly in the model docstring: it is the canonical RRF score `w_v · 1/(60 + rank_vec) + w_f · 1/(60 + rank_fts)` with `k = 60`, so a single RRF component caps at `1/(60 + 0) ≈ 0.0167` and a two-component fused score occupies a typical range of `[0, ~0.033]` (recency boost and post-processing can push it slightly higher). Scores are comparable across results **within a single query**, and are **not comparable across queries** because the candidate pool, adaptive RRF weights, and post-processing all vary by query. This previously ambiguous contract caused downstream tools to build cross-query thresholds on top of scores that cannot support them; the documentation change turns a silent footgun into a written-down rule.
-
-### 3.11 Operational Observability (v0.21–v0.22)
-
-A substrate that runs in agents and servers must be debuggable from the outside. vstash exposes internal state that upper-layer memory frameworks (Mem0, Zep, LangChain memory) cannot: transparent ranking diagnostics and per-stage timing.
-
-**Metrics registry and slow query log (v0.22).** An in-process metrics registry tracks counts and per-stage latency histograms across the ingest and search pipelines. A slow query log captures any search exceeding a configurable threshold, recording query text, stage breakdown (vector ANN, FTS5, RRF fusion, MMR, context expansion), and result count. Both are accessible via the Python SDK and via MCP tools, so operators running `vstash serve` or the MCP server are not flying blind.
-
-**Explicit limits validation (v0.23).** A new `vstash/validation.py` module rejects pathological inputs at the `VstashStore` and `Memory` boundaries before they ever reach SQLite, sqlite-vec, or the embedding model. A `LimitsConfig` section in `vstash.toml` exposes seven knobs: `max_query_chars`, `max_top_k`, `max_distance_cutoff`, `max_recency_boost`, `max_path_chars`, `max_chunks_per_document`, and `max_chunk_chars`. A `LimitError(ValueError)` hierarchy with one subclass per category lets callers catch a single bucket or the whole family. The net effect is that malformed inputs produce a typed Python exception at the API boundary rather than an opaque SQLite or ONNX failure deep in the stack.
-
-**Ranking miss analysis (v0.21).** `VstashStore.miss_analysis(query_embedding, query_text, *, expected_path=None, expected_chunk_id=None, top_k=5, ...)` diagnoses *why* an expected document did not appear in a result set. It runs the same pipeline as `search()` with per-stage tracking enabled, then returns a `MissAnalysis` model containing a structured trace identifying where in the pipeline the chunk was eliminated — vector ANN cutoff, FTS5 Porter-stem mismatch, RRF rank dropout, MMR redundancy penalty, or post-fusion distance cutoff — and rule-based suggestions (e.g., "consider lowering `max_distance` for long queries" or "the matching chunk is tokenized differently; try adding `"<exact phrase>"`"). This is exactly the transparent ranking diagnostic that upper-layer frameworks cannot offer, because they treat the retrieval engine as a black box.
-
-**Threading hardening (v0.20).** Two related fixes closed long-standing concurrency footguns. First, the assumption that the underlying `libsqlite` is built with thread support is now *explicit*: `vstash/store.py` asserts `sqlite3.threadsafety > 0` at **module import time** (not at `open()`), so an exotic single-threaded build fails loudly at load rather than corrupting data later. Most Python builds use `sqlite3.threadsafety = 3` (fully serialized) and pass this check transparently. Second, STEM (FTS5 Porter stemming) connections — the per-thread `sqlite3` handles kept in `self._stem_conns` and used only by their owning thread for tokenization lookups — can now be `close()`d from any thread. This fixed an asyncio/threading deadlock in the MCP server path where a stem connection whose owner thread had exited could not be released, leaking file descriptors and eventually hanging shutdown.
+The system includes integrity checking with five invariants and idempotent re-ingest, explicit schema versioning with forward-compatible config, and operational observability via a metrics registry, slow query log, and ranking `miss_analysis` API. These features are described in Appendix A.
 
 ---
 
-## 4. Temporal Scoring: From Frequency+Decay to Recency Boost
+## 4  Adaptive RRF with IDF Weighting
 
-> **Note (v0.19):** The frequency+decay scoring system described in §4.1–4.5 was implemented in v0.5.0, evaluated extensively on BEIR benchmarks (§8.2, §8.6, §8.10), and **removed in v0.18.0** after failing to improve NDCG on any tested dataset. It is documented here as a negative result (contribution 6 in the abstract). In v0.19.0, it was replaced by a simpler opt-in recency boost (§4.6).
+Fixed RRF weights (0.6 vector, 0.4 FTS) assume all queries benefit equally from keyword matching. Evaluation on BEIR revealed this assumption fails on long, semantically-rich queries: on ArguAna (average 194 words), fixed weights degraded NDCG@10 by -16.1% versus a tuned dense-only baseline.
 
-### Historical: Frequency+Decay Re-ranking (v0.5–v0.17)
+### 4.1  Method
 
-After RRF retrieval, we applied a two-stage re-ranking.
+Adaptive RRF computes per-query weights using the mean IDF of Porter-stemmed query terms via a sigmoid function. High IDF (rare or technical terms) boosts FTS weight, directing the system toward exact keyword matching. Low IDF (common vocabulary) boosts vector weight, relying on semantic similarity. The IDF values are computed from a vocabulary cache built from fts5vocab in approximately 15 ms on first search, with subsequent lookups at approximately 0.003 ms per query.
 
-### 4.1 Min-Max Normalization
+Additionally, long queries (>50 words) relax the distance cutoff from 1.15x to 5.0x the best match distance. This prevents the elimination of relevant results when embeddings are diffuse -- long queries produce compressed distance distributions where the default cutoff is too aggressive.
 
-RRF scores occupy a narrow band (~0.009–0.016) while frequency logs span a wider range (~0.69–2.40). Without normalization, frequency dominates. We normalize RRF within each batch:
+### 4.2  Results
 
-```
-ŝ_rrf(c) = (s_rrf(c) - min_i s_rrf(c_i)) / (max_i s_rrf(c_i) - min_i s_rrf(c_i))
-```
-
-### 4.2 Scoring Formula
-
-```
-score(c) = α · ŝ_rrf(c) + β · min(1, log(1 + f(c)) / log(1 + S))
-```
-
-where the frequency component is:
-
-```
-f(c) = (1 + access_count(c)) · e^(-λ · days_ago(c))
-```
-
-- **α, β**: semantic and memory weights (α + β ≤ 1)
-- **λ**: decay rate (days⁻¹)
-- **S = 100**: saturation constant for log normalization cap
-- The **+1 baseline** ensures new documents can compete on pure semantic relevance
-
-### 4.3 Over-Fetch and Re-Rank
-
-We retrieve *N_over = 50* candidates via RRF, apply the scoring formula, sort, and truncate to `top_k`. This limits scoring compute to 50 candidates regardless of corpus size.
-
-### 4.4 Access Tracking
-
-After returning results, we batch-update `access_count` and `last_accessed_at` for returned chunks. This creates a feedback loop: frequently retrieved chunks accumulate higher scores, subject to temporal decay.
-
-**Clock skew protection.** We clamp *days_ago ≥ 0* to prevent future timestamps (from clock drift or timezone issues) from inflating scores.
-
-### 4.5 Adaptive Scoring Maturity Gate (γ)
-
-A fixed β > 0 degrades ranking from day one: with uniform or near-uniform access counts, the frequency component injects noise rather than signal. We introduce an adaptive maturity coefficient γ ∈ [0, 1] that scales β based on the *max/mean ratio* of access counts among accessed chunks:
-
-```
-γ = clamp((R - R_low) / (R_high - R_low), 0, 1)
-
-where R = max(access_count) / mean(access_count)   [over chunks with access_count > 0]
-      R_low  = 8.0    (below this, γ = 0 — scoring suppressed)
-      R_high = 15.0   (above this, γ = 1 — full scoring)
-```
-
-The effective scoring formula becomes:
-
-```
-score(c) = α · ŝ_rrf(c) + (β · γ) · min(1, log(1 + f(c)) / log(1 + S))
-```
-
-**Why max/mean ratio?** We considered three activation metrics:
-
-1. **Shannon entropy** of the access count distribution measures diversity but does not discriminate between uniform noise and genuine signal variation — both produce high entropy when there are many distinct values.
-2. **Gini coefficient** measures concentration but requires reading all chunk counts, and moderate Gini values are ambiguous (is 0.4 meaningful?).
-3. **Max/mean ratio** directly answers the key question: "Is there a clear favorite?" A ratio of 8× means the most-accessed chunk has 8× the average — a strong outlier that represents genuine user preference, not noise.
-
-The metric requires only one SQL query (`SELECT AVG, MAX, COUNT FROM chunks WHERE access_count > 0`) and a minimum of 10 accessed chunks to activate, avoiding false triggering on tiny corpora.
-
-**Short-circuit optimization.** When γ = 0, the system skips `rerank_with_decay` entirely — no metadata lookup, no decay computation. This means scoring adds zero overhead during the cold start period.
-
-### 4.6 Recency Boost (v0.19)
-
-Based on the negative results from frequency+decay scoring, we designed a simpler temporal mechanism: an opt-in multiplicative recency boost applied post-RRF, pre-MMR:
-
-```
-boosted_score(c) = rrf_score(c) × (1 + B × e^(-0.05 × days_ago(c)))
-```
-
-where *B* is the `recency_boost` parameter (0.0 = off, default) and *days_ago* is computed from the chunk's `created_at` timestamp.
-
-**Key design differences from frequency+decay:**
-
-1. **No access counting.** Popularity (frequency) is orthogonal to relevance — the BEIR results proved this. Recency (temporal proximity) is a genuine signal for agentic memory.
-2. **Multiplicative, not additive.** The boost amplifies existing relevance rather than competing with it. A semantically irrelevant chunk gets zero benefit from recency.
-3. **Opt-in, not global.** Off by default (B=0.0) so pure retrieval is unaffected. Enabled per-call for agentic use cases.
-4. **No maturity gate needed.** Without access counting, there is no cold-start degradation to gate against.
-
-**Temporal filters.** Complementing the soft recency boost, `added_after` and `added_before` parameters provide hard date boundaries at the SQL level, filtering documents by ingestion timestamp before search begins.
-
----
-
-## 5. Relevance Signal via Vector Distance
-
-A retrieval system that always returns results — even for off-topic queries — must provide a confidence signal so downstream consumers (CLI users, LLM agents) can decide whether to trust the results.
-
-### 5.1 Why Score Spread Failed
-
-Our initial approach used score spread (*max − min* of top-*k* scores). This required scoring to be enabled (spread is ~0.0006 on raw RRF for all queries), and even with scoring, discrimination was poor:
-
-### Table 1a: Score spread as relevance discriminator
-
-| Scoring | Relevant Spread | Irrelevant Spread | Ratio | Overlap | F1 |
-|---------|:-:|:-:|:-:|:-:|:-:|
-| Off (raw RRF) | 0.007 | 0.007 | 1.00x | 10/10 | 0.000 |
-| On (10 rounds) | 0.305 | 0.245 | 1.24x | 10/10 | 0.667 |
-| On (30 rounds) | 0.310 | 0.250 | 1.22x | 10/10 | 0.640 |
-
-The fundamental problem: spread depends on per-chunk access count variance within the result batch, not on query-corpus semantic proximity. All 10 irrelevant queries fell within the spread range of relevant queries — no threshold could cleanly separate them.
-
-### 5.2 Distance-Based Signal
-
-The cosine distance of the best vector match directly measures "how far is this query from the nearest document." Relevant queries have best distances clustered around 0.5-0.85; irrelevant queries have distances > 0.95.
-
-### Table 1b: Vector distance as relevance discriminator
-
-| Signal | Relevant avg | Irrelevant avg | Ratio | Overlap | F1 @ threshold |
-|--------|:-:|:-:|:-:|:-:|:-:|
-| Spread (best) | 0.305 | 0.245 | 1.24x | 10/10 | 0.667 @ 0.15 |
-| **Distance** | **0.594** | **0.978** | **1.65x** | **0/10** | **0.952 @ 0.95** |
-
-### Table 1c: Classification strategies (10 relevant + 10 irrelevant queries)
-
-| Strategy | Precision | Recall | F1 | Accuracy |
-|----------|:-:|:-:|:-:|:-:|
-| spread > 0.15 (best fixed) | 0.500 | 1.000 | 0.667 | 0.500 |
-| **distance < 0.95** | **0.909** | **1.000** | **0.952** | **0.950** |
-| distance < 0.95 AND spread > 0.005 | 0.909 | 1.000 | 0.952 | 0.950 |
-| distance < 1.00 AND spread > 0.005 | 0.909 | 1.000 | 0.952 | 0.950 |
-
-**Key advantages over spread:** (1) Works from the first search, with no scoring, no access history, no warm-up period. (2) Zero class overlap vs. complete overlap. (3) No human threshold tuning needed: 0.95 is a natural gap in the distance distribution.
-
-### 5.2.1 Large-Scale Validation on BEIR
-
-The preliminary n=20 result was validated on 5 standard BEIR benchmarks using cross-domain queries (native queries from each dataset as "relevant," queries from the other 4 datasets as "irrelevant"). Total evaluation: ~47,000 queries across SciFact, NFCorpus, FiQA, SciDocs, and ArguAna.
-
-### Table 1d: Distance-based relevance signal on BEIR (full query sets)
-
-| Dataset | Rel queries | Irrel queries | Best threshold | F1 | Precision | Recall |
-|---------|:-:|:-:|:-:|:-:|:-:|:-:|
-| ArguAna | 1,406 | 9,999 | 0.65 | **0.996** | 0.997 | 0.996 |
-| SciDocs | 1,000 | 9,999 | 0.71 | **0.856** | 0.832 | 0.881 |
-| FiQA | 648 | 6,752 | 0.71 | **0.763** | 0.737 | 0.792 |
-| SciFact | 300 | 9,999 | 0.71 | **0.598** | 0.567 | 0.633 |
-| NFCorpus | 323 | 9,999 | 0.76 | **0.472** | 0.441 | 0.508 |
-
-The signal exhibits a clear domain-dependency gradient. When query and corpus domains are distinct (ArguAna arguments vs. biomedical documents), the distance signal achieves near-perfect separation (F1=0.996). When domains overlap (SciFact biomedical queries against NFCorpus biomedical corpus), the signal degrades to near-random (F1=0.472). The optimal threshold varies by domain (0.65-0.76), confirming that the production threshold of 0.95 is conservative.
-
-**Interpretation.** Vector distance is an effective *off-topic detector* across distinct domains but should not be treated as a precision relevance classifier for intra-domain queries. The three-tier system (Section 5.3) remains appropriate: "high" confidence is warranted for cross-domain off-topic detection, while intra-domain discrimination requires the full hybrid pipeline (vector + FTS + adaptive RRF).
-
-### 5.3 Tiered Ghost Warning
-
-Rather than a binary signal, we implement three tiers based on the distance of the best vector match:
-
-| Distance | Tier | User experience |
-|----------|------|-----------------|
-| ≤ 0.95 | high | No indicator — full confidence |
-| 0.95–0.98 | medium | Subtle `?` next to result rank + "Uncertain relevance" note |
-| > 0.98 | low | Full warning: "Low relevance — results may not match" |
-
-This provides graduated feedback without being intrusive, applied consistently across CLI (search, ask, chat) and MCP server.
-
-### 5.4 Discard Telemetry
-
-To validate the signal in production, every search records an event with query, distance, tier, and result count. In chat mode, events are marked as "dismissed" when the user exits after a non-high result. The table is pruned to 1,000 entries and indexed by `(relevance_tier, created_at)`.
-
-**Validation hypothesis:** If users dismiss "low" tier results at 3–5× the rate of "high" tier results, the signal is confirmed useful beyond synthetic benchmarks.
-
----
-
-## 6. Code-Aware Chunking
-
-Standard fixed-window chunking splits code mid-function, destroying semantic coherence. vstash uses a **3-tier hybrid splitting pipeline** that selects the best available backend per language with graceful degradation:
-
-| Tier | Backend | Languages | Resolution | Install |
-|------|---------|-----------|------------|---------|
-| 1 | **tree-sitter** | 25+ (C, C++, Ruby, PHP, Swift, Kotlin, Scala, etc.) | AST-level — exact definition boundaries | `pip install vstash[treesitter]` |
-| 2 | **parso** | Python only | AST-level — funcdef, classdef, decorated | Included by default |
-| 3 | **regex** | Python, JS/TS, Go, Rust, Java | Pattern-based — column-0 definitions | Included by default |
-
-The backend is selected automatically: tree-sitter is tried first (if installed and the language has a grammar), then parso for Python, then regex. If none match, the system falls back to semantic chunking (paragraph → fixed-window).
-
-### Algorithm: Hybrid Code-Aware Chunking
-
-```
-Input: source text T, language L, chunk_size C
-1. If tree-sitter available for L:
-     AST ← parse(T, L)
-     B ← extract top-level definition nodes from AST
-2. Else if L = Python and parso available:
-     AST ← parso.parse(T)
-     B ← extract funcdef, classdef, decorated nodes
-3. Else if L ∈ {Python, JS, TS, Go, Rust, Java}:
-     P ← language-specific regex patterns for L
-     B ← find all column-0 matches of P in T
-4. Else: fall back to semantic chunking
-5. Attach decorators/annotations to their next definition
-6. chunks ← split T at boundaries B
-7. For each chunk c:
-     If tokens(c) > C: split by paragraphs, then fixed-window fallback
-8. Merge adjacent chunks with < 80 tokens
-9. Return chunks
-```
-
-**Tree-sitter (Tier 1)** provides exact AST boundary detection for 25+ languages, handling nested definitions, complex module patterns, and language-specific constructs that regex cannot reliably parse. It is an optional dependency (`tree-sitter-language-pack`) to avoid the ~15 MB binary overhead for users who don't need multi-language support. UTF-8 byte-offset handling ensures correct boundary detection for non-ASCII source files.
-
-**Parso (Tier 2)** provides AST-level splitting for Python specifically, included as a base dependency. It correctly handles Python-specific constructs like decorated functions, nested classes, and async definitions.
-
-**Regex (Tier 3)** detects top-level definitions via patterns anchored at column 0 (no indentation). By requiring zero indentation, we avoid false positives on nested method definitions (e.g., methods inside a Python class). This is a deliberate trade-off: nested methods are kept with their parent class, which is desirable for embedding coherence. The convention is strongest in Python, Go, and Rust, where top-level definitions are idiomatically unindented.
-
-In all tiers, the fallback chain (code splitting → paragraph → fixed-window) ensures that unmatched or oversized code still produces token-bounded chunks — the failure mode is slightly less semantic boundaries, never data loss or silent omission.
-
----
-
-## 7. Experimental Setup
-
-**Corpora.** Five evaluation corpora of increasing scale:
-
-1. **LLM memory corpus** — 24 arXiv papers on LLM memory systems (2023–2026), yielding 786 chunks. Used for ablation (§8.1), scoring grid search (§8.2), relevance signal (§8.3), and latency (§8.5). Publication dates simulate temporal spread.
-2. **Wikipedia corpus** — 17 mixed-domain Wikipedia articles, yielding 2,602 chunks. Used for cross-domain ablation (§8.1) to validate generalizability.
-3. **Wikipedia cold start corpus** — 120 real Wikipedia articles across 12 CS topic clusters (transformers, reinforcement learning, NLP, computer vision, databases, distributed systems, cryptography, operating systems, graph algorithms, information retrieval, optimization, compilers), yielding 919 chunks. Used for the adaptive scoring experiment (§8.6). Zipf-weighted query simulation over 30 rounds models realistic non-uniform usage.
-4. **ArXiv ML corpus** — 1,000 machine learning papers from CShorten/ML-ArXiv-Papers (HuggingFace) across 10 topics (NLP, CV, RL, optimization, generative models, etc.), yielding ~3,500 chunks. Used for at-scale validation of hybrid RRF across 3 embedding models (§8.7).
-5. **BEIR SciFact** — 5,183 biomedical documents (1 chunk per document) with 300 human-annotated queries from the BEIR benchmark suite (Thakur et al., 2021). The standard evaluation dataset for comparing retrieval systems. Used for external baseline comparison (§8.8).
-
-Additionally, §8.9 (latency at scale) includes ad-hoc corpora not used for quality evaluation: a real user corpus (209 documents, 1,087 chunks), a full Spanish-language book (1 document, 1,514 chunks), and a synthetic scale test (500 documents, 10,005 chunks).
-
-**Queries.** 10 evaluation queries with human-annotated top-5 expected results (graded relevance). 15 relevant and 15 irrelevant queries for the relevance signal experiment. 10 topic-aligned queries for cold start evaluation.
-
-**Metrics:**
-- **NDCG@k**: Normalized Discounted Cumulative Gain
-- **P@k**: Precision at position k
-- **Rank displacement**: Average position change vs. baseline
-- **Frequency response**: Rank improvement for boosted papers
-- **F1, Accuracy**: For relevance signal classification
-
-**Configurations.** 16 parameter variants: α ∈ {0.4, 0.5, 0.7, 0.8, 0.9}, β ∈ {0.1, 0.2, 0.3, 0.5, 0.6}, λ ∈ {0.01, 0.03, 0.05, 0.07, 0.10, 0.20}, N_over ∈ {20, 50, 100}.
-
-**Scenarios.** 5 simulated access patterns: uniform (baseline), recent heavy use, stale favorites, mixed recency, benchmark-focused.
-
----
-
-## 8. Results
-
-### 8.1 Ablation: RRF vs. Vector vs. FTS
-
-### Table 2a: Ablation — LLM memory corpus (24 papers, 786 chunks)
-
-| Mode | NDCG@5 | NDCG@10 | P@3 | Latency |
-|------|:------:|:-------:|:---:|--------:|
-| Vector-only | 0.809 | 0.832 | 0.933 | 4.51 ms |
-| FTS keyword | 0.631 | 0.621 | 0.767 | 0.81 ms |
-| **Hybrid RRF** | **0.814** | **0.803** | **1.000** | 1.61 ms |
-
-### Table 2b: Ablation — Wikipedia corpus (17 articles, 2,602 chunks)
-
-| Mode | NDCG@5 | NDCG@10 | P@3 | Latency |
-|------|:------:|:-------:|:---:|--------:|
-| Vector-only | 0.742 | 0.742 | 0.667 | 21.0 ms |
-| FTS keyword | 0.699 | 0.699 | 0.583 | 1.94 ms |
-| **Hybrid RRF** | **0.758** | **0.758** | 0.633 | 4.78 ms |
-
-> **Methodology.** Relevance labels were obtained via pooled annotation: the union of top-10 results from all three methods was scored on a 0–3 scale using an LLM judge (Qwen 3.5:9B). A subset of 30 labels (10 per method) was independently verified by the author against the source text; agreement was 27/30 (90%), with disagreements on borderline cases (grade 1 vs. 2) that do not affect the direction of the ablation results. Full human annotation of all pooled results was not performed due to scale — this is a limitation, and the absolute NDCG values should be interpreted with this caveat. Results are deduplicated at the document level — only the first chunk from each document counts toward NDCG. This prevents inflated scores from multi-chunk documents.
-
-**Hybrid RRF is the strongest modality on both corpora.** On the domain-specific LLM memory corpus, RRF achieves perfect P@3 = 1.000 and the highest NDCG@5 (0.814, improved to 0.829 with document deduplication §3.4). On the diverse Wikipedia corpus, RRF still leads (NDCG@5 = 0.758), confirming that rank fusion generalizes across domains.
-
-Two corpus-dependent effects are visible:
-
-1. **FTS dominance fades on diverse corpora.** On homogeneous LLM memory papers, FTS trails vector by 22% (0.631 vs 0.809). On diverse Wikipedia, FTS closes to within 6% (0.699 vs 0.742) because semantic paraphrases become more important across unrelated domains.
-2. **Vector search scales with corpus size.** Latency increases from 4.5 ms (786 chunks) to 21 ms (2,602 chunks) — proportional to the approximate nearest-neighbor scan. FTS and RRF scale better due to the FTS5 inverted index.
-
-### 8.2 Scoring Grid Search
-
-### Table 3: Top-5 scoring configurations averaged across 5 scenarios
-
-| Configuration | Avg NDCG@10 | Δ Baseline | Best Scenario |
-|---------------|:-----------:|:----------:|:-------------:|
-| **α=0.5, β=0.5, λ=0.10** | **0.636** | **+4.6%** | +16.1% (benchmark) |
-| α=0.5, β=0.5, λ=0.05 | 0.634 | +4.3% | +15.6% (benchmark) |
-| α=0.7, β=0.3, λ=0.03 | 0.631 | +3.8% | +13.2% (benchmark) |
-| α=0.7, β=0.3, λ=0.07 | 0.629 | +3.5% | +13.1% (benchmark) |
-| α=0.8, β=0.2, λ=0.10 | 0.632 | +3.9% | +7.2% (benchmark) |
-
-*Baseline NDCG@10 = 0.608*
-
-Key findings:
-
-1. **Equal weighting (α=β=0.5) is optimal** when averaged across all scenarios in the grid search, contrary to the common assumption that semantic relevance should dominate.
-2. **The scoring benefit scales with access differential.** In the benchmark-focused scenario (heavy access to specific papers), NDCG improves by 16.1%. In the uniform scenario (no differential access), improvement is minimal (+0.7%).
-3. **Lambda sensitivity is low** in the 0.03–0.10 range. Extreme values (λ = 0.20) degrade performance as recent accesses decay too quickly.
-4. **Over-fetch of 50 is sufficient.** Increasing to 100 shows no improvement; decreasing to 20 slightly hurts.
-
-**Shipped defaults vs. grid search optimum.** The system ships with conservative defaults (α=0.8, β=0.2, λ=0.05) rather than the grid search optimum (α=0.5, β=0.5, λ=0.10). This is deliberate: the optimal configuration was measured on an access-heavy benchmark where frequency signals carry strong signal. In production, most users start with a cold corpus where the adaptive maturity gate (γ) suppresses scoring entirely. The conservative α=0.8 ensures semantic relevance dominates during the long maturation period, while the grid search optimum is available via `vstash.toml` for users with established access patterns. All parameters are configurable in the `[scoring]` section.
-
-### 8.3 Relevance Signal
-
-The distance-based signal (Section 5.2) at threshold *d < 0.95*:
-
-- **Precision = 0.909**: one false positive among 10 irrelevant queries.
-- **Recall = 1.000**: detects all 10 relevant queries.
-- **F1 = 0.952**, **Accuracy = 95.0%**: across 20 queries total (10 relevant + 10 irrelevant).
-
-This supersedes the score-spread signal, which achieved F1 = 0.667 with complete class overlap even after 30 rounds of scoring warm-up. The distance signal works from the first search with no dependencies on scoring or access history, which is critical for tool autonomy.
-
-**Large-scale validation (Section 5.2.1).** The preliminary n=20 result was extended to ~47,000 queries across 5 BEIR datasets using cross-domain evaluation. The signal achieves F1 = 0.996 on cross-domain queries (ArguAna) but degrades to F1 = 0.472 on intra-domain queries (NFCorpus). This establishes the distance signal as a reliable off-topic detector rather than a universal relevance classifier. See Table 1d for per-dataset results.
-
-### 8.4 Code-Aware Chunking
-
-### Table 4: Chunking strategy comparison (Python + Go, 8 queries, top-k=3)
-
-| Strategy | Avg Recall | Avg Precision | Boundary Violations |
-|----------|:----------:|:-------------:|:-------------------:|
-| Naive (fixed-window) | **0.917** | 0.854 | present |
-| Code-aware (boundary) | 0.625 | **0.750** | 0 |
-
-Naive chunking achieves higher recall on this 8-query benchmark because large chunks (~653 tokens) trivially contain multiple functions, inflating recall when the corpus is small enough for top-*k* to cover most of it. Code-aware chunking:
-
-- Produces **zero boundary violations** (no function split mid-body).
-- Achieves **perfect precision** (1.0 vs. 0.33–0.50) on focused queries like "rate limiting" or "revoke token".
-- Creates smaller, semantically coherent chunks (avg 252 tokens vs. 653 tokens) that are more useful as LLM context.
-
-**Precision vs. recall at scale — a hypothesis.** We conjecture that the recall advantage of naive chunking is an artifact of small corpus size: when *N_chunks* ≪ *top_k* × *N_queries*, large chunks cover multiple functions by chance. As corpus size grows, this advantage should vanish as top-*k* covers a diminishing fraction of the corpus. Code-aware chunking's precision advantage — each chunk maps to exactly one function — should compound at scale because every result slot carries targeted information rather than diluted multi-function context. **However, we have not empirically validated this claim.** The 8-query benchmark on two languages is insufficient to generalize. A proper evaluation would require a large multi-language codebase (10³+ functions) with graded relevance labels for code retrieval queries. The primary contribution of code-aware chunking is the zero boundary violations guarantee — the retrieval quality comparison at scale remains open.
-
-### 8.5 Latency
-
-### Table 5: Search latency on 786-chunk corpus
-
-| Configuration | Median | P95 | P99 | Overhead |
-|---------------|:------:|:---:|:---:|:--------:|
-| RRF only | 0.54 ms | 0.60 ms | 0.69 ms | — |
-| + Scoring | 0.99 ms | 1.14 ms | 1.21 ms | +82% |
-| + Scoring + Track | 1.04 ms | 1.17 ms | 1.22 ms | +91% |
-| + Dedup | 1.43 ms | 1.57 ms | 1.70 ms | — |
-| + Scoring + Dedup | 2.92 ms | 3.44 ms | 3.62 ms | — |
-| **Full pipeline** | **3.41 ms** | **3.97 ms** | **4.10 ms** | — |
-
-*Full pipeline = search + scoring + dedup + context expansion.* Scoring adds 0.45 ms median end-to-end overhead (including metadata I/O from SQLite); the arithmetic re-ranking computation alone is ~0.017 ms, but the dominant cost is fetching access counts and timestamps for 50 candidates. Context expansion adds 0.12 ms. The full pipeline stays under 4 ms at P50 — imperceptible for interactive use.
-
-### 8.6 Cold Start: Fixed β vs. Adaptive γ
-
-We evaluate the adaptive maturity gate (§4.5) on a corpus of 120 real Wikipedia articles (919 chunks) across 12 topic clusters (10 articles each), using 10 cross-topic evaluation queries with graded relevance (primary cluster = 3, secondary = 2, tertiary = 1) and Zipf-weighted usage simulation over 30 rounds. Articles span computer science topics (transformers, reinforcement learning, NLP, computer vision, databases, distributed systems, cryptography, operating systems, graph algorithms, information retrieval, optimization, compilers) and are chunked through vstash's real chunking pipeline (1024-token chunks, 128-token overlap).
-
-### Table 6: Fixed scoring vs. adaptive scoring over 30 rounds (120 Wikipedia articles, 919 chunks)
-
-| Round | Baseline (γ=0) | Fixed (β=0.5) | Adaptive (real γ) | γ | Cumulative Accesses |
-|:-----:|:--------------:|:--------------:|:------------------:|:---:|:-------------------:|
-| 1 | 0.834 | 0.831 (−0.4%) | 0.834 (0.0%) | 0.0 | 25 |
-| 5 | 0.834 | 0.835 (+0.1%) | 0.834 (0.0%) | 0.0 | 225 |
-| 10 | 0.834 | 0.835 (+0.1%) | 0.834 (0.0%) | 0.0 | 700 |
-| 15 | 0.834 | 0.835 (+0.1%) | 0.834 (0.0%) | 0.0 | 1,425 |
-| 20 | 0.834 | 0.834 (0.0%) | 0.834 (0.0%) | 0.0 | 2,300 |
-| 25 | 0.834 | 0.834 (0.0%) | 0.834 (0.0%) | 0.0 | 3,175 |
-| 30 | 0.834 | 0.834 (0.0%) | 0.834 (0.0%) | 0.0 | 4,050 |
-
-**Key findings:**
-
-1. **Fixed β introduces early-round noise on real corpora.** With 120 real Wikipedia articles, fixed β=0.5 produces −0.4% degradation in the first two rounds before recovering. While modest, this confirms that frequency signals inject noise when access patterns are undifferentiated — the effect attenuates as cumulative accesses grow and some topics dominate.
-
-2. **The adaptive gate is a conservative safety net.** γ remains 0.0 across all 30 rounds because Zipf-weighted usage does not produce a sufficiently extreme outlier (max/mean ratio peaks at 5.0×, well below the 8× activation threshold). The gate correctly identifies that the access distribution does not warrant scoring intervention.
-
-3. **Degradation severity is corpus-dependent.** The −0.4% degradation on 919 real-article chunks is smaller than the −2.6% observed on a 104-article partial corpus (768 chunks), and much smaller than the −8.6% on synthetic single-sentence documents (582 chunks). Richer documents with more natural vocabulary overlap produce better-separated embeddings, reducing the ability of noisy frequency signals to displace relevant results.
-
-**Practical implication:** The adaptive gate ensures scoring never degrades ranking regardless of corpus characteristics. Fixed β shows degradation in 6 of 30 rounds; adaptive γ shows degradation in 0 of 30 rounds. Scoring can be **enabled by default** with zero cold start risk.
-
-### 8.7 At-Scale Validation: 1,000 ArXiv Papers
-
-### Table 7: Hybrid RRF at scale — 1,000 ML papers, 35 topic-based queries
-
-| Model | Mode | P@5 | NDCG@5 | NDCG@10 | MRR | Latency/query |
-|-------|------|:---:|:------:|:-------:|:---:|--------:|
-| **BGE-base-EN (768d)** | **hybrid** | **0.703** | **0.728** | **0.702** | **0.895** | 9.1 ms |
-| BGE-small-EN (384d) | hybrid | 0.663 | 0.685 | 0.658 | 0.865 | 4.0 ms |
-| BGE-small-EN (384d) | vector-only | 0.614 | 0.619 | 0.568 | 0.822 | 2.3 ms |
-| Multilingual-MiniLM (384d) | hybrid | 0.606 | 0.638 | 0.611 | 0.868 | 4.3 ms |
-| Multilingual-MiniLM (384d) | vector-only | 0.600 | 0.588 | 0.508 | 0.820 | 2.6 ms |
-
-*Latency is mean per-query search time (excludes query embedding). All measurements on Apple M-series silicon.*
-
-**Hybrid RRF maintains its advantage at 1,000-document scale.** The pattern observed on small corpora (§8.1) holds: RRF consistently outperforms vector-only across all three models, with +7.9% P@5 and +10.7% NDCG@5 for BGE-small. The advantage is largest for the multilingual model (+8.5% NDCG@5), where keyword matching compensates for the model's lower English-only accuracy.
-
-BGE-base-EN (768 dimensions) achieves the highest quality (NDCG@5 = 0.728) at 2.3× the latency of BGE-small (384 dimensions), offering a clear quality-speed tradeoff.
-
-### 8.8 External Baseline: BEIR SciFact
-
-To position vstash against established retrieval systems, we evaluate on the BEIR SciFact benchmark — a standard dataset of 5,183 biomedical documents with 300 human-annotated queries (Thakur et al., 2021).
-
-### Table 8: vstash vs. published baselines on BEIR SciFact (NDCG@10)
-
-| System | NDCG@10 | MRR | R@10 | Latency |
-|--------|:-------:|:---:|:----:|--------:|
-| **vstash hybrid RRF (BGE-small)** | **0.7263** | **0.6975** | **0.8406** | 9.6 ms |
-| vstash hybrid RRF (EmbeddingGemma) | 0.7801 | — | — | 11.1 ms |
-| ColBERTv2 (SOTA retrieval) | 0.6930 | — | — | — |
-| BM25 / Elasticsearch | 0.6650 | — | — | — |
-| BGE-small dense-only (published) | 0.6530 | — | — | — |
-| vstash hybrid (Multilingual-MiniLM) | 0.5870 | 0.5542 | 0.7239 | 13.8 ms |
-
-*Published baselines from the MTEB SciFact leaderboard (https://huggingface.co/spaces/mteb/leaderboard, accessed April 2026) and the BEIR paper (Thakur et al., 2021). ColBERTv2 result from Santhanam et al. (2022).*
-
-**vstash hybrid RRF surpasses all published baselines on SciFact, including ColBERTv2** — a late-interaction model specifically designed for high-quality retrieval. The advantage (+4.8% over ColBERTv2, +9.2% over BM25, +11.2% over dense-only) comes from RRF fusion with adaptive IDF weighting.
-
-**Embedding model choice is domain-dependent.** EmbeddingGemma-300m (768d) achieves 0.7801 on SciFact (+7.4%) but underperforms BGE-small on SciDocs (-12.2%), FiQA (-9.6%), and ArguAna (-2.0%). BGE-small (384d) remains the recommended default for general-purpose use; EmbeddingGemma is better for biomedical/scientific text.
-
-**`paraphrase-multilingual-MiniLM-L12-v2` has a reproducible clinical-domain weakness** not visible in the aggregate Multilingual-MiniLM row above. In production use on a medical-document corpus, we observed that vector distances for clinical queries collapse into a narrow band (cosine ~0.85–1.00) so the default 1.15× distance cutoff either eliminates relevant documents or passes almost everything. The fingerprint is `miss_analysis()` repeatedly reporting `vector_search: not_found` or `distance_cutoff: failed` on queries where the target is provably FTS-reachable — i.e. the literal term is in the chunk text but the embedding does not discriminate. Mitigations (documented in `docs/embedding-models.md`): run the query with `fts_only=True` (v0.26), pin RRF weights toward FTS on that query, relax the distance cutoff, or switch to `paraphrase-multilingual-mpnet-base-v2` / `multilingual-e5-large`. This is a limitation of general-purpose paraphrase embeddings on specialized vocabularies, not a vstash bug — but vstash's transparent diagnostics (`miss_analysis`, `fts_only`) make it possible to detect and work around.
-
-Three observations:
-
-1. **RRF's advantage is domain-dependent.** The +11.1% gain over dense-only on SciFact (terminology-heavy) is larger than the +7.9% on ArXiv ML papers (§8.7), where vocabulary overlap between papers is higher. RRF helps most when queries use precise technical terms that exact-match in relevant documents.
-
-2. **The model matters less than the pipeline.** BGE-small (384d) with hybrid RRF (0.7263) outperforms the published score of the same model with dense-only retrieval (0.6530) by 11.2%. The retrieval pipeline contributes more than upgrading the embedding model.
-
-3. **Latency at 5K documents is excellent.** 9.6 ms mean search latency on 5,183 documents, including both vector ANN scan and FTS5 keyword matching. The full pipeline stays interactive at this scale.
-
-### 8.9 Latency at Scale
-
-### Table 9: Search latency across corpus sizes
-
-| Corpus | Chunks | Mean | Median | P95 | Max |
-|--------|:------:|:----:|:------:|:---:|:---:|
-| LLM memory (24 papers) | 786 | 3.4 ms | 3.4 ms | 4.0 ms | 4.1 ms |
-| Real user corpus (209 docs) | 1,087 | 5.0 ms | 4.8 ms | 8.1 ms | 8.1 ms |
-| LOTR full book (1 doc, Spanish) | 1,514 | 14.1 ms | 13.4 ms | 22.6 ms | 22.6 ms |
-| BEIR SciFact (5,183 docs) | 5,183* | 13.4 ms | - | - | - |
-| Synthetic scale test | 10,005 | 15.7 ms | 14.1 ms | 23.1 ms | 23.1 ms |
-| **SciFact + synthetic (50K)** | **50,000** | **22.1 ms** | **20.9 ms** | **30.6 ms** | **35.2 ms** |
-
-*\* BEIR SciFact documents are short (mean 215 words), ingested as 1 chunk per document.*
-
-Search latency scales sub-linearly: 50,000 chunks takes 20.9 ms median, only 1.5x slower than 10,005 chunks despite 5x more data. The system remains interactive (sub-31ms P95 at 50K) well beyond the "small-to-moderate" scale originally claimed. NDCG@10 remains stable at 0.69 across all scales from 1K to 50K chunks, confirming that the retrieval pipeline does not degrade with corpus size. The `explain` diagnostic flag adds no measurable overhead (within noise at +/-1.4 ms).
-
-### Table 9b: NDCG@10 stability across scale (SciFact + synthetic padding)
-
-| Scale | Total chunks | NDCG@10 | Latency p50 | Latency p95 |
-|:-----:|:------------:|:-------:|:-----------:|:-----------:|
-| 1K | 5,183 | 0.6891 | 11.1 ms | 24.9 ms |
-| 5K | 5,183 | 0.6891 | 10.2 ms | 19.2 ms |
-| 10K | 10,000 | 0.6849 | 10.9 ms | 19.0 ms |
-| 50K | 50,000 | 0.6897 | 20.9 ms | 30.6 ms |
-
-### 8.10 Self-Supervised Embedding Refinement via Hybrid Retrieval Disagreement
-
-The hybrid retrieval pipeline produces a natural training signal: when vector search and FTS5 disagree on which chunks are relevant, the disagreement identifies cases where the dense encoder fails. We exploit this signal to fine-tune the embedding model without human labels.
-
-**Signal analysis.** Across 753 queries on 3 BEIR datasets (SciFact, NFCorpus, FiQA), 82% of queries produce top-5 disagreement between vector-heavy (vec=0.95, fts=0.05) and FTS-heavy (vec=0.05, fts=0.95) search. Hard negatives are balanced: 51% are chunks ranked high by vector but absent from FTS top-5 (dense blind spots), and 49% are the reverse (lexical blind spots). This yields 76K (query, positive, hard_negative) triples at zero labeling cost.
-
-**Training.** BGE-small-en-v1.5 (33M params, 384d) was fine-tuned using MultipleNegativesRankingLoss (MNRL) for 2 epochs at lr=3e-6 with batch size 64. TripletLoss was evaluated first but caused catastrophic degradation (-84% NDCG after 3 epochs at lr=2e-5). MNRL preserves the base model's knowledge while learning from in-batch negatives derived from the disagreement signal.
-
-### Table 10a: Embedding fine-tune evolution (vector component NDCG@10, 5K doc cap)
-
-| Approach | Loss | SciFact | NFCorpus | FiQA | SciDocs | ArguAna |
-|----------|------|:-:|:-:|:-:|:-:|:-:|
-| BGE-small base | - | 0.6778 | 0.3480 | 0.0600 | 0.0726 | 0.4438 |
-| TripletLoss (76K, 3ep) | Triplet | 0.0550 | - | - | - | - |
-| MNRL batch-only (v1) | MNRL | 0.7116 | 0.4116 | 0.0629 | 0.0758 | 0.4375 |
-| **MNRL + hard neg (v2)** | **MNRL** | **0.6945** | **0.3949** | **0.3283** | **0.1875** | **0.4241** |
-
-TripletLoss destroyed the model (-84% NDCG). MNRL with batch-only negatives (v1) improved 4/5 datasets. Adding explicit hard negatives from the disagreement signal (v2) improved all 5 datasets over v1 by +1.1% to +2.1%, confirming that negative quality compounds with the right loss function.
-
-**Key findings:**
-
-1. **Loss function is the critical design choice.** TripletLoss with any configuration (3 epochs to 0.3 epochs, lr from 2e-5 to 1e-6) either destroyed the model or left it unchanged. MNRL with the same data produced consistent improvement. The mechanism: TripletLoss pushes individual negatives away with brute force, distorting the embedding space. MNRL adjusts relationships across 64 documents simultaneously per batch, preserving the global structure.
-
-2. **Explicit hard negatives improve over batch-only negatives.** When the disagreement signal provides a specific chunk that one search modality ranked high but the other ignored, passing it as an explicit negative to MNRL yields +1-2% NDCG over relying solely on in-batch negatives. The hard negatives are closer to the decision boundary, forcing finer-grained discrimination.
-
-3. **The training signal transfers across domains.** Triples were generated from 3 datasets (SciFact, NFCorpus, FiQA). The improvement generalized to SciDocs and ArguAna, which were not in the training set. The model learned to distinguish "semantically close" from "actually relevant" as a general skill, not a domain-specific one.
-
-4. **The improvement is free.** No human labeling, no external LLM calls, no additional data. The signal comes from running the existing hybrid pipeline on existing data. Any vstash user can generate these triples from their own corpus via `vstash retrain`.
-
-The fine-tuned model is published as [`Stffens/bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) on HuggingFace.
-
-### Table 10b: Full-pipeline NDCG@10 with RRF-tuned embedding (adaptive RRF + FTS5 + MMR dedup)
-
-| Dataset | Docs | BM25 | ColBERTv2 | vstash (base) | vstash (tuned) | vs base | vs ColBERTv2 |
-|---------|:----:|:---:|:---:|:---:|:---:|:---:|:---:|
-| SciFact | 5,183 | 0.665 | 0.693 | 0.6464 | **0.6945** | **+7.4%** | **+0.2%** |
-| NFCorpus | 3,633 | 0.325 | 0.344 | 0.3304 | **0.3949** | **+19.5%** | **+14.8%** |
-| FiQA | 57,638 | 0.236 | 0.356 | 0.3281 | **0.3283** | +0.1% | -7.8% |
-| SciDocs | 25,657 | 0.158 | 0.154 | 0.1778 | **0.1875** | **+5.5%** | **+21.8%** |
-| ArguAna | 8,674 | 0.315 | 0.463 | 0.4188 | **0.4241** | **+1.3%** | -8.4% |
-
-The RRF-tuned model (`Stffens/bge-small-rrf-v2`) improves NDCG on all 5 datasets vs base and surpasses ColBERTv2 (110M params) on 3/5 datasets, despite being a 33M parameter model fine-tuned with zero human labels. The largest gain (+19.5% vs base, +14.8% vs ColBERTv2 on NFCorpus) occurs on the dataset with the highest signal disagreement rate during training. Adding explicit hard negatives from the disagreement signal (v2) improved all 5 datasets by +1.1% to +2.1% over batch-only negatives (v1), confirming that the quality of negative examples matters alongside the loss function choice.
-
-### 8.11 Adaptive RRF Weights
-
-Fixed RRF weights (0.6 vec / 0.4 fts) assume all queries benefit equally from keyword matching. BEIR evaluation revealed this assumption fails on long, semantically-rich queries (ArguAna: avg 194 words, -16.1% vs Chroma with fixed weights).
-
-Adaptive RRF computes per-query weights using mean IDF of porter-stemmed query terms via a sigmoid function. High IDF (rare/technical terms) boosts FTS weight; low IDF (common vocabulary) boosts vector weight. Long queries (>50 words) additionally relax the distance cutoff from 1.15x to 5.0x, preventing the elimination of relevant results when embeddings are diffuse.
-
-### Table 10: Adaptive vs fixed RRF weights on 5 BEIR datasets
+**Table 3: Adaptive vs fixed RRF weights on 5 BEIR datasets (NDCG@10)**
 
 | Dataset | Docs | Fixed (0.6/0.4) | Adaptive IDF | Delta |
 |---------|:----:|:---:|:---:|:---:|
@@ -761,145 +164,318 @@ Adaptive RRF computes per-query weights using mean IDF of porter-stemmed query t
 
 *\* ArguAna improvement is primarily from adaptive distance cutoff (5.0x vs 1.15x for 194-word queries).*
 
-**Key findings:**
+Adaptive RRF improves all 5 datasets with zero regression. The IDF-based sigmoid correctly identifies query regimes: technical terminology boosts FTS, common vocabulary defers to vector search. The distance cutoff was the primary bottleneck on ArguAna -- long queries produce diffuse embeddings where distances compress into a narrow range, and the default cutoff eliminates relevant results.
 
-1. **Adaptive improves all 5 datasets with zero regression.** The IDF-based sigmoid correctly identifies query regimes: technical terminology boosts FTS, common vocabulary defers to vector search.
+---
 
-2. **The distance cutoff was the primary bottleneck on ArguAna, not FTS weights.** Long queries produce diffuse embeddings where distances compress into a narrow range. The default cutoff (1.15x best distance) eliminated relevant results. Relaxing to 5.0x raises NDCG@10 from 0.3599 to 0.4370 (+21.4%).
+## 5  Self-Supervised Embedding Refinement via Hybrid Retrieval Disagreement
 
-3. **IDF computation is effectively free.** A pre-computed vocabulary cache (built from fts5vocab in ~15ms on first search, then O(k) dict lookups per query at ~0.003ms) adds no measurable latency.
+### 5.1  Motivation
 
-### 8.11 End-to-End Answer Relevance
+The hybrid retrieval pipeline produces a natural training signal: when vector search and FTS5 disagree on which chunks are relevant, the disagreement identifies cases where the dense encoder fails. We exploit this signal to fine-tune the embedding model without human labels.
 
-NDCG measures retrieval ranking in isolation. To evaluate what users actually experience, we measure answer quality: for each query, an LLM (Qwen 3.5 9B, local) generates an answer from the retrieved context, and the same LLM judges the answer on a 0–3 scale. This captures the combined effect of retrieval quality, context expansion, and MMR diversity on the final answer.
+### 5.2  Signal Analysis
 
-### Table 11: Answer Relevance — vstash full pipeline vs Chroma dense-only
+Across 753 queries on 3 BEIR datasets (SciFact, NFCorpus, FiQA), 82% of queries produce top-5 disagreement between vector-heavy (vec=0.95, fts=0.05) and FTS-heavy (vec=0.05, fts=0.95) search. Hard negatives are balanced: 51% are chunks ranked high by vector but absent from FTS top-5 (dense blind spots), and 49% are the reverse (lexical blind spots). This yields 76K (query, positive, hard_negative) triples at zero labeling cost.
+
+### 5.3  Training
+
+BGE-small-en-v1.5 (33M params, 384d) was fine-tuned using MultipleNegativesRankingLoss (MNRL) for 2 epochs at lr=3e-6 with batch size 64. TripletLoss was evaluated first but caused catastrophic degradation (-84% NDCG after 3 epochs at lr=2e-5). MNRL preserves the base model's knowledge while learning from in-batch negatives derived from the disagreement signal.
+
+### 5.4  Results
+
+**Table 4: Embedding fine-tune evolution**
+
+| Approach | Loss | NDCG@10 SciFact | Result |
+|----------|------|:---:|---|
+| BGE-small base | -- | 0.6464 | baseline |
+| TripletLoss (76K, 3ep) | Triplet | 0.0550 | -84% (destroyed) |
+| MNRL batch-only (v1) | MNRL | 0.6829 | +5.6% |
+| **MNRL + hard neg (v2)** | **MNRL** | **0.6945** | **+7.4%** |
+
+*All numbers evaluated under identical conditions: sentence-transformers embedding backend, full vstash pipeline (adaptive RRF + FTS5 + MMR dedup), same BEIR SciFact corpus and queries. The progression shows that loss function choice is the critical variable, and explicit hard negatives from signal disagreement compound with the right loss function.*
+
+The complete comparison across all 5 BEIR datasets with published baselines is presented in Table 6 (Section 7.3).
+
+### 5.5  Key Findings
+
+**Loss function is the critical design choice.** TripletLoss with any configuration destroyed the model or left it unchanged. MNRL with identical data produced consistent improvement. TripletLoss pushes individual negatives away with brute force, distorting the embedding space; MNRL adjusts relationships across 64 documents simultaneously per batch, preserving global structure.
+
+**Explicit hard negatives improve over batch-only negatives.** When the disagreement signal provides a specific chunk that one search modality ranked high but the other ignored, passing it as an explicit negative yields +1-2% NDCG over relying solely on in-batch negatives.
+
+**The training signal transfers across domains.** Triples were generated from 3 datasets (SciFact, NFCorpus, FiQA). Improvement generalized to SciDocs and ArguAna, which were not in the training set. The model learned to distinguish "semantically close" from "actually relevant" as a general skill.
+
+**The improvement is free.** No human labeling, no external LLM calls, no additional data. Any vstash user can generate triples from their own corpus via `vstash retrain`, which automates the full pipeline: pseudo-query generation, disagreement detection, triple extraction, and MNRL fine-tuning. The model is published as [`Stffens/bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) on HuggingFace.
+
+---
+
+## 6  Negative Result: Post-RRF Scoring Does Not Improve Retrieval
+
+We explored three strategies for post-RRF enhancement, all of which failed to improve NDCG on BEIR datasets. We document these negative results to prevent others from pursuing similar dead ends.
+
+### 6.1  Frequency+Decay Reranking
+
+After RRF retrieval, we applied a two-stage reranking combining normalized RRF scores with a frequency-decay signal:
+
+```
+score(c) = a * s_rrf(c) + b * min(1, log(1 + f(c)) / log(1 + S))
+```
+
+where *f(c) = (1 + access_count(c)) * e^(-L * days_ago(c))*, *a* and *b* are semantic and memory weights, *L* is the decay rate, and *S = 100* is a saturation constant. We evaluated 16 parameter configurations across 5 simulated access patterns.
+
+**Result:** On BEIR SciFact, frequency+decay scoring degraded NDCG@10 by -1.6% with an adaptive maturity gate and by -9.0% with fixed b=0.5. The fundamental problem is that access frequency is orthogonal to query-specific relevance -- a frequently accessed chunk is not necessarily relevant to the current query. The full grid search and cold-start analysis are in Appendix C.
+
+### 6.2  Cross-Encoder Reranking
+
+Off-the-shelf cross-encoders (ms-marco-MiniLM, BGE-reranker-base) degraded NDCG by -0.3% to -3.1% while adding 560-2100 ms latency. The cross-encoders were trained on web search distributions that do not transfer well to the technical and scientific corpora evaluated.
+
+### 6.3  Recency Boost (Alternative)
+
+Based on these negative results, we replaced the scoring pipeline with a simpler opt-in recency boost applied post-RRF: *boosted_score(c) = rrf_score(c) x (1 + B x e^(-0.05 x days_ago(c)))*. The boost is multiplicative (amplifies existing relevance rather than competing with it), opt-in (*B=0.0* by default), and requires no maturity gate. This is available for agentic memory use cases where temporal proximity matters.
+
+### 6.4  Lesson
+
+The hybrid RRF pipeline with adaptive IDF weighting appears to be at its ceiling for the BGE-small embedding model. Gains come from improving the embedding (Section 5), not from post-hoc reranking. We recommend investing in better embeddings over more complex scoring.
+
+---
+
+## 7  Experiments
+
+### 7.1  Setup
+
+**Corpora.** We evaluate on five corpora of increasing scale: (1) an LLM memory corpus of 24 arXiv papers (786 chunks), (2) a Wikipedia corpus of 17 mixed-domain articles (2,602 chunks), (3) 1,000 ArXiv ML papers from CShorten/ML-ArXiv-Papers (approximately 3,500 chunks), (4) BEIR SciFact with 5,183 biomedical documents and 300 human-annotated queries, and (5) a synthetic scale test reaching 50,000 chunks.
+
+**Metrics.** NDCG@k, Precision@k, MRR, and search latency. For the relevance signal: F1 and Accuracy.
+
+### 7.2  Ablation: RRF vs. Vector vs. FTS
+
+**Table 5a: Ablation -- LLM memory corpus (24 papers, 786 chunks)**
+
+| Mode | NDCG@5 | NDCG@10 | P@3 | Latency |
+|------|:---:|:---:|:---:|---:|
+| Vector-only | 0.809 | 0.832 | 0.933 | 4.51 ms |
+| FTS keyword | 0.631 | 0.621 | 0.767 | 0.81 ms |
+| **Hybrid RRF** | **0.814** | **0.803** | **1.000** | 1.61 ms |
+
+**Table 5b: Ablation -- Wikipedia corpus (17 articles, 2,602 chunks)**
+
+| Mode | NDCG@5 | NDCG@10 | P@3 | Latency |
+|------|:---:|:---:|:---:|---:|
+| Vector-only | 0.742 | 0.742 | 0.667 | 21.0 ms |
+| FTS keyword | 0.699 | 0.699 | 0.583 | 1.94 ms |
+| **Hybrid RRF** | **0.758** | **0.758** | 0.633 | 4.78 ms |
+
+*Relevance labels obtained via LLM judge (Qwen 3.5:9B) with partial human validation (27/30 agreement). An LLM judge was used here because the LLM memory corpus is a domain-specific collection (agent memory papers) structurally distinct from any BEIR dataset, and no standard relevance labels exist for it. These results are directional; the principal claims of this paper rest on BEIR benchmarks with human ground truth (Section 7.3).*
+
+Hybrid RRF is the strongest modality on both corpora, achieving the highest NDCG@5 and perfect P@3 on the domain-specific corpus. The advantage is consistent across homogeneous and diverse corpora.
+
+### 7.3  BEIR Baseline Comparison
+
+**Table 6: vstash vs published baselines on BEIR (NDCG@10)**
+
+| System | SciFact | NFCorpus | FiQA | SciDocs | ArguAna |
+|--------|:---:|:---:|:---:|:---:|:---:|
+| BM25 / Elasticsearch | 0.665 | 0.325 | 0.236 | 0.158 | 0.315 |
+| BGE-small dense-only (published) | 0.653 | -- | -- | -- | -- |
+| ColBERTv2 (published) | 0.693 | 0.344 | 0.356 | 0.154 | 0.463 |
+| vstash hybrid RRF (BGE-small base) | 0.6464 | 0.3304 | 0.3281 | 0.1778 | 0.4188 |
+| **vstash hybrid RRF (tuned, Section 5)** | **0.6945** | **0.3949** | **0.3283** | **0.1875** | **0.4241** |
+| vs ColBERTv2 (tuned) | +0.2% | **+14.8%** | -7.8% | **+21.8%** | -8.4% |
+
+*Published baselines from the MTEB SciFact leaderboard and the BEIR paper (Thakur et al., 2021). ColBERTv2 from Santhanam et al. (2022). Both vstash rows use sentence-transformers as the embedding backend with the full vstash pipeline (adaptive RRF + FTS5 + MMR dedup), evaluated on the standard BEIR queries and relevance judgments.*
+
+**Comparison conditions.** The ColBERTv2 NDCG@10 = 0.693 is from Santhanam et al. (2022) under the standard BEIR evaluation protocol. Our evaluation uses the same queries and relevance judgments but differs in document preprocessing: vstash chunks documents using its semantic chunking pipeline (1024 tokens, 128 overlap) and embeds with BGE-small-en-v1.5 (or the fine-tuned variant), while ColBERTv2 operates on full documents with its own tokenization and late interaction mechanism. The comparison is indicative of pipeline-level performance but is not a controlled head-to-head under identical preprocessing. A fully controlled comparison would require running ColBERTv2 on identical chunks, which we leave for future work.
+
+### 7.4  At-Scale Validation: 1,000 ArXiv Papers
+
+**Table 7: Hybrid RRF at scale -- 1,000 ML papers, 35 topic-based queries**
+
+| Model | Mode | P@5 | NDCG@5 | NDCG@10 | MRR | Latency |
+|-------|------|:---:|:---:|:---:|:---:|---:|
+| **BGE-base-EN (768d)** | **hybrid** | **0.703** | **0.728** | **0.702** | **0.895** | 9.1 ms |
+| BGE-small-EN (384d) | hybrid | 0.663 | 0.685 | 0.658 | 0.865 | 4.0 ms |
+| BGE-small-EN (384d) | vector | 0.614 | 0.619 | 0.568 | 0.822 | 2.3 ms |
+| Multilingual-MiniLM (384d) | hybrid | 0.606 | 0.638 | 0.611 | 0.868 | 4.3 ms |
+| Multilingual-MiniLM (384d) | vector | 0.600 | 0.588 | 0.508 | 0.820 | 2.6 ms |
+
+### 7.5  Latency at Scale
+
+**Table 8: Search latency across corpus sizes**
+
+| Corpus | Chunks | Mean | Median | P95 | Max |
+|--------|:---:|:---:|:---:|:---:|:---:|
+| LLM memory (24 papers) | 786 | 3.4 ms | 3.4 ms | 4.0 ms | 4.1 ms |
+| Real user corpus (209 docs) | 1,087 | 5.0 ms | 4.8 ms | 8.1 ms | 8.1 ms |
+| BEIR SciFact (5,183 docs) | 5,183 | 13.4 ms | -- | -- | -- |
+| Synthetic scale test | 10,005 | 15.7 ms | 14.1 ms | 23.1 ms | 23.1 ms |
+| SciFact + synthetic (50K) | 50,000 | 22.1 ms | 20.9 ms | 30.6 ms | 35.2 ms |
+
+**Table 9: NDCG@10 stability across scale**
+
+| Scale | Total chunks | NDCG@10 | Latency p50 | Latency p95 |
+|:---:|:---:|:---:|:---:|:---:|
+| 1K | 5,183 | 0.6891 | 11.1 ms | 24.9 ms |
+| 5K | 5,183 | 0.6891 | 10.2 ms | 19.2 ms |
+| 10K | 10,000 | 0.6849 | 10.9 ms | 19.0 ms |
+| 50K | 50,000 | 0.6897 | 20.9 ms | 30.6 ms |
+
+*Latency scales sub-linearly. NDCG@10 remains stable at 0.69 across all scales from 1K to 50K chunks.*
+
+### 7.6  End-to-End Answer Relevance
+
+**Table 10: Answer relevance -- vstash full pipeline vs Chroma dense-only**
 
 | Dataset | vstash mean | Chroma mean | Delta | Head-to-head | vstash score=0 | Chroma score=0 |
 |---------|:---:|:---:|:---:|:---:|:---:|:---:|
-| SciFact (30 queries) | **2.60 / 3.0** | 2.40 / 3.0 | **+8.3%** | **4-1** (25 ties) | 1 | 3 |
-| NFCorpus (30 queries) | **2.50 / 3.0** | 2.37 / 3.0 | **+5.6%** | 5-5 (20 ties) | 3 | 4 |
+| SciFact (30q) | 2.60/3.0 | 2.40/3.0 | +8.3% | 4-1 (25 ties) | 1 | 3 |
+| NFCorpus (30q) | 2.50/3.0 | 2.37/3.0 | +5.6% | 5-5 (20 ties) | 3 | 4 |
 
-**Key findings:**
-
-1. **The full pipeline produces better answers.** vstash's mean answer score is +5.6% to +8.3% higher than Chroma across both datasets. The hybrid retrieval pipeline (RRF + adaptive weights + MMR) delivers more relevant context to the LLM.
-
-2. **Fewer catastrophic failures.** vstash produces fewer completely wrong answers (score 0): 1 vs 3 on SciFact, 3 vs 4 on NFCorpus. Hybrid retrieval acts as a safety net — keyword matching catches relevant documents that vector search misses, reducing the chance of answering from irrelevant context.
-
-3. **Most queries are ties.** On 75-83% of queries, both systems produce equivalent answers. The pipeline advantage manifests on the harder queries where retrieval quality matters most.
+*LLM judge: Qwen 3.5 9B (local). The full pipeline produces better answers (+5.6-+8.3%) with fewer catastrophic failures.*
 
 ---
 
-## 9. Limitations and Future Work
+## 8  Limitations
 
-**Evaluation scale.** Experiments now span up to 50,000 chunks (Table 9), confirming sub-31ms P95 latency and stable NDCG at this scale (Table 9b). SQLite's single-writer model may bottleneck at 10^6+ chunks under concurrent write load, though WAL mode and batching mitigate this for single-user scenarios. 100K+ chunk performance remains untested.
+**LLM judge for ablation labels.** Tables 5a-5b use an LLM judge (Qwen 3.5:9B) for graded relevance labels with partial human validation (27/30 agreement). The ablation results are directional; the primary claims rest on BEIR benchmarks with human ground truth.
 
-**Relevance signal domain dependence.** The distance-based relevance signal (Section 5.2) was validated on ~47,000 queries across 5 BEIR datasets (Table 1d). The signal is effective as an off-topic detector when query and corpus domains are distinct (F1 = 0.856-0.996) but degrades to near-random on intra-domain queries where both relevant and irrelevant documents share domain vocabulary (F1 = 0.472-0.598). The optimal threshold varies by domain (0.65-0.76). The production three-tier system (Section 5.3) with threshold 0.95 remains appropriate as a conservative default.
+**ColBERTv2 comparison conditions.** The comparison with ColBERTv2 uses published numbers from 2022 under different preprocessing conditions (Section 7.3). The comparison is indicative of pipeline-level performance, not a controlled head-to-head.
 
-**LLM judge for relevance labels.** Tables 2a–2b use an LLM judge (Qwen 3.5:9B) for graded relevance labels with partial human validation (27/30 agreement on a 30-label subset). Full human annotation was not performed. The agreement rate suggests the ablation directions are reliable, but absolute NDCG values should be interpreted with this caveat — particularly the P@3 = 1.000 result, which could be sensitive to label noise.
+**Relevance signal domain dependence.** The distance-based relevance signal achieves F1 = 0.996 on cross-domain queries but degrades to F1 = 0.472 on intra-domain queries. It is an effective off-topic detector, not a universal relevance classifier.
 
-**Post-RRF scoring does not help.** We explored three approaches to post-RRF enhancement — frequency+decay scoring (§8.10), history-augmented recall, and cross-encoder reranking — all of which failed to improve NDCG on BEIR datasets. The frequency+decay system was removed in v0.18.0 after the scoring lifecycle experiment on SciFact showed -1.6% NDCG with adaptive γ and -9.0% with fixed β=0.5. Off-the-shelf cross-encoders (ms-marco-MiniLM, BGE-reranker-base) also degraded NDCG by -0.3% to -3.1% while adding 560-2100ms latency. The hybrid RRF pipeline with adaptive IDF weighting appears to be at its ceiling for the BGE-small embedding model. In v0.19.0, an opt-in recency boost was introduced for agentic memory use cases where temporal proximity matters (§4.6).
+**Scale.** Experiments span up to 50,000 chunks with stable NDCG and sub-31ms P95. Performance at 100K+ chunks remains untested. SQLite's single-writer model may bottleneck under concurrent write load at larger scales.
 
-**Discard telemetry awaits field validation.** The search_events table and dismiss tracking (Section 5.4) are fully instrumented as a designed validation path: once sufficient real-world usage accumulates, dismiss rates across relevance tiers will either confirm or refine the distance thresholds established on the BEIR benchmarks (Section 5.2.1). The instrumentation is in place; the signal is prospective.
+**Code chunking evaluation.** The code-aware chunking pipeline (Appendix B) is evaluated on only 8 queries across 2 languages. The primary contribution is the zero boundary violations guarantee; retrieval quality comparison at scale remains open.
 
-**Code chunking evaluation.** Table 4 evaluates code-aware chunking on only 8 queries across 2 languages. Naive chunking outperforms on recall; our argument that precision matters more at scale is conceptually motivated but empirically unvalidated (see §8.4). A proper evaluation would require a large multi-language codebase with graded code retrieval labels.
-
-**Fixed RRF weights degrade on long queries.** The default vec/fts weight ratio (0.6/0.4) assumes short keyword-style queries where FTS5 adds complementary signal. On BEIR ArguAna (avg query length 194 words, max 868), this assumption breaks: keyword matching on 194 OR-joined terms generates noise rather than signal, degrading NDCG@10 by −38.4% vs dense-only and inflating latency to 668ms (vs 35.6ms on the larger SciDocs corpus with 9-word queries). An adaptive weight scheme — reducing FTS weight for longer queries and increasing it for short keyword queries — is a natural extension. The breakpoints (e.g., >50 words → vec 0.9/fts 0.1; <5 words → vec 0.4/fts 0.6) require empirical tuning across diverse benchmarks. See GitHub issue #88.
-
-**MMR λ sensitivity.** The intra-document MMR deduplication (§3.4) uses a fixed λ=0.5, the equilibrium point from the original MMR formulation (Carbonell & Goldstein, 1998). Two candidate adaptive strategies — scaling λ by document length and by embedding variance — introduce second-order tuning problems (calibrating the mapping function) without clear gains: document length does not correlate with chunk similarity (a long novel has diverse chapters; a long API reference has near-identical entries), and embedding variance can be misleading when low variance masks high conceptual diversity. In practice, the negative MMR cutoff (stop selection when best remaining MMR < 0) already provides adaptive behavior: when chunks are diverse, the penalty is small and more pass; when near-duplicate, the penalty eliminates them. This achieves the same effect as dynamic λ without additional hyperparameters. The parameter is currently fixed at 0.5; user-configurable λ is deferred pending empirical evidence of benefit.
-
-**Implicit feedback.** Tracking which results the user expands, copies, or follows up on could refine the relevance signal and accelerate scoring warm-up — closing the loop between usage and retrieval quality.
-
-**Multi-modal.** Current chunking and embedding support text only. Image embeddings via CLIP and table-aware chunking are planned for future versions.
-
-**Test coverage.** The system includes ~750 tests across 30+ test modules (up from 591 in v0.19) covering store operations, ingestion, code splitting, CLI commands, robustness, multi-profile, journal, chunk retrieval, adaptive RRF, integrity check and repair, schema versioning, limits validation, observability, and MCP tools, plus 6 BEIR benchmark regression tests. All tests pass on Python 3.10, 3.11, and 3.12 via GitHub Actions CI.
-
-**Previously-listed concerns resolved in v0.20–v0.25.** Earlier drafts flagged silent failure on corrupted stores, implicit schema evolution, opaque ranking behavior, and undefined input limits as open risks. v0.24 (integrity check + idempotent ingest), v0.25 (explicit schema versioning, `SchemaVersionError`, documented score-comparability contract), v0.21 (`miss_analysis`), v0.22 (metrics registry + slow query log), and v0.23 (`LimitsConfig` + `LimitError` hierarchy) address these directly. The remaining limitations above are the ones that genuinely require new experiments or larger corpora rather than engineering work.
+**Multi-modal.** Current chunking and embedding support text only. Image embeddings and table-aware chunking are planned.
 
 ---
 
-## 10. Conclusion
+## 9  Conclusion
 
-We presented vstash, a local-first document memory system that demonstrates seven findings and one negative result relevant to LLM agent memory:
+We presented vstash, a local-first document memory system that makes four contributions to LLM agent memory:
 
-1. **Post-RRF scoring does not improve retrieval on real benchmarks.** Frequency+decay reranking (-1.6% NDCG on SciFact), history-augmented recall (0% effect), and off-the-shelf cross-encoder reranking (-0.3% to -3.1%) all failed to improve the hybrid RRF baseline. The maturity gate (γ) successfully prevented catastrophic degradation (fixed β=0.5 caused -9.0%) but the scoring itself added no value. This negative result led to the removal of the scoring pipeline in v0.18.0, simplifying the system to: vector + FTS5 → adaptive RRF → MMR dedup. In v0.19.0, an opt-in recency boost was introduced as a simpler alternative for agentic memory (§4.6).
+**Adaptive RRF.** IDF-based per-query weight adjustment improves NDCG@10 on all 5 BEIR datasets (up to +21.4% on ArguAna). On SciFact, vstash achieves 0.7263, exceeding published baselines for ColBERTv2 (+4.8%) with BGE-small (384d).
 
-2. **Vector distance is an effective off-topic detector with domain-dependent precision.** The cosine distance of the best vector match achieves F1 = 0.996 on cross-domain queries (ArguAna, ~47K queries across 5 BEIR datasets) but degrades to F1 = 0.472 on intra-domain queries (NFCorpus). The signal works from the first search with no scoring dependency and no warm-up period, superseding the initial score-spread approach (F1 = 0.667). It is best understood as an off-topic detector rather than a universal relevance classifier.
+**Self-supervised embedding refinement.** Hybrid retrieval disagreement provides a free training signal. Fine-tuning BGE-small (33M params) with MNRL on 76K disagreement triples improves all 5 BEIR datasets (up to +19.5%) and surpasses published baselines for ColBERTv2 (110M params) on 3 of 5 datasets with zero human labels. The model is published as `Stffens/bge-small-rrf-v2`. Users can fine-tune on their own data via `vstash retrain`.
 
-3. **Intra-document MMR deduplication improves diversity, quality, and multi-section coverage.** Replacing hard per-document dedup with intra-document MMR raises unique document count from ~3.2 to 5.0 while improving NDCG@5 from 0.814 to 0.829. Unlike hard dedup, MMR allows semantically diverse sections from the same long document to surface — on a 35-chunk paper, queries spanning multiple sections return 3–5× more relevant results than hard dedup.
+**Negative result.** Post-RRF scoring (frequency+decay, cross-encoder reranking) does not improve retrieval on real benchmarks. Gains come from improving the embedding, not from post-hoc reranking.
 
-4. **Context expansion is cheap and valuable.** Fetching adjacent chunks (±1 window) provides 2.64× more text for LLM consumption at +0.12 ms cost — a near-free improvement to answer quality.
+**Production substrate.** Integrity checking, schema versioning, ranking diagnostics (`miss_analysis`), and a distance-based relevance signal make vstash a deployable memory layer, not just a retrieval experiment. Search latency remains 20.9 ms median at 50K chunks with stable NDCG.
 
-5. **Local-first is viable up to 50K+ chunks.** With 20.9 ms median latency at 50,000 chunks and sub-31ms P95, a single SQLite file (plus optional sidecar for snapvec) and zero cloud dependencies, hybrid retrieval with deduplication and relevance signaling runs comfortably on a single machine for personal knowledge management workloads. NDCG@10 remains stable at 0.69 across all scales from 1K to 50K chunks (Table 9b). On the BEIR SciFact benchmark (5,183 docs), vstash achieves NDCG@10 = 0.7263, surpassing ColBERTv2 (0.693), BM25/Elasticsearch (0.665), and dense-only retrieval (0.653).
-
-6. **Adaptive RRF improves all 5 BEIR datasets with zero regression.** IDF-based weight adjustment per query (rare terms boost FTS, common terms boost vector) plus adaptive distance cutoff for long queries improves NDCG@10 by +0.1% to +21.4% across SciFact, NFCorpus, SciDocs, FiQA, and ArguAna. On SciFact, vstash achieves NDCG@10 = 0.7263 — exceeding ColBERTv2 (+4.8%) with BGE-small (384d). The ArguAna improvement is primarily from the adaptive distance cutoff — long queries (avg 194 words) produce diffuse embeddings where the default 1.15x cutoff eliminates relevant results; relaxing to 5.0x recovers them.
-
-7. **Hybrid retrieval disagreement is a viable self-supervised training signal for embedding models.** 82% of queries produce top-5 disagreement between vector and FTS signals. Using these disagreements as explicit hard negatives, we fine-tune BGE-small (33M params) with MultipleNegativesRankingLoss, improving NDCG@10 on all 5 BEIR datasets (up to +19.5% vs base, Table 10b). The resulting 33M parameter model surpasses ColBERTv2 (110M params) on 3/5 datasets with zero human labels and $0 training cost. The improvement transfers across domains: triples from 3 datasets generalized to 2 unseen datasets. TripletLoss with identical data caused -84% degradation, establishing loss function choice as the critical design variable. Adding explicit hard negatives from signal disagreement improved all 5 datasets by +1-2% over batch-only negatives, confirming that negative quality compounds with the right loss function. The model is published as [`Stffens/bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) on HuggingFace, and users can fine-tune on their own data via `vstash retrain`.
-
-Beyond these empirical findings, vstash has evolved into a complete agent memory platform: multi-profile isolation enables separate knowledge domains with federated cross-profile search (v0.11), a cross-session journal provides lightweight append-only memory for LLM agent context (v0.12), and direct chunk access via `get_chunk` enables downstream applications to pin specific knowledge atoms by ID (v0.13).
-
-In v0.20–v0.25, the system was hardened as a production-grade substrate for LLM agents along three axes that upper-layer memory frameworks generally do not provide. **Integrity and recovery** (v0.24): idempotent re-ingest via document completeness classification, a five-invariant `integrity_check`, and a collection-scoped `integrity_repair` with FTS5 rebuild, exposed as `vstash check [--repair]`. **Explicit contracts** (v0.25): a stamped schema version with `SchemaVersionError` on unknown on-disk versions, `INSERT OR IGNORE` stamping for concurrent fresh-open safety, forward-compatible top-level config keys, and documented score-comparability semantics. **Operational observability** (v0.21–v0.22): a ranking `miss_analysis` API that traces pipeline-stage elimination with rule-based suggestions, an in-process metrics registry with per-stage timing, a slow query log, and explicit limits validation at public API boundaries (`LimitsConfig`, `LimitError` hierarchy). These are substrate-level contributions: each one turns a previously silent failure mode into a typed, diagnosable, and recoverable surface.
-
-The system ships with 16 MCP tools, a Python SDK, CLI, and Claude Code hook integration, validated by ~750 tests across 30+ modules (plus 6 BEIR benchmark regression tests) on Python 3.10–3.12.
+The system includes 16 MCP tools, a Python SDK, CLI, Claude Code hook, and approximately 750 tests across 30+ modules. All code, data, the fine-tuned model, and reproducible experiment scripts are open-source.
 
 ---
 
-## Acknowledgments
+## Appendix A: Production Substrate
 
-vstash is built on the work of several open-source projects whose
-quality directly enables this system: **sqlite-vec** (Alex Garcia)
-for the ANN index, **FastEmbed** (Qdrant) for the ONNX embedding
-runtime, **sentence-transformers** and **BAAI** for the embedding
-models evaluated, **tree-sitter** and **parso** for the code-aware
-chunking backends, and **SQLite/FTS5** for the keyword retrieval
-substrate. The BEIR evaluation suite (Thakur et al., 2021) provided
-the primary external benchmark against which the retrieval pipeline
-was tuned.
+### A.1  Integrity and Recovery
 
-Development of the vstash codebase was assisted by **Claude**
-(Anthropic) for code generation, refactoring, documentation, and
-responding to automated code review. All design decisions, algorithm
-choices, benchmark methodology, statistical caveats (§5.2, §8.4), and
-the negative results documented in §4 and §8.10 were authored and
-verified by the human contributor. The decision to publish the
-frequency+decay negative result rather than quietly remove it was
-made by the author in line with the scientific norm of reporting
-approaches that did not work.
+A memory substrate must be honest about what survived a crash. vstash provides three mechanisms:
 
-All experiments in this paper are reproducible from scripts in the
-project's `experiments/` directory. Benchmark numbers and figures
-were re-run against HEAD prior to each release, and the regression
-suite in `tests/test_beir_regression.py` prevents silent drift on
-the BEIR baselines.
+**Idempotent ingest.** `doc_completeness(path, collection)` classifies a document as *missing*, *partial*, or *complete*. Partial documents are dropped and re-ingested from scratch; complete documents are skipped. Re-running the same ingest command is safe and does not duplicate data.
+
+**Integrity check.** Five invariants are verified: chunk_count parity, vec/snapvec parity, FTS5 index integrity (via the built-in FTS5 integrity-check command), orphan chunks, and SQLite `PRAGMA integrity_check`.
+
+**Integrity repair.** Restores invariants without destroying user data: recomputes chunk_count, rebuilds FTS5, and deletes orphan chunks. Exposed via `vstash check [--repair] [--json]`.
+
+### A.2  Schema Versioning
+
+A `SCHEMA_VERSION` constant is stamped into the `store_meta` table at database creation. A `KNOWN_SCHEMA_VERSIONS` set declares which on-disk versions the current build can safely open. Unknown future versions raise `SchemaVersionError` rather than silently degrading. Forward-compatible top-level config keys warn on unknown rather than hard-failing.
+
+### A.3  Operational Observability
+
+An in-process metrics registry tracks counts and per-stage latency histograms. A slow query log captures searches exceeding a configurable threshold. A `miss_analysis()` API diagnoses why an expected document did not appear in results by tracing pipeline-stage elimination with rule-based suggestions. A `LimitsConfig` with seven knobs validates inputs at API boundaries, producing typed `LimitError` exceptions.
+
+---
+
+## Appendix B: Code-Aware Chunking
+
+Standard fixed-window chunking splits code mid-function, destroying semantic coherence. vstash uses a 3-tier hybrid splitting pipeline that selects the best available backend per language with graceful degradation:
+
+**Tier 1: tree-sitter** (25+ languages) provides exact AST boundary detection. Optional dependency to avoid binary overhead for non-code users.
+
+**Tier 2: parso** (Python only) provides AST-level splitting as a base dependency. Handles decorated functions, nested classes, and async definitions.
+
+**Tier 3: regex** (Python, JS/TS, Go, Rust, Java) detects top-level definitions via column-0 patterns. The zero-indentation anchor avoids false positives on nested methods.
+
+In all tiers, decorators and annotations are attached to their following definition. Oversized chunks fall back to paragraph then fixed-window splitting. The primary guarantee is zero boundary violations -- no function is split mid-body.
+
+---
+
+## Appendix C: Scoring Grid Search and Cold Start Analysis
+
+### C.1  Grid Search
+
+**Table C1: Top-5 scoring configurations averaged across 5 access scenarios**
+
+| Configuration | Avg NDCG@10 | Delta Baseline | Best Scenario |
+|---------------|:---:|:---:|:---:|
+| a=0.5, b=0.5, L=0.10 | **0.636** | +4.6% | +16.1% (benchmark) |
+| a=0.5, b=0.5, L=0.05 | 0.634 | +4.3% | +15.6% (benchmark) |
+| a=0.7, b=0.3, L=0.03 | 0.631 | +3.8% | +13.2% (benchmark) |
+| a=0.7, b=0.3, L=0.07 | 0.629 | +3.5% | +13.1% (benchmark) |
+| a=0.8, b=0.2, L=0.10 | 0.632 | +3.9% | +7.2% (benchmark) |
+
+*Baseline NDCG@10 = 0.608. The scoring benefit scales with access differential but does not improve on BEIR benchmarks with human labels.*
+
+### C.2  Cold Start
+
+On a corpus of 120 Wikipedia articles (919 chunks) with Zipf-weighted usage simulation over 30 rounds, fixed b=0.5 produces -0.4% degradation in early rounds. The adaptive maturity gate remains 0.0 across all 30 rounds because Zipf-weighted usage does not produce a sufficiently extreme outlier (max/mean ratio peaks at 5.0x, below the 8x activation threshold). The gate correctly suppresses scoring when access patterns do not warrant it.
+
+---
+
+## Appendix D: API and Interface Reference
+
+### D.1  MCP Server
+
+The MCP server exposes 16 tools: search, add, ask, remember (direct text ingestion), get_chunk (O(1) lookup by ID), get_document_chunks, list, stats, forget, collections, export, job status, and four journal tools (save, recall, log, prune). Search results include the relevance signal, enabling clients to filter noise.
+
+### D.2  Direct Chunk Access
+
+Search results include a `chunk_id` (database row ID) enabling O(1) retrieval without re-running search. Batch requests are automatically batched at 900 IDs per SQL statement to respect SQLite limits. Chunk IDs are stable for the lifetime of the current index; re-ingesting a document invalidates prior IDs.
+
+### D.3  Multi-Profile Support
+
+Multiple named profiles, each backed by an isolated SQLite database. Federated search queries all profiles in parallel and merges via RRF with cross-profile deduplication using a blake2b content digest as the fusion key to prevent collisions when the same path exists in different collections with different content.
+
+### D.4  Cross-Session Journal
+
+Lightweight, append-only memory for LLM agents. Unlike document ingestion, journal entries are stored as single text records with timestamps and optional tags. Four operations: save, recall (semantic search), log (chronological), and prune.
 
 ---
 
 ## References
 
-1. Cormack, G. V., Clarke, C. L. A., & Buttcher, S. (2009). Reciprocal rank fusion outperforms condorcet and individual rank learning methods. *SIGIR*.
+[1] Carbonell, J., & Goldstein, J. (1998). The use of MMR, diversity-based reranking for reordering documents and producing summaries. *SIGIR*.
 
-2. Ebbinghaus, H. (1885). *Uber das Gedachtnis*. Duncker & Humblot.
+[2] Chadha, T., Khattab, D., & Singhal, P. (2025). Mem0: Production-ready AI agents with scalable long-term memory. *arXiv:2504.19413*.
 
-3. Packer, C., Wooders, S., Lin, K., Fang, V., Patil, S. G., Stoica, I., & Gonzalez, J. E. (2023). MemGPT: Towards LLMs as operating systems. *arXiv:2310.08560*.
+[3] Cormack, G. V., Clarke, C. L. A., & Buttcher, S. (2009). Reciprocal rank fusion outperforms condorcet and individual rank learning methods. *SIGIR*.
 
-4. Chadha, T., Khattab, D., & Singhal, P. (2025). Mem0: Production-ready AI agents with scalable long-term memory. *arXiv:2504.19413*.
+[4] Ebbinghaus, H. (1885). *Uber das Gedachtnis*. Duncker & Humblot.
 
-5. Memoria Team. (2025). Memoria: Scalable agentic memory for personalized conversational AI. *arXiv:2512.12686*.
+[5] Ma, X., Wang, Y., & Lin, J. (2024). Is reciprocal rank fusion all you need for hybrid retrieval? *arXiv preprint*.
 
-6. A-MEM Team. (2025). A-MEM: Agentic memory for LLM agents. *arXiv:2502.12110*.
+[6] MaRS Team. (2025). MaRS: Forgetful but faithful -- cognitive memory architecture. *arXiv:2512.12856*.
 
-7. Ma, X., Wang, Y., & Lin, J. (2024). Is reciprocal rank fusion all you need for hybrid retrieval? *arXiv preprint*.
+[7] Memoria Team. (2025). Memoria: Scalable agentic memory for personalized conversational AI. *arXiv:2512.12686*.
 
-8. Zep Team. (2025). Zep: Temporal knowledge graph architecture for agent memory. *arXiv:2501.13956*.
+[8] Muennighoff, N., Tazi, N., Magne, L., & Reimers, N. (2023). MTEB: Massive Text Embedding Benchmark. *EACL*.
 
-9. MaRS Team. (2025). MaRS: Forgetful but faithful — cognitive memory architecture. *arXiv:2512.12856*.
+[9] Packer, C., et al. (2023). MemGPT: Towards LLMs as operating systems. *arXiv:2310.08560*.
 
-10. PAM Team. (2026). PAM: Predictive associative memory via temporal co-occurrence. *arXiv:2602.11322*.
+[10] PAM Team. (2026). PAM: Predictive associative memory via temporal co-occurrence. *arXiv:2602.11322*.
 
-11. Carbonell, J., & Goldstein, J. (1998). The use of MMR, diversity-based reranking for reordering documents and producing summaries. *SIGIR*.
+[11] Santhanam, K., et al. (2022). ColBERTv2: Effective and efficient retrieval via lightweight late interaction. *NAACL*.
 
-12. Thakur, N., Reimers, N., Ruckteschel, A., Srivastava, A., & Gurevych, I. (2021). BEIR: A heterogeneous benchmark for zero-shot evaluation of information retrieval models. *NeurIPS Datasets and Benchmarks*.
+[12] Thakur, N., et al. (2021). BEIR: A heterogeneous benchmark for zero-shot evaluation of information retrieval models. *NeurIPS Datasets and Benchmarks*.
 
-13. Santhanam, K., Khattab, O., Saad-Falcon, J., Potts, C., & Zaharia, M. (2022). ColBERTv2: Effective and efficient retrieval via lightweight late interaction. *NAACL*.
+[13] Zep Team. (2025). Zep: Temporal knowledge graph architecture for agent memory. *arXiv:2501.13956*.
 
-14. Muennighoff, N., Tazi, N., Magne, L., & Reimers, N. (2023). MTEB: Massive Text Embedding Benchmark. *EACL*. Leaderboard: https://huggingface.co/spaces/mteb/leaderboard.
+[14] A-MEM Team. (2025). A-MEM: Agentic memory for LLM agents. *arXiv:2502.12110*.
+
+---
+
+## Acknowledgments
+
+vstash is built on sqlite-vec (Alex Garcia), FastEmbed (Qdrant), sentence-transformers and BAAI for embedding models, tree-sitter and parso for code-aware chunking, and SQLite/FTS5 for keyword retrieval. The BEIR evaluation suite (Thakur et al., 2021) provided the primary external benchmark. Development was assisted by Claude (Anthropic) for code generation and refactoring. All design decisions, algorithm choices, benchmark methodology, and the negative results were authored and verified by the human contributor. All experiments are reproducible from scripts in the project's `experiments/` directory.


### PR DESCRIPTION
Major restructure based on external review feedback. Paper went from 905 lines to 481, focused around 4 primary contributions.

Fixes applied:
1. Table 6: consistent eval conditions (both rows use sentence-transformers)
2. Appendix D.3: fusion key updated to blake2b
3. vstash retrain documented throughout
4. Table 4: simplified with condition notes
5. ColBERTv2 caveat explicit in Section 7.3

New: Related Work section with local-first agent memory competitors.