### PR TITLE
fix(embed): fall back to sentence-transformers when ONNX init fails

### DIFF
--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -282,6 +282,9 @@ _HF_ONNX_MODELS: set[str] = {
 
 _hf_onnx_cache: dict[str, tuple] = {}  # model_name -> (session, tokenizer, max_len)
 _hf_onnx_lock = threading.Lock()
+_hf_st_cache: dict[str, object] = {}  # model_name -> SentenceTransformer
+_hf_st_lock = threading.Lock()
+_hf_onnx_unavailable: set[str] = set()
 
 
 def _is_hf_onnx_model(model_name: str) -> bool:
@@ -332,14 +335,60 @@ def _init_hf_onnx(model_name: str) -> tuple:
     return _hf_onnx_cache[model_name]
 
 
+def _init_hf_st(model_name: str):
+    """Lazily load a SentenceTransformer for an HF model. Used as the
+    fallback path when the ONNX export is broken (missing external data
+    file) or when sentence-transformers is the only published format."""
+    if model_name not in _hf_st_cache:
+        with _hf_st_lock:
+            if model_name not in _hf_st_cache:
+                try:
+                    from sentence_transformers import SentenceTransformer
+                except ImportError as exc:
+                    raise ImportError(
+                        f"Cannot load {model_name}: ONNX init failed AND "
+                        "sentence-transformers is not installed. Install with: "
+                        "pip install 'sentence-transformers>=3' torch 'accelerate>=1.1.0'"
+                    ) from exc
+                _logger.info("Loading %s via SentenceTransformer fallback", model_name)
+                _hf_st_cache[model_name] = SentenceTransformer(model_name)
+    return _hf_st_cache[model_name]
+
+
+def _embed_hf_st(texts: list[str], model_name: str) -> list[list[float]]:
+    """Embed texts via the SentenceTransformer fallback path."""
+    if not texts:
+        return []
+    model = _init_hf_st(model_name)
+    vecs = model.encode(texts, normalize_embeddings=True, show_progress_bar=False)
+    return [list(map(float, v)) for v in vecs]
+
+
 def _embed_hf_onnx(texts: list[str], model_name: str) -> list[list[float]]:
-    """Embed texts using a custom HF ONNX model with mean pooling."""
+    """Embed texts using a custom HF ONNX model with mean pooling.
+
+    Falls back to ``_embed_hf_st`` if the ONNX init fails for this model
+    (e.g., the HF repo publishes a stub ``model.onnx`` whose external
+    ``.data`` file was never uploaded).
+    """
     import numpy as np
 
     if not texts:
         return []
 
-    session, tokenizer, max_len = _init_hf_onnx(model_name)
+    if model_name in _hf_onnx_unavailable:
+        return _embed_hf_st(texts, model_name)
+
+    try:
+        session, tokenizer, max_len = _init_hf_onnx(model_name)
+    except Exception as exc:  # includes onnxruntime RuntimeException
+        _logger.warning(
+            "HF ONNX init failed for %s (%s); falling back to sentence-transformers.",
+            model_name,
+            exc.__class__.__name__,
+        )
+        _hf_onnx_unavailable.add(model_name)
+        return _embed_hf_st(texts, model_name)
     all_embeddings: list[list[float]] = []
     batch_size = 32
 


### PR DESCRIPTION
## Why

Follow-up to #234 (merged), which tried to also download \`model.onnx.data\` alongside \`model.onnx\` from HF. That only helps when the \`.data\` file is actually published, and for \`Stffens/bge-small-rrf-v2\` it is not:

\`\`\`python
>>> from huggingface_hub import list_repo_files
>>> sorted(list_repo_files('Stffens/bge-small-rrf-v2'))
['.gitattributes', '1_Pooling/config.json', 'README.md', 'config.json',
 'config_sentence_transformers.json', 'model.onnx', 'model.safetensors',
 'modules.json', 'sentence_bert_config.json', 'tokenizer.json',
 'tokenizer_config.json']
\`\`\`

The 1.26 MB \`model.onnx\` is a stub that references external weights that were never uploaded, so \`ort.InferenceSession\` crashes at init:

\`\`\`
filesystem error: cannot get file size: No such file or directory
[.../model.onnx.data]
\`\`\`

The repo should be fixed upstream (either re-export monolithic ONNX or upload the \`.data\` file), but the library should not crash in the meantime.

## What ships

- New \`_init_hf_st\` + \`_embed_hf_st\` helpers that load the same model via \`SentenceTransformer\` (which handles safetensors).
- \`_embed_hf_onnx\` now wraps the \`_init_hf_onnx\` call in a broad \`except\` (ONNX RuntimeException, FileNotFoundError, ImportError). On failure it logs a warning once per model, adds the model to an \`_hf_onnx_unavailable\` set, and routes to the ST fallback.
- Cached per-model: second call skips the ONNX attempt entirely.
- Single-query path (\`_query_hf_onnx\`) and warmup (\`_warmup_hf_onnx\`) both delegate to \`_embed_hf_onnx\`, so they inherit the fallback with zero extra wiring.

## Test plan

- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] Targeted tests: \`pytest -k 'embed or retrain'\` — 102 passing
- [ ] Re-run BEIR Colab bench with \`Stffens/bge-small-rrf-v2\` end to end (blocked on this merge)

Once merged, the \`docs/phase0-readme-refresh\` Colab notebook picks it up automatically.