### PR TITLE
docs(paper): ground Section 4 opener in Table 3 instead of an untraceable baseline

### DIFF
--- a/paper/arxiv/vstash.tex
+++ b/paper/arxiv/vstash.tex
@@ -240,7 +240,7 @@ The system includes integrity checking with five invariants and idempotent re-in
 
 \subsection{4 Adaptive RRF with IDF Weighting}\label{adaptive-rrf-with-idf-weighting}
 
-Fixed RRF weights (0.6 vector, 0.4 FTS) assume all queries benefit equally from keyword matching. Evaluation on BEIR revealed this assumption fails on long, semantically-rich queries: on ArguAna (average 194 words), fixed weights degraded NDCG@10 by -16.1\% versus a tuned dense-only baseline.
+Fixed RRF weights (0.6 vector, 0.4 FTS) assume all queries benefit equally from keyword matching. Evaluation on BEIR revealed this assumption fails on long, semantically-rich queries: on ArguAna (average 194 words), fixed weights score NDCG@10 = 0.3599 vs 0.4370 for adaptive IDF -- a 17.6\% relative shortfall (Table 3) and the largest gap of any of the 5 benchmarks, which is what motivates adaptive weighting.
 
 \subsubsection{4.1 Method}\label{method}
 

--- a/paper/vstash-paper.md
+++ b/paper/vstash-paper.md
@@ -144,7 +144,7 @@ The system includes integrity checking with five invariants and idempotent re-in
 
 ## 4  Adaptive RRF with IDF Weighting
 
-Fixed RRF weights (0.6 vector, 0.4 FTS) assume all queries benefit equally from keyword matching. Evaluation on BEIR revealed this assumption fails on long, semantically-rich queries: on ArguAna (average 194 words), fixed weights degraded NDCG@10 by -16.1% versus a tuned dense-only baseline.
+Fixed RRF weights (0.6 vector, 0.4 FTS) assume all queries benefit equally from keyword matching. Evaluation on BEIR revealed this assumption fails on long, semantically-rich queries: on ArguAna (average 194 words), fixed weights score NDCG@10 = 0.3599 vs 0.4370 for adaptive IDF -- a 17.6% relative shortfall (Table 3) and the largest gap of any of the 5 benchmarks, which is what motivates adaptive weighting.
 
 ### 4.1  Method
 


### PR DESCRIPTION
## Summary

Final item from the paper audit. The Section 4 opener claimed:

> \"on ArguAna (average 194 words), fixed weights degraded NDCG@10 by -16.1% versus a tuned dense-only baseline.\"

But \"tuned dense-only baseline\" is not defined anywhere in the paper and the -16.1% figure does not match any row of any committed experiment JSON (no BGE-small dense-only ArguAna number exists in \`experiments/results/\`).

Rewrote the sentence to use numbers that are actually in Table 3:

> \"on ArguAna (average 194 words), fixed weights score NDCG@10 = 0.3599 vs 0.4370 for adaptive IDF -- a 17.6% relative shortfall (Table 3) and the largest gap of any of the 5 benchmarks, which is what motivates adaptive weighting.\"

Math check: \`(0.3599 - 0.4370) / 0.4370 = -17.64%\`. Same motivating point (fixed weights fail on long queries), traceable math, no phantom baseline.

Source for 0.3599 and 0.4370: \`experiments/results/beir_multi.json\` and \`experiments/results/beir_adaptive_baseline.json\`, both listed in \`experiments/results/CANONICAL.md\`.

## Test plan

- [x] Both md and tex updated consistently
- [x] Math verified: \`(0.3599-0.4370)/0.4370 = -17.64%\`
- [x] Reference to Table 3 means the reader can cross-check in one hop