### PR TITLE
Release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to vstash are documented here.
 ### Added
 
 - **Query LRU cache** for `VstashStore.search()`. Opt-in via `[cache] query_cache_size` in `vstash.toml` (default 0 = disabled). Repeated identical queries return from an in-memory LRU cache. Automatically invalidated on any write (add, delete, reindex). Skipped for `explain=True` and `miss_analysis()`. Benchmark shows ~700x speedup on cache hits for repeated queries.
+- **Deferred FTS indexing** in `batch_mode(defer_fts=True)`. FTS5 inserts are collected in memory during batch operations and flushed in a single bulk pass on exit.
+
+### Changed
+
+- **`ingest_directory` now uses batched store writes.** Files are prepared (parse + chunk + embed) individually, then stored via `add_documents_batch` in a single transaction with deferred FTS. Combined speedup: **5x** at 500 docs versus the old per-file `add_document` loop.
 
 ## [0.30.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to vstash are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **Query LRU cache** for `VstashStore.search()`. Opt-in via `[cache] query_cache_size` in `vstash.toml` (default 0 = disabled). Repeated identical queries return from an in-memory LRU cache. Automatically invalidated on any write (add, delete, reindex). Skipped for `explain=True` and `miss_analysis()`. Benchmark shows ~700x speedup on cache hits for repeated queries.
+
 ## [0.30.0] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to vstash are documented here.
 
-## [Unreleased]
+## [0.31.0] - 2026-04-16
 
 ### Added
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -189,6 +189,21 @@ vector_backend = "sqlite-vec"  # or "snapvec" for compressed ANN
 
 ---
 
+## `[cache]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `query_cache_size` | int | `0` | Maximum cached query results (LRU). 0 = disabled. |
+
+```toml
+[cache]
+query_cache_size = 128  # cache up to 128 unique queries in memory
+```
+
+When enabled, repeated identical searches return instantly from an in-memory LRU cache. The cache is automatically invalidated whenever the corpus changes (add, delete, reindex). Disabled by default so search side effects (access tracking, explain) are never suppressed unless the caller opts in. The cache is skipped for `explain=True` and `miss_analysis()` calls.
+
+---
+
 ## Environment Variables
 
 | Variable | Purpose |

