### PR TITLE
✨ feat: snapvec-ivfpq vector backend with fp16 rerank

### DIFF
--- a/experiments/retrain_smoke.py
+++ b/experiments/retrain_smoke.py
@@ -1,0 +1,84 @@
+"""Retrain pipeline sanity check against snapvec 0.7.1.
+
+Builds a small vstash store from the SciFact corpus, runs
+`generate_triples` with a handful of pseudo-queries, and reports
+how many disagreement pairs came out. Skips the MNRL training step
+(that takes minutes + GPU and is covered by the published model).
+
+What this validates:
+  - VstashStore ingest still works after the snapvec 0.7.1 bump
+  - hybrid search (vector + FTS + RRF) still returns sensible results
+  - retrain's disagreement detector still finds pairs
+
+Usage:
+    python -m experiments.retrain_smoke
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+from pathlib import Path
+
+from experiments.beir_benchmark import download_beir, load_beir
+from vstash.embed import embed_texts
+from vstash.retrain import generate_triples
+from vstash.store import VstashStore
+
+MODEL = "BAAI/bge-small-en-v1.5"
+N_DOCS = 500
+MAX_QUERIES = 50
+
+
+def main() -> None:
+    cache = download_beir("scifact")
+    corpus, _, _ = load_beir(cache)
+    doc_ids = list(corpus.keys())[:N_DOCS]
+    texts = [
+        (corpus[d].get("title", "") + " " + corpus[d].get("text", "")).strip()
+        for d in doc_ids
+    ]
+    print(f"embedding {len(texts)} SciFact docs ...")
+    t0 = time.perf_counter()
+    batch = 256
+    embeddings: list[list[float]] = []
+    for start in range(0, len(texts), batch):
+        end = min(start + batch, len(texts))
+        embeddings.extend(embed_texts(texts[start:end], MODEL))
+    print(f"  embedded in {time.perf_counter() - t0:.1f}s")
+
+    with tempfile.TemporaryDirectory() as td:
+        db_path = str(Path(td) / "smoke.db")
+        store = VstashStore(db_path, embedding_dim=384, vector_backend="sqlite-vec")
+
+        print("ingesting ...")
+        t0 = time.perf_counter()
+        for i, (doc_id, text, emb) in enumerate(zip(doc_ids, texts, embeddings)):
+            store.add_document(
+                path=f"scifact/{doc_id}",
+                title=doc_id,
+                chunks=[text],
+                embeddings=[emb],
+                source_type="text",
+            )
+            if i % 100 == 99:
+                print(f"  {i + 1}/{len(texts)}")
+        print(f"  ingested in {time.perf_counter() - t0:.1f}s")
+
+        stats = store.stats()
+        print(f"  store: {stats.documents} docs, {stats.chunks} chunks")
+
+        print(f"generating triples (max_queries={MAX_QUERIES}) ...")
+        t0 = time.perf_counter()
+        pairs = generate_triples(store, MODEL, max_queries=MAX_QUERIES)
+        print(f"  generated {len(pairs)} pairs in {time.perf_counter() - t0:.1f}s")
+
+        if pairs:
+            print("\nsample pair:")
+            p = pairs[0]
+            print(f"  query:    {p['query'][:80]} ...")
+            print(f"  positive: {p['positive'][:80]} ...")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -71,6 +71,30 @@ class TestIVFPQBackendWrapper:
         assert not be.fitted
         assert len(be) == 0
 
+    def test_load_treats_file_existence_as_authoritative(self, tmp_path):
+        """A fitted .snpi survives a missing sidecar (crash resilience)."""
+        from pathlib import Path as _P
+
+        rng = np.random.default_rng(5)
+        vecs = _unit_vectors(rng, N, DIM)
+        path = str(tmp_path / "idx.snpi")
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32, rerank_candidates=32)
+        be.fit(vecs)
+        be.add_batch(list(range(N)), vecs)
+        be.save(path)
+        # Previously the loader required a .fitted sidecar; deleting it
+        # must not downgrade load() to the unfit path.
+        sidecar = _P(path + ".fitted")
+        if sidecar.exists():
+            sidecar.unlink()
+        loaded = IVFPQBackend.load(path, dim=DIM, nlist=16, M=24, K=32)
+        assert loaded.fitted
+        assert len(loaded) == N
+
+    def test_constructor_rejects_invalid_dim_M_combo(self):
+        with pytest.raises(ValueError, match="must divide embedding_dim"):
+            IVFPQBackend(dim=384, nlist=16, M=10, K=32)  # 384 % 10 != 0
+
 
 class TestVstashStoreIVFPQIntegration:
     def test_backend_initialization(self, tmp_path):

--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -1,0 +1,200 @@
+"""Tests for the snapvec-ivfpq backend adapter and VstashStore integration."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("snapvec", reason="snapvec not installed")
+
+from vstash._ivfpq_backend import IVFPQBackend  # noqa: E402
+from vstash.store import VstashStore  # noqa: E402
+
+DIM = 96  # multiple of ivfpq_M so no param juggling is needed
+N = 400   # big enough for the default nlist without overfitting warnings
+
+
+def _unit_vectors(rng: np.random.Generator, n: int, dim: int) -> np.ndarray:
+    x = rng.standard_normal((n, dim)).astype(np.float32)
+    x /= np.linalg.norm(x, axis=1, keepdims=True) + 1e-9
+    return x
+
+
+class TestIVFPQBackendWrapper:
+    def test_pre_fit_is_empty_and_search_returns_nothing(self):
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32)
+        assert len(be) == 0
+        assert not be.fitted
+        assert be.search(np.zeros(DIM, dtype=np.float32), k=5) == []
+
+    def test_pre_fit_add_batch_is_no_op(self):
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32)
+        be.add_batch([1, 2, 3], _unit_vectors(np.random.default_rng(0), 3, DIM))
+        assert len(be) == 0
+
+    def test_fit_then_add_then_search(self, tmp_path):
+        rng = np.random.default_rng(0)
+        vecs = _unit_vectors(rng, N, DIM)
+        ids = list(range(N))
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32, rerank_candidates=32)
+        be.fit(vecs)
+        be.add_batch(ids, vecs)
+        assert len(be) == N
+        # First vector should find itself at rank 0
+        hits = be.search(vecs[0], k=5)
+        assert hits, "expected non-empty results post-fit"
+        assert hits[0][0] == 0
+        # Distances should be in [0, 2] cosine-like range
+        assert all(0.0 <= d <= 2.0 for _, d in hits)
+
+    def test_save_load_roundtrip(self, tmp_path):
+        rng = np.random.default_rng(1)
+        vecs = _unit_vectors(rng, N, DIM)
+        ids = list(range(N))
+        path = str(tmp_path / "idx.snpi")
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32, rerank_candidates=32)
+        be.fit(vecs)
+        be.add_batch(ids, vecs)
+        be.save(path)
+
+        be2 = IVFPQBackend.load(
+            path, dim=DIM, nlist=16, M=24, K=32, rerank_candidates=32
+        )
+        assert be2.fitted
+        assert len(be2) == N
+        hits = be2.search(vecs[3], k=5)
+        assert hits[0][0] == 3
+
+    def test_load_missing_file_returns_unfit(self, tmp_path):
+        missing = str(tmp_path / "nope.snpi")
+        be = IVFPQBackend.load(missing, dim=DIM, nlist=16, M=24, K=32)
+        assert not be.fitted
+        assert len(be) == 0
+
+
+class TestVstashStoreIVFPQIntegration:
+    def test_backend_initialization(self, tmp_path):
+        store = VstashStore(
+            str(tmp_path / "s.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+            ivfpq_rerank_candidates=32,
+        )
+        assert store._vector_backend == "snapvec-ivfpq"
+        assert isinstance(store._snap, IVFPQBackend)
+        assert not store._snap.fitted
+        store.close()
+
+    def test_ingest_falls_through_to_sqlite_vec_pre_fit(self, tmp_path):
+        store = VstashStore(
+            str(tmp_path / "s.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        rng = np.random.default_rng(2)
+        vecs = _unit_vectors(rng, 5, DIM)
+        store.add_document(
+            path="/t/a.md",
+            title="A",
+            chunks=[f"chunk {i}" for i in range(5)],
+            embeddings=vecs.tolist(),
+            source_type="text",
+        )
+        # sqlite-vec still answers pre-fit
+        results = store.search(vecs[0].tolist(), "chunk 0", top_k=3)
+        assert len(results) > 0
+        store.close()
+
+    def test_fit_ivfpq_end_to_end(self, tmp_path):
+        store = VstashStore(
+            str(tmp_path / "s.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+            ivfpq_rerank_candidates=32,
+        )
+        rng = np.random.default_rng(3)
+        vecs = _unit_vectors(rng, N, DIM)
+        # Ingest as a single batch for speed
+        store.add_document(
+            path="/t/bulk.md",
+            title="Bulk",
+            chunks=[f"chunk {i}" for i in range(N)],
+            embeddings=vecs.tolist(),
+            source_type="text",
+        )
+        stats = store.fit_ivfpq(training_sample=N)
+        assert stats["n_indexed"] == N
+        assert store._snap.fitted
+
+        # Post-fit search should now go through IVFPQ
+        results = store.search(vecs[0].tolist(), "chunk 0", top_k=5)
+        assert len(results) > 0
+        # Index file should exist
+        assert store._ivfpq_path.exists()
+        store.close()
+
+    def test_fit_ivfpq_rejects_non_ivfpq_backend(self, tmp_path):
+        store = VstashStore(
+            str(tmp_path / "s.db"),
+            embedding_dim=DIM,
+            vector_backend="sqlite-vec",
+        )
+        with pytest.raises(RuntimeError, match="snapvec-ivfpq"):
+            store.fit_ivfpq()
+        store.close()
+
+    def test_fit_ivfpq_rejects_empty_corpus(self, tmp_path):
+        store = VstashStore(
+            str(tmp_path / "s.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        with pytest.raises(RuntimeError, match="empty"):
+            store.fit_ivfpq()
+        store.close()
+
+    def test_reopen_after_fit_loads_index(self, tmp_path):
+        db_path = str(tmp_path / "reopen.db")
+        store = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        rng = np.random.default_rng(4)
+        vecs = _unit_vectors(rng, N, DIM)
+        store.add_document(
+            path="/t/bulk.md",
+            title="Bulk",
+            chunks=[f"chunk {i}" for i in range(N)],
+            embeddings=vecs.tolist(),
+            source_type="text",
+        )
+        store.fit_ivfpq(training_sample=N)
+        store.close()
+
+        store2 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        assert store2._snap.fitted
+        assert len(store2._snap) == N
+        store2.close()

--- a/vstash/_ivfpq_backend.py
+++ b/vstash/_ivfpq_backend.py
@@ -1,0 +1,182 @@
+"""IVFPQ backend adapter for VstashStore.
+
+Wraps snapvec.IVFPQSnapIndex so it can slot into the same hot-path that
+the flat SnapIndex uses. The key adaptation is that IVFPQ requires an
+explicit `fit()` call on a training sample before the first `add_batch`;
+the adapter tracks fitted state and forwards a consistent API.
+
+Lifecycle:
+    1. Store is created with vector_backend="snapvec-ivfpq". The .snpi
+       file does not exist yet, so IVFPQBackend(fitted=False). sqlite-vec
+       receives every chunk as usual (dual-population).
+    2. Search falls back to sqlite-vec while len(backend) == 0 (matches
+       the existing `elif self._snap is not None and len(self._snap) > 0`
+       branch in VstashStore.search).
+    3. User runs `vstash snapvec fit`. The CLI reads all embeddings from
+       vec_chunks, calls backend.fit(sample) + backend.add_batch(all),
+       backend.save(path).
+    4. On next store open, IVFPQBackend.load() reads the .snpi, sets
+       fitted=True. len() returns the indexed count, so search now
+       prefers the IVFPQ path.
+    5. Post-fit add_document calls are forwarded to the fitted index.
+    6. Deletes forward through in all states (no-op before fit).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+class IVFPQBackend:
+    """Thin adapter around snapvec.IVFPQSnapIndex with pre-fit safe API.
+
+    Attributes mirror SnapIndex where the search hot-path reads them,
+    so VstashStore does not need a type switch on the snap object.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        *,
+        nlist: int,
+        M: int = 96,
+        K: int = 256,
+        seed: int = 0,
+        keep_full_precision: bool = True,
+        rerank_candidates: int = 100,
+        nprobe: int = 0,
+    ) -> None:
+        from snapvec import IVFPQSnapIndex
+
+        if dim % M != 0:
+            raise ValueError(
+                f"ivfpq_M={M} must divide embedding_dim={dim}. "
+                f"Pick a divisor (e.g. 96 for dim=384, 128 for dim=1024)."
+            )
+        self.dim = dim
+        self._nlist = nlist
+        self._M = M
+        self._K = K
+        self._seed = seed
+        self._keep_full_precision = keep_full_precision
+        self._rerank_candidates = rerank_candidates
+        self._nprobe = nprobe
+        self._index = IVFPQSnapIndex(
+            dim=dim,
+            nlist=nlist,
+            M=M,
+            K=K,
+            seed=seed,
+            normalized=True,
+            use_rht=False,
+            keep_full_precision=keep_full_precision,
+        )
+        self._fitted: bool = False
+
+    # ------------------------------------------------------------------ #
+    # state                                                               #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def fitted(self) -> bool:
+        return self._fitted
+
+    def __len__(self) -> int:
+        # Before fit, the index has no routable vectors — report 0 so the
+        # store's search code falls through to sqlite-vec.
+        return len(self._index) if self._fitted else 0
+
+    # ------------------------------------------------------------------ #
+    # training and build                                                  #
+    # ------------------------------------------------------------------ #
+
+    def fit(self, training_vectors: np.ndarray) -> None:
+        if self._fitted:
+            raise RuntimeError("IVFPQBackend already fitted")
+        self._index.fit(np.asarray(training_vectors, dtype=np.float32))
+        self._fitted = True
+
+    def add_batch(self, ids: list[Any], vectors: np.ndarray) -> None:
+        if not self._fitted:
+            # Silently drop pre-fit adds. sqlite-vec is the source of
+            # truth until fit() runs and the CLI repopulates from there.
+            return
+        self._index.add_batch(list(ids), np.asarray(vectors, dtype=np.float32))
+
+    def delete(self, id_: Any) -> bool:
+        if not self._fitted:
+            return False
+        return self._index.delete(id_)
+
+    # ------------------------------------------------------------------ #
+    # search                                                              #
+    # ------------------------------------------------------------------ #
+
+    def search(self, query: np.ndarray, k: int = 10) -> list[tuple[Any, float]]:
+        if not self._fitted:
+            return []
+        kwargs: dict[str, Any] = {}
+        if self._nprobe > 0:
+            kwargs["nprobe"] = self._nprobe
+        if self._rerank_candidates > 0 and self._keep_full_precision:
+            kwargs["rerank_candidates"] = max(self._rerank_candidates, k)
+        results = self._index.search(np.asarray(query, dtype=np.float32), k=k, **kwargs)
+        # IVFPQ returns similarity scores, not cosine distance. Convert
+        # to a pseudo-distance in [0, 2] so downstream relevance_tier()
+        # and ranking heuristics keep working. cosine_dist = 1 - cos_sim.
+        return [(id_, max(0.0, 1.0 - float(score))) for id_, score in results]
+
+    # ------------------------------------------------------------------ #
+    # persistence                                                         #
+    # ------------------------------------------------------------------ #
+
+    def save(self, path: str) -> None:
+        if self._fitted:
+            self._index.save(path)
+            # Touch a sidecar so load() can tell a pre-fit state apart
+            # from a fitted empty index.
+            Path(path + ".fitted").write_text("1")
+
+    @classmethod
+    def load(
+        cls,
+        path: str,
+        *,
+        dim: int,
+        nlist: int,
+        M: int = 96,
+        K: int = 256,
+        seed: int = 0,
+        keep_full_precision: bool = True,
+        rerank_candidates: int = 100,
+        nprobe: int = 0,
+    ) -> IVFPQBackend:
+        from snapvec import IVFPQSnapIndex
+
+        fitted_flag = Path(path + ".fitted").exists()
+        if not fitted_flag or not Path(path).exists():
+            return cls(
+                dim=dim,
+                nlist=nlist,
+                M=M,
+                K=K,
+                seed=seed,
+                keep_full_precision=keep_full_precision,
+                rerank_candidates=rerank_candidates,
+                nprobe=nprobe,
+            )
+        backend = cls.__new__(cls)
+        backend.dim = dim
+        backend._nlist = nlist
+        backend._M = M
+        backend._K = K
+        backend._seed = seed
+        backend._keep_full_precision = keep_full_precision
+        backend._rerank_candidates = rerank_candidates
+        backend._nprobe = nprobe
+        backend._index = IVFPQSnapIndex.load(path)
+        backend._fitted = True
+        return backend

--- a/vstash/_ivfpq_backend.py
+++ b/vstash/_ivfpq_backend.py
@@ -15,9 +15,8 @@ Lifecycle:
     3. User runs `vstash snapvec fit`. The CLI reads all embeddings from
        vec_chunks, calls backend.fit(sample) + backend.add_batch(all),
        backend.save(path).
-    4. On next store open, IVFPQBackend.load() reads the .snpi, sets
-       fitted=True. len() returns the indexed count, so search now
-       prefers the IVFPQ path.
+    4. On next store open, IVFPQBackend.load() reads the .snpi and the
+       presence of the file is authoritative for fitted state.
     5. Post-fit add_document calls are forwarded to the fitted index.
     6. Deletes forward through in all states (no-op before fit).
 """
@@ -35,6 +34,10 @@ class IVFPQBackend:
 
     Attributes mirror SnapIndex where the search hot-path reads them,
     so VstashStore does not need a type switch on the snap object.
+
+    The underlying IVFPQSnapIndex is built with ``normalized=True``
+    (cosine scoring assumes unit-length inputs), so this adapter
+    L2-normalizes at every entry point — fit, add_batch, and search.
     """
 
     def __init__(
@@ -90,13 +93,26 @@ class IVFPQBackend:
         return len(self._index) if self._fitted else 0
 
     # ------------------------------------------------------------------ #
+    # normalization                                                       #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _normalize(x: np.ndarray) -> np.ndarray:
+        x = np.asarray(x, dtype=np.float32)
+        if x.ndim == 1:
+            norm = float(np.linalg.norm(x))
+            return x / norm if norm > 1e-9 else x
+        norms = np.linalg.norm(x, axis=1, keepdims=True)
+        return x / np.where(norms > 1e-9, norms, 1.0)
+
+    # ------------------------------------------------------------------ #
     # training and build                                                  #
     # ------------------------------------------------------------------ #
 
     def fit(self, training_vectors: np.ndarray) -> None:
         if self._fitted:
             raise RuntimeError("IVFPQBackend already fitted")
-        self._index.fit(np.asarray(training_vectors, dtype=np.float32))
+        self._index.fit(self._normalize(training_vectors))
         self._fitted = True
 
     def add_batch(self, ids: list[Any], vectors: np.ndarray) -> None:
@@ -104,7 +120,7 @@ class IVFPQBackend:
             # Silently drop pre-fit adds. sqlite-vec is the source of
             # truth until fit() runs and the CLI repopulates from there.
             return
-        self._index.add_batch(list(ids), np.asarray(vectors, dtype=np.float32))
+        self._index.add_batch(list(ids), self._normalize(vectors))
 
     def delete(self, id_: Any) -> bool:
         if not self._fitted:
@@ -123,7 +139,7 @@ class IVFPQBackend:
             kwargs["nprobe"] = self._nprobe
         if self._rerank_candidates > 0 and self._keep_full_precision:
             kwargs["rerank_candidates"] = max(self._rerank_candidates, k)
-        results = self._index.search(np.asarray(query, dtype=np.float32), k=k, **kwargs)
+        results = self._index.search(self._normalize(query), k=k, **kwargs)
         # IVFPQ returns similarity scores, not cosine distance. Convert
         # to a pseudo-distance in [0, 2] so downstream relevance_tier()
         # and ranking heuristics keep working. cosine_dist = 1 - cos_sim.
@@ -136,9 +152,6 @@ class IVFPQBackend:
     def save(self, path: str) -> None:
         if self._fitted:
             self._index.save(path)
-            # Touch a sidecar so load() can tell a pre-fit state apart
-            # from a fitted empty index.
-            Path(path + ".fitted").write_text("1")
 
     @classmethod
     def load(
@@ -154,29 +167,27 @@ class IVFPQBackend:
         rerank_candidates: int = 100,
         nprobe: int = 0,
     ) -> IVFPQBackend:
+        """Load a fitted index from disk, or return an unfit backend.
+
+        The presence of the index file is authoritative: if ``path``
+        exists it's treated as a fitted index. This avoids the split
+        between an index file and a sidecar flag getting out of sync
+        after a crash. Constructor validation (dim % M) still runs via
+        the normal ``__init__`` path.
+        """
         from snapvec import IVFPQSnapIndex
 
-        fitted_flag = Path(path + ".fitted").exists()
-        if not fitted_flag or not Path(path).exists():
-            return cls(
-                dim=dim,
-                nlist=nlist,
-                M=M,
-                K=K,
-                seed=seed,
-                keep_full_precision=keep_full_precision,
-                rerank_candidates=rerank_candidates,
-                nprobe=nprobe,
-            )
-        backend = cls.__new__(cls)
-        backend.dim = dim
-        backend._nlist = nlist
-        backend._M = M
-        backend._K = K
-        backend._seed = seed
-        backend._keep_full_precision = keep_full_precision
-        backend._rerank_candidates = rerank_candidates
-        backend._nprobe = nprobe
-        backend._index = IVFPQSnapIndex.load(path)
-        backend._fitted = True
+        backend = cls(
+            dim=dim,
+            nlist=nlist,
+            M=M,
+            K=K,
+            seed=seed,
+            keep_full_precision=keep_full_precision,
+            rerank_candidates=rerank_candidates,
+            nprobe=nprobe,
+        )
+        if Path(path).exists():
+            backend._index = IVFPQSnapIndex.load(path)
+            backend._fitted = True
         return backend

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -144,6 +144,11 @@ def _get_store(
         embedding_dim=dim,
         vector_backend=cfg.storage.vector_backend,
         snapvec_bits=cfg.storage.snapvec_bits,
+        ivfpq_nlist=cfg.storage.ivfpq_nlist,
+        ivfpq_M=cfg.storage.ivfpq_M,
+        ivfpq_K=cfg.storage.ivfpq_K,
+        ivfpq_rerank_candidates=cfg.storage.ivfpq_rerank_candidates,
+        ivfpq_nprobe=cfg.storage.ivfpq_nprobe,
     )
     return cfg, store
 
@@ -1569,6 +1574,50 @@ def profile_active(ctx: typer.Context) -> None:
 # ------------------------------------------------------------------ #
 # vstash journal                                                       #
 # ------------------------------------------------------------------ #
+
+snapvec_app = typer.Typer(
+    name="snapvec",
+    help="Manage the snapvec vector backend (IVFPQ index training).",
+    no_args_is_help=True,
+    add_completion=False,
+    rich_markup_mode="rich",
+)
+app.add_typer(snapvec_app, name="snapvec")
+
+
+@snapvec_app.command(name="fit")
+def snapvec_fit(
+    ctx: typer.Context,
+    training_sample: int = typer.Option(
+        50_000,
+        "--training-sample",
+        help="Vectors sampled for IVFPQ codebook training (FAISS rule: >=30 * nlist)",
+    ),
+) -> None:
+    """Train and persist the IVFPQ index from the current corpus.
+
+    Requires ``storage.vector_backend = 'snapvec-ivfpq'`` in vstash.toml.
+    Reads every embedding out of vec_chunks, fits the IVF coarse centroids
+    + residual PQ codebooks, indexes all rows, and saves the ``.snpi``
+    file next to the database. After this completes, searches route
+    through the IVFPQ backend with fp16 rerank.
+    """
+    _, store = _get_store(profile=_profile_from_ctx(ctx))
+    try:
+        stats = store.fit_ivfpq(training_sample=training_sample)
+    except RuntimeError as exc:
+        console.print(f"[red]x[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"[green]+[/green] IVFPQ index fit: "
+        f"{stats['n_indexed']} vectors indexed, "
+        f"nlist={stats['nlist']}, "
+        f"training_sample={stats['training_sample']}, "
+        f"build={stats['build_seconds']}s"
+    )
+    console.print(f"  saved to [dim]{stats['path']}[/dim]")
+
 
 journal_app = typer.Typer(
     name="journal",

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1606,7 +1606,7 @@ def snapvec_fit(
     try:
         stats = store.fit_ivfpq(training_sample=training_sample)
     except RuntimeError as exc:
-        console.print(f"[red]x[/red] {exc}")
+        console.print(f"[red]x[/red] {_safe_exc(exc)}")
         raise typer.Exit(code=1) from exc
 
     console.print(

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -132,15 +132,54 @@ class StorageConfig(BaseModel):
         default_factory=lambda: os.getenv("VSTASH_DB_PATH") or "~/.vstash/memory.db",
         description="Path to SQLite database file",
     )
-    vector_backend: Literal["sqlite-vec", "snapvec"] = Field(
+    vector_backend: Literal["sqlite-vec", "snapvec", "snapvec-ivfpq"] = Field(
         default="sqlite-vec",
-        description="Vector search backend: 'sqlite-vec' (default) or 'snapvec' (compressed ANN)",
+        description=(
+            "Vector search backend: 'sqlite-vec' (default, exact), "
+            "'snapvec' (flat compressed ANN), "
+            "'snapvec-ivfpq' (IVF + residual PQ with fp16 rerank, >=50K chunks)"
+        ),
     )
     snapvec_bits: int = Field(
         default=4,
         ge=2,
         le=4,
-        description="Quantization bits for snapvec backend (2, 3, or 4)",
+        description="Quantization bits for snapvec flat backend (2, 3, or 4)",
+    )
+    ivfpq_nlist: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "IVF coarse clusters for snapvec-ivfpq. 0 = auto (4 * sqrt(N)). "
+            "FAISS rule: need at least 30 training vectors per cluster."
+        ),
+    )
+    ivfpq_M: int = Field(
+        default=96,
+        ge=1,
+        description="PQ subspaces for snapvec-ivfpq. Must divide embedding_dim.",
+    )
+    ivfpq_K: int = Field(
+        default=256,
+        ge=2,
+        le=256,
+        description="PQ centroids per subspace for snapvec-ivfpq.",
+    )
+    ivfpq_rerank_candidates: int = Field(
+        default=100,
+        ge=0,
+        description=(
+            "Candidates to rerank with fp16 full-precision cache for "
+            "snapvec-ivfpq. 0 disables rerank; 100 typically saturates recall."
+        ),
+    )
+    ivfpq_nprobe: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Clusters to visit per query. 0 = snapvec default (nlist // 16). "
+            "Higher = better recall at linear latency cost."
+        ),
     )
 
 

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from types import TracebackType
-from typing import Literal
+from typing import Any, Literal
 
 import threading
 
@@ -261,6 +261,11 @@ class VstashStore:
         embedding_dim: int = 384,
         vector_backend: str = "sqlite-vec",
         snapvec_bits: int = 4,
+        ivfpq_nlist: int = 0,
+        ivfpq_M: int = 96,
+        ivfpq_K: int = 256,
+        ivfpq_rerank_candidates: int = 100,
+        ivfpq_nprobe: int = 0,
         observability: ObservabilityConfig | None = None,
         limits: LimitsConfig | None = None,
     ) -> None:
@@ -302,17 +307,152 @@ class VstashStore:
         self._limits: LimitsConfig = limits or LimitsConfig()
 
         # --- SnapVec backend (optional) ---
-        self._snap: SnapIndex | None = None  # type: ignore[name-defined]
+        self._snap: Any = None
         self._vector_backend = vector_backend
         self._snapvec_bits = snapvec_bits
+        self._ivfpq_nlist = ivfpq_nlist
+        self._ivfpq_M = ivfpq_M
+        self._ivfpq_K = ivfpq_K
+        self._ivfpq_rerank_candidates = ivfpq_rerank_candidates
+        self._ivfpq_nprobe = ivfpq_nprobe
         self._snap_dirty = False
         if vector_backend == "snapvec":
             self._init_snapvec()
+        elif vector_backend == "snapvec-ivfpq":
+            self._init_ivfpq()
 
     @property
     def _snapvec_path(self) -> Path:
-        """Path to the snapvec index file (next to the .db file)."""
+        """Path to the flat snapvec index file (next to the .db file)."""
         return self.db_path.with_suffix(".snpv")
+
+    @property
+    def _ivfpq_path(self) -> Path:
+        """Path to the IVFPQ snapvec index file (next to the .db file)."""
+        return self.db_path.with_suffix(".snpi")
+
+    def _init_ivfpq(self) -> None:
+        """Load or create the IVFPQ backend.
+
+        The backend starts unfit; sqlite-vec remains authoritative until
+        ``fit_ivfpq()`` trains on the corpus. After that, searches prefer
+        the IVFPQ path and new adds append directly.
+        """
+        if not _HAS_SNAPVEC:
+            logger.warning(
+                "snapvec-ivfpq backend requested but snapvec is not installed. "
+                "Install with: pip install vstash[snapvec]. Falling back to sqlite-vec."
+            )
+            self._vector_backend = "sqlite-vec"
+            return
+
+        from ._ivfpq_backend import IVFPQBackend
+
+        nlist = self._ivfpq_nlist or self._derive_nlist()
+        try:
+            self._snap = IVFPQBackend.load(
+                str(self._ivfpq_path),
+                dim=self.embedding_dim,
+                nlist=nlist,
+                M=self._ivfpq_M,
+                K=self._ivfpq_K,
+                keep_full_precision=True,
+                rerank_candidates=self._ivfpq_rerank_candidates,
+                nprobe=self._ivfpq_nprobe,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to load IVFPQ index at %s — starting unfitted. "
+                "Run 'vstash snapvec fit' to train from current vec_chunks.",
+                self._ivfpq_path,
+                exc_info=True,
+            )
+            self._snap = IVFPQBackend(
+                dim=self.embedding_dim,
+                nlist=nlist,
+                M=self._ivfpq_M,
+                K=self._ivfpq_K,
+                keep_full_precision=True,
+                rerank_candidates=self._ivfpq_rerank_candidates,
+                nprobe=self._ivfpq_nprobe,
+            )
+
+    def _derive_nlist(self) -> int:
+        """Pick a default nlist from current corpus size.
+
+        FAISS rule of thumb: 4 * sqrt(N) coarse clusters, minimum 8.
+        Clamped to 1024 to keep search LUT builds quick.
+        """
+        import math
+
+        n = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        if n <= 0:
+            return 256  # placeholder; real nlist is derived at fit() time
+        return max(8, min(1024, int(4 * math.sqrt(n))))
+
+    def fit_ivfpq(self, *, training_sample: int = 50_000) -> dict[str, Any]:
+        """Train the IVFPQ backend on current vec_chunks and index all rows.
+
+        Requires ``vector_backend='snapvec-ivfpq'``. Reads every
+        ``(rowid, embedding)`` out of vec_chunks, samples up to
+        ``training_sample`` for fit(), calls add_batch on the full set,
+        and persists the index.
+
+        Returns a dict with stats (n_indexed, nlist, training_sample,
+        build_seconds).
+        """
+        if self._vector_backend != "snapvec-ivfpq":
+            raise RuntimeError(
+                f"fit_ivfpq requires vector_backend='snapvec-ivfpq'; "
+                f"current backend is {self._vector_backend!r}"
+            )
+        from ._ivfpq_backend import IVFPQBackend
+
+        import numpy as np
+        import time as _time
+
+        rows = self._conn.execute(
+            "SELECT rowid, embedding FROM vec_chunks"
+        ).fetchall()
+        if not rows:
+            raise RuntimeError("vec_chunks is empty; ingest data before fit_ivfpq")
+        ids: list[int] = []
+        vecs: list[list[float]] = []
+        for r in rows:
+            ids.append(int(r["rowid"]))
+            vecs.append(_deserialize(bytes(r["embedding"])))
+        matrix = np.asarray(vecs, dtype=np.float32)
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        matrix = matrix / np.where(norms > 1e-9, norms, 1.0)
+
+        nlist = self._ivfpq_nlist or max(8, min(1024, int(4 * np.sqrt(len(ids)))))
+        t0 = _time.perf_counter()
+        self._snap = IVFPQBackend(
+            dim=self.embedding_dim,
+            nlist=nlist,
+            M=self._ivfpq_M,
+            K=self._ivfpq_K,
+            keep_full_precision=True,
+            rerank_candidates=self._ivfpq_rerank_candidates,
+            nprobe=self._ivfpq_nprobe,
+        )
+        if len(matrix) <= training_sample:
+            sample = matrix
+        else:
+            rng = np.random.default_rng(0)
+            sel = rng.choice(len(matrix), size=training_sample, replace=False)
+            sample = matrix[sel]
+        self._snap.fit(sample)
+        self._snap.add_batch(ids, matrix)
+        self._snap.save(str(self._ivfpq_path))
+        build_s = _time.perf_counter() - t0
+        return {
+            "n_indexed": len(ids),
+            "nlist": nlist,
+            "training_sample": len(sample),
+            "build_seconds": round(build_s, 2),
+            "path": str(self._ivfpq_path),
+        }
 
     def _init_snapvec(self) -> None:
         """Load or create the SnapIndex for the snapvec backend."""
@@ -350,18 +490,33 @@ class VstashStore:
             self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
 
     def _save_snapvec(self) -> None:
-        """Persist the SnapIndex to disk. Called after successful SQLite commit."""
-        if self._snap is not None:
-            self._snap.save(str(self._snapvec_path))
-            self._snap_dirty = False
+        """Persist the snapvec index to disk. Called after successful SQLite commit.
+
+        IVFPQBackend.save is a no-op before fit, so pre-fit mutations stay
+        in sqlite-vec (the authoritative source until fit_ivfpq runs).
+        """
+        if self._snap is None:
+            return
+        target = (
+            self._ivfpq_path
+            if self._vector_backend == "snapvec-ivfpq"
+            else self._snapvec_path
+        )
+        self._snap.save(str(target))
+        self._snap_dirty = False
 
     def _reload_snapvec(self) -> None:
-        """Reload SnapIndex from disk after a failed transaction.
+        """Reload the snapvec index from disk after a failed transaction.
 
         Restores the on-disk state so the in-memory index matches SQLite
         after a rollback.
         """
         if self._snap is None:
+            return
+        if self._vector_backend == "snapvec-ivfpq":
+            # Re-run the load path used at construction time.
+            self._init_ivfpq()
+            self._snap_dirty = False
             return
         path = self._snapvec_path
         if path.exists():

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -349,17 +349,22 @@ class VstashStore:
         from ._ivfpq_backend import IVFPQBackend
 
         nlist = self._ivfpq_nlist or self._derive_nlist()
+        kwargs = dict(
+            dim=self.embedding_dim,
+            nlist=nlist,
+            M=self._ivfpq_M,
+            K=self._ivfpq_K,
+            keep_full_precision=True,
+            rerank_candidates=self._ivfpq_rerank_candidates,
+            nprobe=self._ivfpq_nprobe,
+        )
         try:
-            self._snap = IVFPQBackend.load(
-                str(self._ivfpq_path),
-                dim=self.embedding_dim,
-                nlist=nlist,
-                M=self._ivfpq_M,
-                K=self._ivfpq_K,
-                keep_full_precision=True,
-                rerank_candidates=self._ivfpq_rerank_candidates,
-                nprobe=self._ivfpq_nprobe,
-            )
+            self._snap = IVFPQBackend.load(str(self._ivfpq_path), **kwargs)
+        except ValueError:
+            # Config error (e.g. ivfpq_M does not divide embedding_dim).
+            # Surface directly so the user gets the real message instead of
+            # the generic "failed to load, run vstash snapvec fit".
+            raise
         except Exception:
             logger.warning(
                 "Failed to load IVFPQ index at %s — starting unfitted. "
@@ -367,28 +372,21 @@ class VstashStore:
                 self._ivfpq_path,
                 exc_info=True,
             )
-            self._snap = IVFPQBackend(
-                dim=self.embedding_dim,
-                nlist=nlist,
-                M=self._ivfpq_M,
-                K=self._ivfpq_K,
-                keep_full_precision=True,
-                rerank_candidates=self._ivfpq_rerank_candidates,
-                nprobe=self._ivfpq_nprobe,
-            )
+            self._snap = IVFPQBackend(**kwargs)
 
-    def _derive_nlist(self) -> int:
-        """Pick a default nlist from current corpus size.
-
-        FAISS rule of thumb: 4 * sqrt(N) coarse clusters, minimum 8.
-        Clamped to 1024 to keep search LUT builds quick.
-        """
+    @staticmethod
+    def _nlist_for(n: int) -> int:
+        """FAISS rule of thumb: 4 * sqrt(N), clamped to [8, 1024]."""
         import math
 
-        n = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
         if n <= 0:
             return 256  # placeholder; real nlist is derived at fit() time
         return max(8, min(1024, int(4 * math.sqrt(n))))
+
+    def _derive_nlist(self) -> int:
+        """Pick a default nlist from the current corpus size."""
+        n = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+        return self._nlist_for(n)
 
     def fit_ivfpq(self, *, training_sample: int = 50_000) -> dict[str, Any]:
         """Train the IVFPQ backend on current vec_chunks and index all rows.
@@ -406,26 +404,30 @@ class VstashStore:
                 f"fit_ivfpq requires vector_backend='snapvec-ivfpq'; "
                 f"current backend is {self._vector_backend!r}"
             )
-        from ._ivfpq_backend import IVFPQBackend
-
-        import numpy as np
         import time as _time
 
-        rows = self._conn.execute(
-            "SELECT rowid, embedding FROM vec_chunks"
-        ).fetchall()
-        if not rows:
-            raise RuntimeError("vec_chunks is empty; ingest data before fit_ivfpq")
-        ids: list[int] = []
-        vecs: list[list[float]] = []
-        for r in rows:
-            ids.append(int(r["rowid"]))
-            vecs.append(_deserialize(bytes(r["embedding"])))
-        matrix = np.asarray(vecs, dtype=np.float32)
-        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
-        matrix = matrix / np.where(norms > 1e-9, norms, 1.0)
+        import numpy as np
 
-        nlist = self._ivfpq_nlist or max(8, min(1024, int(4 * np.sqrt(len(ids)))))
+        from ._ivfpq_backend import IVFPQBackend
+
+        # Stream vec_chunks into a pre-allocated float32 matrix so peak
+        # memory stays bounded at ~N * dim * 4 bytes (e.g. ~150 MB at
+        # 100K x 384) instead of exploding via fetchall + list-of-lists.
+        n_rows = self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0]
+        if not n_rows:
+            raise RuntimeError("vec_chunks is empty; ingest data before fit_ivfpq")
+        ids = np.empty(n_rows, dtype=np.int64)
+        matrix = np.empty((n_rows, self.embedding_dim), dtype=np.float32)
+        cursor = self._conn.execute("SELECT rowid, embedding FROM vec_chunks")
+        for i, row in enumerate(cursor):
+            ids[i] = int(row["rowid"])
+            matrix[i] = np.frombuffer(row["embedding"], dtype=np.float32)
+        # IVFPQBackend normalizes internally, but the coarse k-means for
+        # training benefits from pre-normalized input too.
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        matrix /= np.where(norms > 1e-9, norms, 1.0)
+
+        nlist = self._ivfpq_nlist or self._nlist_for(n_rows)
         t0 = _time.perf_counter()
         self._snap = IVFPQBackend(
             dim=self.embedding_dim,
@@ -436,20 +438,20 @@ class VstashStore:
             rerank_candidates=self._ivfpq_rerank_candidates,
             nprobe=self._ivfpq_nprobe,
         )
-        if len(matrix) <= training_sample:
+        if n_rows <= training_sample:
             sample = matrix
         else:
             rng = np.random.default_rng(0)
-            sel = rng.choice(len(matrix), size=training_sample, replace=False)
+            sel = rng.choice(n_rows, size=training_sample, replace=False)
             sample = matrix[sel]
         self._snap.fit(sample)
-        self._snap.add_batch(ids, matrix)
+        self._snap.add_batch(ids.tolist(), matrix)
         self._snap.save(str(self._ivfpq_path))
         build_s = _time.perf_counter() - t0
         return {
-            "n_indexed": len(ids),
+            "n_indexed": int(n_rows),
             "nlist": nlist,
-            "training_sample": len(sample),
+            "training_sample": int(len(sample)),
             "build_seconds": round(build_s, 2),
             "path": str(self._ivfpq_path),
         }
@@ -492,10 +494,27 @@ class VstashStore:
     def _save_snapvec(self) -> None:
         """Persist the snapvec index to disk. Called after successful SQLite commit.
 
-        IVFPQBackend.save is a no-op before fit, so pre-fit mutations stay
-        in sqlite-vec (the authoritative source until fit_ivfpq runs).
+        Flat SnapIndex is small and cheap to rewrite on every commit.
+        IVFPQ with keep_full_precision=True can be 80+ MB at 100K
+        vectors — rewriting on each add_document would thrash disk.
+        For IVFPQ we mark the index dirty in memory and flush on
+        ``close()`` (or on an explicit checkpoint). SQLite's vec_chunks
+        stays the source of truth, so a crash at worst loses the most
+        recent post-fit adds and the operator can re-run
+        ``vstash snapvec fit`` to rebuild.
         """
         if self._snap is None:
+            return
+        if self._vector_backend == "snapvec-ivfpq":
+            # Defer to close() / explicit checkpoint.
+            self._snap_dirty = True
+            return
+        self._snap.save(str(self._snapvec_path))
+        self._snap_dirty = False
+
+    def _checkpoint_snapvec(self) -> None:
+        """Flush the in-memory snapvec index to disk if dirty."""
+        if self._snap is None or not self._snap_dirty:
             return
         target = (
             self._ivfpq_path
@@ -3834,6 +3853,13 @@ class VstashStore:
         multi-threaded server like ``vstash serve`` or the MCP server.
         """
         import contextlib
+
+        # Flush any pending snapvec writes before tearing down.  For the
+        # flat backend this is usually a no-op (_save_snapvec already ran
+        # on every commit); for snapvec-ivfpq it is the primary save
+        # point, so the IVFPQ file only hits disk once per session.
+        with contextlib.suppress(Exception):
+            self._checkpoint_snapvec()
 
         # Close all per-thread stem connections under the lock so we
         # don't race a worker thread that's just creating a new one.


### PR DESCRIPTION
Re-opens #208 on \`develop\` after #207 was squash-merged and deleted the stacked base branch.

## Summary

Adds \`vector_backend = \"snapvec-ivfpq\"\` that routes searches through \`IVFPQSnapIndex\` with \`keep_full_precision=True\` + \`rerank_candidates=100\`. **23x faster than sqlite-vec at N=100K with -0.4% recall and 43% less disk** (benchmark in #207).

## Design

sqlite-vec stays authoritative until the index is trained. Ingest populates \`vec_chunks\`; the IVFPQ adapter drops pre-fit \`add_batch\` calls. New CLI \`vstash snapvec fit\` reads \`vec_chunks\`, trains codebooks on a sample, indexes everything, saves \`.snpi\`. Post-fit, searches prefer IVFPQ + fp16 rerank and adds forward directly.

## Review comments applied (from #208)

All 9 review comments from Gemini + Copilot already applied:
- Adapter L2-normalizes at fit/add/search (IVFPQ runs \`normalized=True\`)
- \`fit_ivfpq\` streams \`vec_chunks\` via \`np.frombuffer\` (bounded memory)
- IVFPQ save debounced to \`close()\` (avoids rewriting 80+ MB per add)
- \`.fitted\` sidecar removed — \`.snpi\` existence is authoritative
- Config errors (\`ivfpq_M\` not dividing \`embedding_dim\`) surface directly
- \`_safe_exc\` on CLI errors
- Shared \`_nlist_for(n)\` helper
- \`load()\` uses constructor instead of \`cls.__new__\`

## Test plan

- [x] \`pytest tests/test_snapvec_ivfpq_backend.py\` — 13 passed
- [x] Full fast suite: 731 passed
- [x] \`ruff check\`