### PR TITLE
docs(notebook): clone develop for T1.4 + T1.4b reproducer

### DIFF
--- a/experiments/retrain_t1_4_multi_beir.ipynb
+++ b/experiments/retrain_t1_4_multi_beir.ipynb
@@ -43,10 +43,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Cell 1: Setup -- feat/retrain-t14b-batched-mining branch (T1.4 + T1.4b).\n",
+    "# Cell 1: Setup -- vstash develop (T1.4 + T1.4b already merged).\n",
     "!pip install -q 'sentence-transformers>=3' torch 'accelerate>=1.1.0'\n",
     "!rm -rf /content/vstash\n",
-    "!git clone --branch feat/retrain-t14b-batched-mining https://github.com/stffns/vstash.git /content/vstash\n",
+    "!git clone --branch develop https://github.com/stffns/vstash.git /content/vstash\n",
     "%cd /content/vstash\n",
     "!pip install -q -e ."
    ]


### PR DESCRIPTION
Follow-up to #238 + #239. Cell 1 previously cloned the feature branch; point it at develop so the notebook keeps working after feature branches are deleted.