--- a/experiments/deferred_fts_bench.py
+++ b/experiments/deferred_fts_bench.py
@@ -1,0 +1,67 @@
+"""Benchmark: deferred FTS indexing vs immediate FTS during batch ingest.
+
+Measures ingest latency for N documents with and without defer_fts=True.
+Run: python -m experiments.deferred_fts_bench
+"""
+
+from __future__ import annotations
+
+import statistics
+import tempfile
+import time
+
+from vstash.embed import embed_texts, get_embedding_dim
+from vstash.store import VstashStore
+
+
+def _make_docs(n: int, dim: int, embeddings: list[list[float]]):
+    return [
+        {
+            "path": f"/bench/doc_{i}.md",
+            "title": f"Document {i}",
+            "chunks": [f"This is the content of document number {i} about topic {i % 10}."],
+            "embeddings": [embeddings[i % len(embeddings)]],
+            "source_type": "markdown",
+        }
+        for i in range(n)
+    ]
+
+
+def _bench_ingest(label: str, n: int, dim: int, docs: list, defer_fts: bool, rounds: int = 3):
+    latencies = []
+    for _ in range(rounds):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = VstashStore(f"{tmpdir}/bench.db", embedding_dim=dim)
+            t0 = time.perf_counter()
+            with store.batch_mode(defer_fts=defer_fts):
+                for doc in docs:
+                    store.add_document(
+                        path=doc["path"],
+                        title=doc["title"],
+                        chunks=doc["chunks"],
+                        embeddings=doc["embeddings"],
+                    )
+            elapsed = (time.perf_counter() - t0) * 1000
+            latencies.append(elapsed)
+            store.close()
+    p50 = statistics.median(latencies)
+    print(f"  {label:30s}  p50={p50:8.1f}ms  (n={n}, rounds={rounds})")
+    return p50
+
+
+def main():
+    dim = get_embedding_dim("BAAI/bge-small-en-v1.5")
+    seed_texts = [f"sample text for embedding {i}" for i in range(10)]
+    embeddings = embed_texts(seed_texts, model_name="BAAI/bge-small-en-v1.5")
+
+    for n in [50, 200, 500]:
+        docs = _make_docs(n, dim, embeddings)
+        print(f"\nBatch ingest: {n} documents (1 chunk each)")
+        p50_imm = _bench_ingest("immediate FTS", n, dim, docs, defer_fts=False)
+        p50_def = _bench_ingest("deferred FTS", n, dim, docs, defer_fts=True)
+        speedup = p50_imm / p50_def if p50_def > 0 else float("inf")
+        print(f"  {'speedup':30s}  {speedup:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/query_cache_bench.py
+++ b/experiments/query_cache_bench.py
@@ -1,0 +1,70 @@
+"""Benchmark: query LRU cache hit vs cold search latency.
+
+Measures repeated-query speedup when cache is enabled vs disabled.
+Run: python -m experiments.query_cache_bench
+"""
+
+from __future__ import annotations
+
+import statistics
+import tempfile
+import time
+
+from vstash.config import CacheConfig
+from vstash.embed import embed_texts, get_embedding_dim
+from vstash.store import VstashStore
+
+
+def _bench(label: str, store: VstashStore, q_emb: list[float], q_text: str, rounds: int = 50):
+    latencies = []
+    for _ in range(rounds):
+        t0 = time.perf_counter()
+        store.search(q_emb, q_text, top_k=5)
+        latencies.append((time.perf_counter() - t0) * 1000)
+    p50 = statistics.median(latencies)
+    p99 = sorted(latencies)[int(len(latencies) * 0.99)]
+    print(f"  {label:20s}  p50={p50:7.2f}ms  p99={p99:7.2f}ms  (n={rounds})")
+    return p50
+
+
+def main():
+    dim = get_embedding_dim("BAAI/bge-small-en-v1.5")
+    chunks = [
+        "Python is a high-level programming language known for readability.",
+        "Machine learning models require training data and compute.",
+        "SQLite is a lightweight embedded database engine.",
+        "Reciprocal Rank Fusion combines ranked lists from multiple retrievers.",
+        "Vector embeddings capture semantic meaning in dense float arrays.",
+    ] * 20  # 100 chunks
+
+    embeddings = embed_texts(chunks, model_name="BAAI/bge-small-en-v1.5")
+    q_emb = embed_texts(["python programming language"], model_name="BAAI/bge-small-en-v1.5")[0]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Without cache
+        db_no_cache = f"{tmpdir}/no_cache.db"
+        store_nc = VstashStore(db_no_cache, embedding_dim=dim, cache=CacheConfig(query_cache_size=0))
+        store_nc.add_document(
+            path="/bench/corpus.md", title="Corpus", chunks=chunks, embeddings=embeddings
+        )
+        print("Repeated query (100 chunks, 50 rounds):")
+        p50_cold = _bench("no cache", store_nc, q_emb, "python programming language")
+        store_nc.close()
+
+        # With cache
+        db_cache = f"{tmpdir}/cache.db"
+        store_c = VstashStore(db_cache, embedding_dim=dim, cache=CacheConfig(query_cache_size=128))
+        store_c.add_document(
+            path="/bench/corpus.md", title="Corpus", chunks=chunks, embeddings=embeddings
+        )
+        # Warm the cache with one search
+        store_c.search(q_emb, "python programming language", top_k=5)
+        p50_hot = _bench("cache (hot)", store_c, q_emb, "python programming language")
+        store_c.close()
+
+        speedup = p50_cold / p50_hot if p50_hot > 0 else float("inf")
+        print(f"\n  Speedup: {speedup:.1f}x (p50 cold/hot)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deferred_fts.py
+++ b/tests/test_deferred_fts.py
@@ -1,0 +1,153 @@
+"""Tests for deferred FTS indexing in batch_mode."""
+
+from __future__ import annotations
+
+import pytest
+
+from vstash.store import VstashStore
+
+from .conftest import requires_sqlite_vec
+
+
+@requires_sqlite_vec
+class TestDeferredFTS:
+    """Deferred FTS indexing: correctness, flush, and edge cases."""
+
+    @pytest.fixture
+    def store(self, tmp_db_path: str) -> VstashStore:
+        dim = 384
+        s = VstashStore(tmp_db_path, embedding_dim=dim)
+        yield s
+        s.close()
+
+    def _add_doc(self, store: VstashStore, path: str, text: str) -> str:
+        dim = store.embedding_dim
+        return store.add_document(
+            path=path,
+            title=path,
+            chunks=[text],
+            embeddings=[[0.1] * dim],
+        )
+
+    def _fts_has_terms(self, store: VstashStore) -> bool:
+        """Check if FTS5 index has any indexed terms."""
+        return store._conn.execute("SELECT COUNT(*) FROM fts_chunks_vocab").fetchone()[0] > 0
+
+    def _fts_match(self, store: VstashStore, term: str) -> int:
+        """Count FTS MATCH results for a term."""
+        safe = '"' + term.replace('"', '""') + '"'
+        try:
+            return len(
+                store._conn.execute(
+                    "SELECT rowid FROM fts_chunks WHERE fts_chunks MATCH ?",
+                    [safe],
+                ).fetchall()
+            )
+        except Exception:
+            return 0
+
+    def test_defer_fts_skips_inserts_during_batch(self, store: VstashStore):
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/a.md", "alpha bravo charlie")
+            assert not self._fts_has_terms(store)
+            assert len(store._deferred_fts_rows) == 1
+
+    def test_defer_fts_flushes_on_exit(self, store: VstashStore):
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/a.md", "alpha bravo charlie")
+            self._add_doc(store, "/b.md", "delta echo foxtrot")
+        assert self._fts_has_terms(store)
+        assert len(store._deferred_fts_rows) == 0
+
+    def test_fts_search_works_after_flush(self, store: VstashStore):
+        dim = store.embedding_dim
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/a.md", "quantum entanglement physics")
+            self._add_doc(store, "/b.md", "classical mechanics newton")
+
+        results = store.search([0.1] * dim, "quantum", top_k=5)
+        texts = [r.text for r in results]
+        assert any("quantum" in t for t in texts)
+
+    def test_no_defer_still_inserts_immediately(self, store: VstashStore):
+        with store.batch_mode(defer_fts=False):
+            self._add_doc(store, "/a.md", "immediate fts insert")
+            assert self._fts_has_terms(store)
+
+    def test_default_batch_mode_no_defer(self, store: VstashStore):
+        with store.batch_mode():
+            self._add_doc(store, "/a.md", "immediate fts insert")
+            assert self._fts_has_terms(store)
+
+    def test_add_documents_batch_with_defer(self, store: VstashStore):
+        dim = store.embedding_dim
+        docs = [
+            {
+                "path": f"/doc{i}.md",
+                "title": f"Doc {i}",
+                "chunks": [f"content for document {i} xyzzy"],
+                "embeddings": [[0.1 * (i + 1)] * dim],
+                "source_type": "markdown",
+            }
+            for i in range(5)
+        ]
+        with store.batch_mode(defer_fts=True):
+            store.add_documents_batch(docs)
+            assert not self._fts_has_terms(store)
+        assert self._fts_match(store, "xyzzy") == 5
+
+    def test_mixed_add_and_batch_with_defer(self, store: VstashStore):
+        dim = store.embedding_dim
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/single.md", "single doc add foobar")
+            store.add_documents_batch(
+                [
+                    {
+                        "path": "/batch1.md",
+                        "title": "Batch 1",
+                        "chunks": ["batch content one foobar"],
+                        "embeddings": [[0.2] * dim],
+                        "source_type": "markdown",
+                    },
+                    {
+                        "path": "/batch2.md",
+                        "title": "Batch 2",
+                        "chunks": ["batch content two foobar"],
+                        "embeddings": [[0.3] * dim],
+                        "source_type": "markdown",
+                    },
+                ]
+            )
+            assert not self._fts_has_terms(store)
+        assert self._fts_match(store, "foobar") == 3
+
+    def test_nested_batch_flushes_at_outermost(self, store: VstashStore):
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/outer.md", "outer document")
+            with store.batch_mode(defer_fts=True):
+                self._add_doc(store, "/inner.md", "inner document")
+            assert not self._fts_has_terms(store)
+        assert self._fts_has_terms(store)
+
+    def test_large_batch_deferred(self, store: VstashStore):
+        n = 50
+        with store.batch_mode(defer_fts=True):
+            for i in range(n):
+                self._add_doc(store, f"/doc{i}.md", f"document number {i} zztoken")
+        assert self._fts_match(store, "zztoken") == n
+
+    def test_error_during_batch_still_flushes(self, store: VstashStore):
+        try:
+            with store.batch_mode(defer_fts=True):
+                self._add_doc(store, "/ok.md", "this is fine xqtoken")
+                raise RuntimeError("simulated failure")
+        except RuntimeError:
+            pass
+        assert self._fts_match(store, "xqtoken") == 1
+        assert len(store._deferred_fts_rows) == 0
+
+    def test_fts_not_searchable_during_defer(self, store: VstashStore):
+        with store.batch_mode(defer_fts=True):
+            self._add_doc(store, "/a.md", "uniquetoken12345")
+            assert self._fts_match(store, "uniquetoken12345") == 0
+        assert self._fts_match(store, "uniquetoken12345") == 1

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -1,0 +1,190 @@
+"""Tests for query result LRU cache in VstashStore."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from vstash.config import CacheConfig
+from vstash.store import VstashStore
+
+from .conftest import requires_sqlite_vec
+
+
+@requires_sqlite_vec
+class TestQueryCache:
+    """Query LRU cache: hit, miss, invalidation, opt-out."""
+
+    @pytest.fixture
+    def cached_store(self, tmp_db_path: str) -> VstashStore:
+        dim = 384
+        store = VstashStore(
+            tmp_db_path,
+            embedding_dim=dim,
+            cache=CacheConfig(query_cache_size=8),
+        )
+        chunks = [
+            "Python is a high-level programming language.",
+            "Machine learning uses neural networks.",
+        ]
+        embeddings = [[0.1] * dim, [0.3] * dim]
+        store.add_document(
+            path="/test/doc.md",
+            title="Test Doc",
+            chunks=chunks,
+            embeddings=embeddings,
+        )
+        yield store
+        store.close()
+
+    def test_cache_hit_returns_same_results(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        r1 = cached_store.search(q_emb, "python", top_k=2)
+        r2 = cached_store.search(q_emb, "python", top_k=2)
+        assert len(r1) > 0
+        assert [r.chunk_id for r in r1] == [r.chunk_id for r in r2]
+
+    def test_cache_hit_returns_copy(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        r1 = cached_store.search(q_emb, "python", top_k=2)
+        r2 = cached_store.search(q_emb, "python", top_k=2)
+        assert r1 is not r2
+
+    def test_cache_miss_on_different_query(self, cached_store: VstashStore):
+        dim = cached_store.embedding_dim
+        r1 = cached_store.search([0.1] * dim, "python", top_k=2)
+        r2 = cached_store.search([0.3] * dim, "neural", top_k=2)
+        assert [r.chunk_id for r in r1] != [r.chunk_id for r in r2]
+
+    def test_cache_invalidated_on_add(self, cached_store: VstashStore):
+        dim = cached_store.embedding_dim
+        q_emb = [0.1] * dim
+        cached_store.search(q_emb, "python", top_k=5)
+        epoch_before = cached_store._cache_epoch
+
+        cached_store.add_document(
+            path="/test/new.md",
+            title="New",
+            chunks=["Python decorators are powerful."],
+            embeddings=[[0.1] * dim],
+        )
+
+        assert cached_store._cache_epoch == epoch_before + 1
+        assert len(cached_store._query_cache) == 0
+
+    def test_cache_invalidated_on_delete(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        cached_store.search(q_emb, "python", top_k=2)
+        assert len(cached_store._query_cache) == 1
+
+        cached_store.delete_document("/test/doc.md")
+        assert len(cached_store._query_cache) == 0
+
+    def test_cache_disabled_when_size_zero(self, tmp_db_path: str):
+        dim = 384
+        store = VstashStore(
+            tmp_db_path,
+            embedding_dim=dim,
+            cache=CacheConfig(query_cache_size=0),
+        )
+        store.add_document(
+            path="/test/doc.md",
+            title="Test",
+            chunks=["hello world"],
+            embeddings=[[0.1] * dim],
+        )
+        store.search([0.1] * dim, "hello", top_k=2)
+        assert len(store._query_cache) == 0
+        store.close()
+
+    def test_cache_disabled_by_default(self, tmp_db_path: str):
+        dim = 384
+        store = VstashStore(tmp_db_path, embedding_dim=dim)
+        assert store._cache_config.query_cache_size == 0
+        store.close()
+
+    def test_cache_skipped_with_explain(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        cached_store.search(q_emb, "python", top_k=2, explain=True)
+        assert len(cached_store._query_cache) == 0
+
+    def test_lru_eviction(self, tmp_db_path: str):
+        dim = 384
+        store = VstashStore(
+            tmp_db_path,
+            embedding_dim=dim,
+            cache=CacheConfig(query_cache_size=2),
+        )
+        store.add_document(
+            path="/test/doc.md",
+            title="Test",
+            chunks=["hello world"],
+            embeddings=[[0.1] * dim],
+        )
+        store.search([0.1] * dim, "a", top_k=1)
+        store.search([0.2] * dim, "b", top_k=1)
+        store.search([0.3] * dim, "c", top_k=1)
+        assert len(store._query_cache) == 2
+        store.close()
+
+    def test_different_params_different_cache_entries(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        cached_store.search(q_emb, "python", top_k=2)
+        cached_store.search(q_emb, "python", top_k=5)
+        assert len(cached_store._query_cache) == 2
+
+    def test_cache_respects_collection_filter(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        r1 = cached_store.search(q_emb, "python", top_k=2)
+        r2 = cached_store.search(q_emb, "python", top_k=2, collection="nonexistent")
+        ids_1 = [r.chunk_id for r in r1]
+        ids_2 = [r.chunk_id for r in r2]
+        assert ids_1 != ids_2 or (len(r1) > 0 and len(r2) == 0)
+
+    def test_integrity_repair_invalidates_cache(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        cached_store.search(q_emb, "python", top_k=2)
+        assert len(cached_store._query_cache) == 1
+
+        cached_store.integrity_repair()
+        assert len(cached_store._query_cache) == 0
+
+    def test_concurrent_cache_access(self, cached_store: VstashStore):
+        q_emb = [0.1] * cached_store.embedding_dim
+        # Warm cache with a cold search first so all threads hit the cache
+        r0 = cached_store.search(q_emb, "python", top_k=2)
+        assert len(r0) > 0
+
+        def do_search(_i: int):
+            return cached_store.search(q_emb, "python", top_k=2)
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(do_search, i) for i in range(20)]
+            results = [f.result() for f in futures]
+
+        assert all(len(r) > 0 for r in results)
+        ids = [r[0].chunk_id for r in results]
+        assert len(set(ids)) == 1
+
+    def test_exception_does_not_cache_partial_result(self, tmp_db_path: str):
+        dim = 384
+        store = VstashStore(
+            tmp_db_path,
+            embedding_dim=dim,
+            cache=CacheConfig(query_cache_size=8),
+        )
+        store.add_document(
+            path="/test/doc.md",
+            title="Test",
+            chunks=["hello world"],
+            embeddings=[[0.1] * dim],
+        )
+        # Corrupt chunks table to force an error mid-search
+        store._conn.execute("DROP TABLE chunks")
+        try:
+            store.search([0.1] * dim, "hello", top_k=2)
+        except Exception:
+            pass
+        assert len(store._query_cache) == 0
+        store.close()

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,6 +1,6 @@
 """vstash — local document memory with instant semantic search."""
 
-__version__ = "0.30.0"
+__version__ = "0.31.0"
 
 from .memory import Memory
 from .models import ChunkInfo, DocumentInfo, ExplainInfo, IngestResult, SearchResult, StoreStats

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -149,6 +149,7 @@ def _get_store(
         ivfpq_K=cfg.storage.ivfpq_K,
         ivfpq_rerank_candidates=cfg.storage.ivfpq_rerank_candidates,
         ivfpq_nprobe=cfg.storage.ivfpq_nprobe,
+        cache=cfg.cache,
     )
     return cfg, store
 
@@ -1198,6 +1199,7 @@ def reindex(
         embedding_dim=current_dim,
         vector_backend=cfg.storage.vector_backend,
         snapvec_bits=cfg.storage.snapvec_bits,
+        cache=cfg.cache,
     )
 
     with store:

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -355,6 +355,22 @@ class LimitsConfig(BaseModel):
     )
 
 
+class CacheConfig(BaseModel):
+    """Query result caching configuration."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query_cache_size: int = Field(
+        default=0,
+        ge=0,
+        le=10_000,
+        description=(
+            "Maximum number of query results to cache in memory (LRU eviction). "
+            "0 = disabled (default). 128-512 is a good range for interactive use."
+        ),
+    )
+
+
 class VstashConfig(BaseModel):
     """Root configuration for vstash.
 
@@ -398,6 +414,7 @@ class VstashConfig(BaseModel):
     recency: RecencyConfig = Field(default_factory=RecencyConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     limits: LimitsConfig = Field(default_factory=LimitsConfig)
+    cache: CacheConfig = Field(default_factory=CacheConfig)
 
     @property
     def cerebras_api_key(self) -> str:

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -27,8 +27,27 @@ from rich.progress import (
 
 from .config import EXCLUDED_DIRS, MAX_DIR_BYTES, MAX_DIR_FILES, SUPPORTED_EXTENSIONS, VstashConfig
 from .embed import embed_texts
+from typing import TypedDict
+
 from .models import IngestResult
 from .store import VstashStore
+
+
+class _PreparedDoc(TypedDict):
+    """Data ready to pass to add_document / add_documents_batch."""
+
+    path: str
+    title: str
+    chunks: list[str]
+    embeddings: list[list[float]]
+    source_type: str
+    collection: str
+    project: str | None
+    layer: str | None
+    tags: str | None
+    char_count: int
+    source: str
+
 
 console = Console(stderr=True)
 
@@ -393,6 +412,159 @@ def _get_source_type(source: str) -> str:
 # ------------------------------------------------------------------ #
 
 
+def _prepare_document(
+    source: str,
+    cfg: VstashConfig,
+    store: VstashStore,
+    *,
+    force: bool = False,
+    collection: str = "default",
+    project: str | None = None,
+    layer: str | None = None,
+    tags: str | None = None,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
+    quiet: bool = False,
+) -> _PreparedDoc | IngestResult:
+    """Parse, chunk, and embed a source -- everything except the store write.
+
+    Returns a _PreparedDoc dict if ready to store, or an IngestResult
+    for skip/error/empty conditions.  The ``quiet`` flag suppresses
+    per-file Rich progress bars (used by ingest_directory which shows
+    its own progress bar).
+    """
+    source_path = str(Path(source).resolve()) if not _is_url(source) else source
+    title = _get_title(source)
+    source_type = _get_source_type(source)
+
+    if not force:
+        status = store.doc_completeness(source_path, collection=collection)
+        if status == "complete":
+            return IngestResult(status="skipped", source=source, title=title)
+        if status == "partial":
+            store.delete_document(source_path, collection=collection)
+
+    is_code = source_type == "code" and not _is_url(source) and cfg.chunking.code_aware
+
+    # --- Parse ---
+    if quiet:
+        try:
+            if is_code:
+                text = _read_raw_code(source_path)
+                if text is None:
+                    text = _parse(source)
+                    is_code = False
+            else:
+                text = _parse(source)
+        except Exception as exc:
+            return IngestResult(status="error", source=source, error=str(exc))
+    else:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[bold cyan]Parsing[/bold cyan] {task.description}"),
+            TimeElapsedColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            progress.add_task(Path(source).name if not _is_url(source) else source)
+            try:
+                if is_code:
+                    text = _read_raw_code(source_path)
+                    if text is None:
+                        text = _parse(source)
+                        is_code = False
+                else:
+                    text = _parse(source)
+            except Exception as exc:
+                from rich.markup import escape as _rich_escape
+
+                console.print(f"[red]✗ Error parsing {source}: {_rich_escape(str(exc))}[/red]")
+                return IngestResult(status="error", source=source, error=str(exc))
+
+    if not text or not text.strip():
+        if not quiet:
+            console.print(f"[yellow]⚠ No text extracted from {source}[/yellow]")
+        return IngestResult(status="empty", source=source)
+
+    if _is_url(source):
+        extracted = _extract_title_from_content(text)
+        if extracted:
+            title = extracted
+
+    char_count = len(text)
+
+    # --- Frontmatter ---
+    frontmatter = _extract_frontmatter(text)
+    fm_project = project or frontmatter.get("project")
+    fm_layer = layer or frontmatter.get("layer")
+    if fm_project is not None:
+        if isinstance(fm_project, (dict, list)):
+            if not quiet:
+                console.print(
+                    f"[yellow]⚠ Frontmatter 'project' is a {type(fm_project).__name__}, "
+                    f"expected string -- ignoring.[/yellow]"
+                )
+            fm_project = None
+        else:
+            fm_project = str(fm_project)
+    if fm_layer is not None:
+        if isinstance(fm_layer, (dict, list)):
+            if not quiet:
+                console.print(
+                    f"[yellow]⚠ Frontmatter 'layer' is a {type(fm_layer).__name__}, "
+                    f"expected string -- ignoring.[/yellow]"
+                )
+            fm_layer = None
+        else:
+            fm_layer = str(fm_layer)
+    fm_tags_raw = tags or frontmatter.get("tags")
+    fm_tags: str | None = None
+    if fm_tags_raw:
+        if isinstance(fm_tags_raw, list):
+            fm_tags = ",".join(str(t) for t in fm_tags_raw)
+        elif not isinstance(fm_tags_raw, (dict,)):
+            fm_tags = str(fm_tags_raw)
+    text = _strip_frontmatter(text)
+
+    # --- Chunk ---
+    cs = chunk_size if chunk_size is not None else cfg.chunking.size
+    co = chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap
+    if cs <= 0:
+        raise ValueError(f"chunk_size must be positive, got {cs}")
+    if co < 0:
+        raise ValueError(f"chunk_overlap must be non-negative, got {co}")
+    if co >= cs:
+        raise ValueError(f"chunk_overlap ({co}) must be less than chunk_size ({cs})")
+    if is_code:
+        ext = Path(source).suffix.lower()
+        language = _EXT_TO_LANG.get(ext, "")
+        chunks = chunk_code(text, cs, co, language)
+    else:
+        chunks = chunk_text(text, cs, co)
+
+    if not chunks:
+        if not quiet:
+            console.print(f"[yellow]⚠ No chunks generated from {source}[/yellow]")
+        return IngestResult(status="empty", source=source)
+
+    # --- Embed ---
+    embeddings = _embed_with_progress(chunks, cfg.embeddings.model, quiet=quiet)
+
+    return _PreparedDoc(
+        path=source_path,
+        title=title,
+        chunks=chunks,
+        embeddings=embeddings,
+        source_type=source_type,
+        collection=collection,
+        project=fm_project,
+        layer=fm_layer,
+        tags=fm_tags,
+        char_count=char_count,
+        source=source,
+    )
+
+
 def ingest(
     source: str,
     cfg: VstashConfig,
@@ -420,151 +592,32 @@ def ingest(
     """
     start_time = time.time()
 
-    source_path = str(Path(source).resolve()) if not _is_url(source) else source
-    title = _get_title(source)
-    source_type = _get_source_type(source)
+    prepared = _prepare_document(
+        source,
+        cfg,
+        store,
+        force=force,
+        collection=collection,
+        project=project,
+        layer=layer,
+        tags=tags,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+    if isinstance(prepared, IngestResult):
+        return prepared
 
-    # Idempotent re-ingest (#134).  Without --force, we now distinguish
-    # three states instead of "exists / not exists":
-    #   - "complete": fully ingested → skip
-    #   - "partial":  prior ingest crashed mid-flight → drop the partial
-    #     rows and re-ingest fresh (still treated as a non-error path)
-    #   - "missing":  ingest from scratch
-    if not force:
-        # Pass collection: doc_completeness must check the *exact*
-        # (collection, path) row, not "any document with this path",
-        # otherwise a partial copy in collection A could mask the
-        # health of collection B.  Same reason we restrict the
-        # delete_document call below to the target collection.
-        status = store.doc_completeness(source_path, collection=collection)
-        if status == "complete":
-            return IngestResult(
-                status="skipped",
-                source=source,
-                title=title,
-            )
-        if status == "partial":
-            # Drop the half-ingested document so the fresh ingest below
-            # produces a clean state instead of duplicating chunks.
-            # Scope to ``collection`` so we don't wipe other collections'
-            # complete copies of the same path.
-            store.delete_document(source_path, collection=collection)
-
-    # Should we try code-aware chunking?
-    is_code = source_type == "code" and not _is_url(source) and cfg.chunking.code_aware
-
-    # --- Step 1: Parse ---
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[bold cyan]Parsing[/bold cyan] {task.description}"),
-        TimeElapsedColumn(),
-        console=console,
-        transient=True,
-    ) as progress:
-        progress.add_task(Path(source).name if not _is_url(source) else source)
-        try:
-            if is_code:
-                text = _read_raw_code(source_path)
-                if text is None:
-                    text = _parse(source)
-                    is_code = False
-            else:
-                text = _parse(source)
-        except Exception as exc:
-            # rich.markup.escape on the exception text so brackets in
-            # messages like "pip install vstash[ingest]" don't get
-            # interpreted as markup tags and silently dropped.
-            from rich.markup import escape as _rich_escape
-
-            console.print(f"[red]✗ Error parsing {source}: {_rich_escape(str(exc))}[/red]")
-            return IngestResult(
-                status="error",
-                source=source,
-                error=str(exc),
-            )
-
-    if not text or not text.strip():
-        console.print(f"[yellow]⚠ No text extracted from {source}[/yellow]")
-        return IngestResult(status="empty", source=source)
-
-    # For URLs, try to extract a real title from the parsed content
-    if _is_url(source):
-        extracted = _extract_title_from_content(text)
-        if extracted:
-            title = extracted
-
-    char_count = len(text)
-
-    # --- Step 2: Extract frontmatter metadata ---
-    frontmatter = _extract_frontmatter(text)
-    # Explicit params override frontmatter values
-    fm_project = project or frontmatter.get("project")
-    fm_layer = layer or frontmatter.get("layer")
-    # Coerce non-string scalars to str; warn on dicts/lists
-    if fm_project is not None:
-        if isinstance(fm_project, (dict, list)):
-            console.print(
-                f"[yellow]⚠ Frontmatter 'project' is a {type(fm_project).__name__}, "
-                f"expected string — ignoring.[/yellow]"
-            )
-            fm_project = None
-        else:
-            fm_project = str(fm_project)
-    if fm_layer is not None:
-        if isinstance(fm_layer, (dict, list)):
-            console.print(
-                f"[yellow]⚠ Frontmatter 'layer' is a {type(fm_layer).__name__}, "
-                f"expected string — ignoring.[/yellow]"
-            )
-            fm_layer = None
-        else:
-            fm_layer = str(fm_layer)
-    fm_tags_raw = tags or frontmatter.get("tags")
-    fm_tags: str | None = None
-    if fm_tags_raw:
-        if isinstance(fm_tags_raw, list):
-            fm_tags = ",".join(str(t) for t in fm_tags_raw)
-        elif not isinstance(fm_tags_raw, (dict,)):
-            fm_tags = str(fm_tags_raw)
-    # Strip frontmatter block from text before chunking
-    text = _strip_frontmatter(text)
-
-    # --- Step 3: Chunk ---
-    with console.status("[bold cyan]Chunking...[/bold cyan]", spinner="dots"):
-        cs = chunk_size if chunk_size is not None else cfg.chunking.size
-        co = chunk_overlap if chunk_overlap is not None else cfg.chunking.overlap
-        if cs <= 0:
-            raise ValueError(f"chunk_size must be positive, got {cs}")
-        if co < 0:
-            raise ValueError(f"chunk_overlap must be non-negative, got {co}")
-        if co >= cs:
-            raise ValueError(f"chunk_overlap ({co}) must be less than chunk_size ({cs})")
-        if is_code:
-            ext = Path(source).suffix.lower()
-            language = _EXT_TO_LANG.get(ext, "")
-            chunks = chunk_code(text, cs, co, language)
-        else:
-            chunks = chunk_text(text, cs, co)
-
-    if not chunks:
-        console.print(f"[yellow]⚠ No chunks generated from {source}[/yellow]")
-        return IngestResult(status="empty", source=source)
-
-    # --- Step 4: Embed (with progress bar — this is the slow part) ---
-    embeddings = _embed_with_progress(chunks, cfg.embeddings.model)
-
-    # --- Step 5: Store ---
     with console.status("[bold cyan]Storing...[/bold cyan]", spinner="dots"):
         doc_id = store.add_document(
-            path=source_path,
-            title=title,
-            chunks=chunks,
-            embeddings=embeddings,
-            source_type=source_type,
-            collection=collection,
-            project=fm_project,
-            layer=fm_layer,
-            tags=fm_tags,
+            path=prepared["path"],
+            title=prepared["title"],
+            chunks=prepared["chunks"],
+            embeddings=prepared["embeddings"],
+            source_type=prepared["source_type"],
+            collection=prepared["collection"],
+            project=prepared["project"],
+            layer=prepared["layer"],
+            tags=prepared["tags"],
         )
 
     elapsed = round(time.time() - start_time, 2)
@@ -573,9 +626,9 @@ def ingest(
         status="ok",
         doc_id=doc_id,
         source=source,
-        title=title,
-        chunks=len(chunks),
-        chars=char_count,
+        title=prepared["title"],
+        chunks=len(prepared["chunks"]),
+        chars=prepared["char_count"],
         elapsed_s=elapsed,
     )
 
@@ -844,21 +897,21 @@ def ingest_directory(
     )
 
     results: list[IngestResult] = []
-    with (
-        store.batch_mode(),
-        Progress(
-            SpinnerColumn(),
-            TextColumn("[bold]Processing directory[/bold]"),
-            BarColumn(),
-            MofNCompleteColumn(),
-            TimeElapsedColumn(),
-            console=console,
-        ) as progress,
-    ):
+    pending: list[_PreparedDoc] = []
+
+    # Phase 1: parse + chunk + embed (per-file, progress bar)
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[bold]Preparing[/bold]"),
+        BarColumn(),
+        MofNCompleteColumn(),
+        TimeElapsedColumn(),
+        console=console,
+    ) as progress:
         task = progress.add_task("", total=len(files))
         for f in files:
             progress.update(task, description=f.name)
