### PR TITLE
fix(embed): download ONNX external data file alongside model.onnx

### DIFF
--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -303,8 +303,24 @@ def _init_hf_onnx(model_name: str) -> tuple:
 
                 try:
                     model_path = hf_hub_download(model_name, "onnx/model.onnx")
+                    onnx_prefix = "onnx/"
                 except (EntryNotFoundError, OSError):
                     model_path = hf_hub_download(model_name, "model.onnx")
+                    onnx_prefix = ""
+                # Large ONNX exports store weights in an external data file
+                # (`model.onnx.data` with a dot, or `model.onnx_data` with
+                # an underscore depending on the exporter version). ONNX
+                # Runtime expects that file to sit next to the .onnx. Fetch
+                # it alongside; best-effort, not all models have it.
+                for data_name in (
+                    f"{onnx_prefix}model.onnx.data",
+                    f"{onnx_prefix}model.onnx_data",
+                ):
+                    try:
+                        hf_hub_download(model_name, data_name)
+                        break
+                    except (EntryNotFoundError, OSError):
+                        continue
                 try:
                     tokenizer_path = hf_hub_download(model_name, "onnx/tokenizer.json")
                 except (EntryNotFoundError, OSError):


### PR DESCRIPTION
## Why

Running BEIR benchmark with \`Stffens/bge-small-rrf-v2\` on a fresh Colab T4 crashes with:

\`\`\`
[E:onnxruntime:...] Exception during initialization:
filesystem error: cannot get file size: No such file or directory
[/root/.cache/huggingface/hub/models--Stffens--bge-small-rrf-v2/.../model.onnx.data]
\`\`\`

HF ONNX exports for large models store weights in a separate \`model.onnx.data\` (or the older \`model.onnx_data\`) file next to the \`.onnx\` graph. ONNX Runtime loads the graph and calls \`getsize\` on the external data path immediately at \`InferenceSession\` init. \`_init_hf_onnx\` only downloaded \`model.onnx\`, so it worked for models that happened to export without external data and failed otherwise.

## What ships

Best-effort download of both naming conventions alongside the graph:
- \`{prefix}model.onnx.data\` (current convention)
- \`{prefix}model.onnx_data\` (older Optimum / earlier exporters)

Silent skip if neither exists (small models). Same pattern as the Gemma path at \`embed.py:194-195\` which already handled this for its repo.

## Test plan

- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] \`from vstash.embed import _init_hf_onnx\` works locally
- [ ] Re-run BEIR Colab bench (blocked on this merge) with \`Stffens/bge-small-rrf-v2\` end to end, confirm session init succeeds and the 5 datasets finish

Once merged, \`docs/phase0-readme-refresh\` notebook (which clones \`develop\`) will pick this up automatically.