-            result = ingest(
+            prepared = _prepare_document(
                 str(f),
                 cfg,
                 store,
@@ -869,9 +922,49 @@ def ingest_directory(
                 tags=tags,
                 chunk_size=chunk_size,
                 chunk_overlap=chunk_overlap,
+                quiet=True,
             )
-            results.append(result)
+            if isinstance(prepared, IngestResult):
+                if prepared.status == "error":
+                    console.print(f"[red]  x {f.name}: {prepared.error}[/red]")
+                results.append(prepared)
+            else:
+                pending.append(prepared)
             progress.advance(task)
+
+    # Phase 2: store all prepared docs in one batched transaction
+    if pending:
+        batch_docs = [
+            {
+                "path": doc["path"],
+                "title": doc["title"],
+                "chunks": doc["chunks"],
+                "embeddings": doc["embeddings"],
+                "source_type": doc["source_type"],
+                "collection": doc["collection"],
+                "project": doc["project"],
+                "layer": doc["layer"],
+                "tags": doc["tags"],
+            }
+            for doc in pending
+        ]
+        store_start = time.time()
+        with store.batch_mode(defer_fts=True):
+            doc_ids = store.add_documents_batch(batch_docs)
+        store_elapsed = round(time.time() - store_start, 2)
+
+        for doc, doc_id in zip(pending, doc_ids):
+            results.append(
+                IngestResult(
+                    status="ok",
+                    doc_id=doc_id,
+                    source=doc["source"],
+                    title=doc["title"],
+                    chunks=len(doc["chunks"]),
+                    chars=doc["char_count"],
+                    elapsed_s=store_elapsed,
+                )
+            )
 
     return results
 
@@ -1101,18 +1194,28 @@ def _parse(source: str) -> str:
     return text.strip()
 
 
-def _embed_with_progress(chunks: list[str], model_name: str) -> list[list[float]]:
+def _embed_with_progress(
+    chunks: list[str], model_name: str, quiet: bool = False
+) -> list[list[float]]:
     """Embed chunks with a Rich progress bar. Batches for efficiency.
 
     Args:
         chunks: Text chunks to embed.
         model_name: FastEmbed model identifier.
+        quiet: Skip progress bar (used in batch directory ingest).
 
     Returns:
         List of embedding vectors.
     """
     BATCH_SIZE = 64
-    all_embeddings: list[list[float]] = []
+
+    if quiet:
+        all_embeddings: list[list[float]] = []
+        for i in range(0, len(chunks), BATCH_SIZE):
+            all_embeddings.extend(embed_texts(chunks[i : i + BATCH_SIZE], model_name))
+        return all_embeddings
+
+    all_embeddings = []
 
     with Progress(
         SpinnerColumn(),

--- a/vstash/journal.py
+++ b/vstash/journal.py
@@ -76,6 +76,7 @@ def _get_journal_store(cfg: VstashConfig | None = None) -> tuple[VstashConfig, V
         embedding_dim=dim,
         vector_backend=cfg.storage.vector_backend,
         snapvec_bits=cfg.storage.snapvec_bits,
+        cache=cfg.cache,
     )
     return cfg, store
 

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -119,6 +119,7 @@ def _get_store() -> VstashStore:
                     snapvec_bits=cfg.storage.snapvec_bits,
                     observability=cfg.observability,
                     limits=cfg.limits,
+                    cache=cfg.cache,
                 )
                 # Detect embedding model drift on non-empty stores.
                 if _store.stats().chunks > 0:
@@ -296,6 +297,7 @@ def _run_directory_job(
             embedding_dim=dim,
             vector_backend=cfg.storage.vector_backend,
             snapvec_bits=cfg.storage.snapvec_bits,
+            cache=cfg.cache,
         )
         try:
             results = ingest_directory(

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -106,6 +106,7 @@ class Memory:
             snapvec_bits=self._cfg.storage.snapvec_bits,
             observability=self._cfg.observability,
             limits=self._cfg.limits,
+            cache=self._cfg.cache,
         )
         # Silent killer defense: warn if the DB was built with a
         # different embedding model or a fastembed version that changed

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -294,6 +294,10 @@ class VstashStore:
         self._batch_depth: int = 0
         self._batch_dirty: bool = False
 
+        # --- Deferred FTS indexing ---
+        self._defer_fts: bool = False
+        self._deferred_fts_rows: list[tuple[int, str]] = []
+
         # --- Observability ---
         # Store the whole ObservabilityConfig object (frozen Pydantic
         # model) so that future knobs can be added without touching
@@ -1017,10 +1021,11 @@ class VstashStore:
 
                 # FTS5 entries (rowid must match chunks.id)
                 fts_data = [(rowid, text) for rowid, text in zip(rowids, chunks)]
-                self._conn.executemany(
-                    "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
-                    fts_data,
-                )
+                if not self._defer_fts:
+                    self._conn.executemany(
+                        "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
+                        fts_data,
+                    )
 
                 # Add to snapvec in-memory (persisted after successful commit)
                 if self._snap is not None:
@@ -1029,6 +1034,8 @@ class VstashStore:
                     self._snap_dirty = True
 
                 self._conn.commit()
+                if self._defer_fts:
+                    self._deferred_fts_rows.extend(fts_data)
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
                 # Persist snapvec AFTER successful SQLite commit
@@ -1067,6 +1074,7 @@ class VstashStore:
 
         with self._write_lock:
             self._conn.execute("BEGIN IMMEDIATE")
+            pending_fts: list[tuple[int, str]] = []
             try:
                 now_iso = datetime.now(timezone.utc).isoformat()
 
@@ -1136,10 +1144,13 @@ class VstashStore:
                     )
 
                     fts_data = list(zip(rowids, chunks))
-                    self._conn.executemany(
-                        "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
-                        fts_data,
-                    )
+                    if self._defer_fts:
+                        pending_fts.extend(fts_data)
+                    else:
+                        self._conn.executemany(
+                            "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
+                            fts_data,
+                        )
 
                     if self._snap is not None:
                         snap_vecs = np.array(embeddings, dtype=np.float32)
@@ -1147,6 +1158,8 @@ class VstashStore:
                         self._snap_dirty = True
 
                 self._conn.commit()
+                if pending_fts:
+                    self._deferred_fts_rows.extend(pending_fts)
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
                 if self._snap_dirty:
@@ -3506,32 +3519,78 @@ class VstashStore:
             return
         self._idf_cache = None
 
+    def _flush_deferred_fts(self) -> None:
+        """Bulk-insert all deferred FTS rows in a single transaction."""
+        if not self._deferred_fts_rows:
+            return
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                self._conn.executemany(
+                    "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
+                    self._deferred_fts_rows,
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+            else:
+                self._deferred_fts_rows.clear()
+
     @contextmanager
-    def batch_mode(self) -> Iterator[None]:
-        """Context manager that defers IDF cache invalidation.
+    def batch_mode(self, *, defer_fts: bool = False) -> Iterator[None]:
+        """Context manager that defers IDF cache invalidation and optionally FTS indexing.
 
-        Use this when adding or deleting many documents in a loop to avoid
-        redundant cache rebuilds.  Supports re-entrant (nested) usage.
+        Use this when adding many documents in a loop to avoid redundant
+        cache rebuilds and per-insert FTS overhead.  Supports re-entrant
+        (nested) usage.
 
-        Not thread-safe — intended for single-threaded batch operations.
-        Searches executed during a batch may use stale IDF weights; the
-        cache is refreshed once the outermost batch exits.
+        Args:
+            defer_fts: When True, FTS5 inserts are collected in memory
+                and flushed in one bulk pass when the outermost batch
+                exits.  This avoids updating the FTS B-tree per chunk,
+                which is the dominant cost at >100 documents.
+
+        Not thread-safe -- intended for single-threaded batch operations.
+        Searches executed during a batch may use stale IDF weights and
+        (when defer_fts=True) miss newly added documents in FTS results.
+
+        Precondition when ``defer_fts=True``: do not ingest the same
+        path twice within a single batch.  Re-ingesting a path deletes
+        the old chunks (firing the FTS delete trigger), but deferred
+        rows for the old rowids are already queued and would become
+        orphaned FTS entries on flush.
 
         Example::
 
-            with store.batch_mode():
+            with store.batch_mode(defer_fts=True):
                 for path in paths:
                     store.add_document(...)
-            # IDF cache is invalidated once here
+            # IDF cache invalidated + FTS populated in one pass
         """
         self._batch_depth += 1
+        was_deferring = self._defer_fts
+        if defer_fts:
+            self._defer_fts = True
         try:
             yield
         finally:
             self._batch_depth -= 1
-            if self._batch_depth == 0 and self._batch_dirty:
-                self._idf_cache = None
-                self._batch_dirty = False
+            if self._batch_depth == 0:
+                try:
+                    if self._defer_fts:
+                        self._flush_deferred_fts()
+                except Exception:
+                    logger.error(
+                        "FTS flush failed; documents are stored but not FTS-indexed. "
+                        "Run 'vstash reindex' to rebuild the FTS index."
+                    )
+                    raise
+                finally:
+                    self._defer_fts = was_deferring
+                    if self._batch_dirty:
+                        self._idf_cache = None
+                        self._batch_dirty = False
 
     def _compute_adaptive_rrf_params(
         self, query_text: str, default_cutoff: float = 1.15

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -29,7 +29,9 @@ import threading
 import numpy as np
 import sqlite_vec
 
-from .config import LimitsConfig, ObservabilityConfig
+from collections import OrderedDict
+
+from .config import CacheConfig, LimitsConfig, ObservabilityConfig
 from .validation import validate_document_input, validate_search_input
 from .models import (
     ChunkInfo,
@@ -268,6 +270,7 @@ class VstashStore:
         ivfpq_nprobe: int = 0,
         observability: ObservabilityConfig | None = None,
         limits: LimitsConfig | None = None,
+        cache: CacheConfig | None = None,
     ) -> None:
         self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -306,6 +309,12 @@ class VstashStore:
         # boundary (search, add_document) — never inside the hot path.
         self._limits: LimitsConfig = limits or LimitsConfig()
 
+        # --- Query result cache (opt-in LRU) ---
+        self._cache_config: CacheConfig = cache or CacheConfig()
+        self._cache_epoch: int = 0
+        self._query_cache: OrderedDict[int, list[SearchResult]] = OrderedDict()
+        self._cache_lock = threading.Lock()
+
         # --- SnapVec backend (optional) ---
         self._snap: Any = None
         self._vector_backend = vector_backend
@@ -320,6 +329,11 @@ class VstashStore:
             self._init_snapvec()
         elif vector_backend == "snapvec-ivfpq":
             self._init_ivfpq()
+
+    def _bump_cache_epoch(self) -> None:
+        with self._cache_lock:
+            self._cache_epoch += 1
+            self._query_cache.clear()
 
     @property
     def _snapvec_path(self) -> Path:
@@ -447,6 +461,7 @@ class VstashStore:
         self._snap.fit(sample)
         self._snap.add_batch(ids.tolist(), matrix)
         self._snap.save(str(self._ivfpq_path))
+        self._bump_cache_epoch()
         build_s = _time.perf_counter() - t0
         return {
             "n_indexed": int(n_rows),
@@ -516,11 +531,7 @@ class VstashStore:
         """Flush the in-memory snapvec index to disk if dirty."""
         if self._snap is None or not self._snap_dirty:
             return
-        target = (
-            self._ivfpq_path
-            if self._vector_backend == "snapvec-ivfpq"
-            else self._snapvec_path
-        )
+        target = self._ivfpq_path if self._vector_backend == "snapvec-ivfpq" else self._snapvec_path
         self._snap.save(str(target))
         self._snap_dirty = False
 
@@ -1019,6 +1030,7 @@ class VstashStore:
 
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
                 # Persist snapvec AFTER successful SQLite commit
                 if self._snap_dirty:
                     self._save_snapvec()
@@ -1136,6 +1148,7 @@ class VstashStore:
 
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
                 if self._snap_dirty:
                     self._save_snapvec()
             except Exception:
@@ -1174,6 +1187,7 @@ class VstashStore:
                 self._delete_by_doc_ids([row[0] for row in rows])
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
                 if self._snap_dirty:
                     self._save_snapvec()
             except Exception:
@@ -1283,6 +1297,7 @@ class VstashStore:
                 self._delete_by_doc_ids(doc_ids)
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
                 # Persist snapvec AFTER successful SQLite commit
                 if self._snap_dirty:
                     self._save_snapvec()
@@ -1433,6 +1448,32 @@ class VstashStore:
             fts_weight=fts_weight,
         )
 
+        # --- Query cache key ---
+        _cache_key: int | None = None
+        _cache_max = self._cache_config.query_cache_size
+        if _cache_max > 0 and _tracer is None and not explain:
+            _emb_bytes = np.array(query_embedding, dtype=np.float32).tobytes()
+            _cache_key = hash(
+                (
+                    _emb_bytes,
+                    query_text,
+                    top_k,
+                    vec_weight,
+                    fts_weight,
+                    distance_cutoff,
+                    collection,
+                    project,
+                    layer,
+                    adaptive_rrf,
+                    recency_boost,
+                    added_after,
+                    added_before,
+                    mmr_lambda,
+                    fts_only,
+                    self._cache_epoch,
+                )
+            )
+
         # Per-search miss-analysis tracker (#108).  The tracer is owned
         # by the caller (miss_analysis) and passed in; this keeps the
         # tracking state thread-local to the caller and zero-cost on
@@ -1460,6 +1501,18 @@ class VstashStore:
         _fts_weight_observed: float = 0.0
         registry.counter_inc("searches_total")
         try:
+            # --- Cache hit (inside try/finally so observability is recorded) ---
+            if _cache_key is not None:
+                cached: list[SearchResult] | None = None
+                with self._cache_lock:
+                    if _cache_key in self._query_cache:
+                        self._query_cache.move_to_end(_cache_key)
+                        cached = list(self._query_cache[_cache_key])
+                if cached is not None:
+                    _result_count = len(cached)
+                    registry.counter_inc("query_cache_hits_total")
+                    return cached
+
             # FTS-only short-circuit (#152): bypass vector search entirely.
             # This forces the weights to (0.0, 1.0) and disables adaptive
             # RRF so the pipeline cannot silently re-enable the vector
@@ -2041,6 +2094,13 @@ class VstashStore:
 
             # _tracer.verdicts has been populated in-place by the record()
             # calls above when tracking is enabled.  No store-level state.
+
+            if _cache_key is not None:
+                with self._cache_lock:
+                    self._query_cache[_cache_key] = list(results)
+                    while len(self._query_cache) > _cache_max:
+                        self._query_cache.popitem(last=False)
+
             return results
         finally:
             # Record latency and slow-query telemetry for every search,
@@ -3265,6 +3325,7 @@ class VstashStore:
 
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
             except Exception as exc:
                 self._conn.rollback()
                 repairs.append(
@@ -3821,6 +3882,7 @@ class VstashStore:
 
                 self._conn.commit()
                 self._invalidate_idf_cache()
+                self._bump_cache_epoch()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -65,6 +65,7 @@ def _get_store() -> VstashStore:
             snapvec_bits=cfg.storage.snapvec_bits,
             observability=cfg.observability,
             limits=cfg.limits,
+            cache=cfg.cache,
         )
         # Detect embedding model drift on non-empty stores.
         if _store.stats().chunks > 0:


### PR DESCRIPTION
## Summary

- **Query LRU cache** -- opt-in via `[cache] query_cache_size` in vstash.toml. ~700x speedup on repeated queries. Thread-safe, epoch-invalidated on writes.
- **Deferred FTS indexing** -- `batch_mode(defer_fts=True)` collects FTS inserts in memory and flushes in one bulk pass.
- **Batched directory ingest** -- `ingest_directory` now uses two-phase pipeline (prepare all files, then `add_documents_batch` in one transaction). 5x faster store writes at 500 docs.

## Test plan

- [x] 762 tests pass, 0 failures
- [x] Lint + format clean
- [x] Both feature PRs (#213, #214) reviewed by Gemini, Copilot, and code-reviewer agent
- [x] All review feedback addressed (2 rounds each)