### PR TITLE
feat(retrain): eval observability (H-R5) + seed reproducibility (H-R7)

### DIFF
--- a/experiments/hypotheses.md
+++ b/experiments/hypotheses.md
@@ -1,0 +1,318 @@
+# vstash improvement hypotheses
+
+Living backlog of concrete, testable hypotheses to raise vstash retrieval
+quality or reduce cost. Spun off from `retrain_roadmap.md` after the T1.4
+first-Colab regression (-5.15% macro NDCG@10) and the T1.5 fix landing.
+
+Each hypothesis is:
+
+- **Statement**: what we believe will happen.
+- **Test**: how we measure it, with a clear success bar.
+- **Files**: where the change lives.
+- **Effort**: rough day count.
+- **Risk**: what breaks if the hypothesis is wrong.
+
+Ordered by expected ROI / day. Strike through when shipped. Link the PR.
+
+---
+
+## Retrain (signal quality + training)
+
+### H-R1. Labeled queries should be the default path when qrels exist
+
+**Statement.** `retrain_multi(..., training_queries_by_dataset=...)` currently
+opts in to the v5 recipe. If the user passes eval_queries with BEIR-style
+qrels, we can reuse them for training automatically. Chunk-prefix fallback
+should only fire when no labels exist. Removes the footgun that caused the
+2026-04-18 -5.15% run.
+
+**Test.** Re-run `experiments/retrain_t1_4_multi_beir.ipynb` with the new
+default path (no explicit flag). Target: macro NDCG@10 delta >= the explicit
+T1.5 run on the same seed.
+
+**Files.** `vstash/retrain.py` (retrain_multi entrypoint), `vstash/cli.py`
+(`vstash retrain-multi` wiring).
+
+**Effort.** 1 day.
+
+**Risk.** Users who relied on chunk-prefix mining on a labeled corpus get
+different training data silently. Mitigate with a `training_pair_source`
+parameter that defaults to `"auto"` and logs the choice.
+
+---
+
+### H-R2. Multi-triplet emission on labeled queries (T1.2 revisited)
+
+**Statement.** `generate_labeled_triples_batched` already emits
+`|gold| * |hard_neg|` triples per query. The legacy unlabeled path
+(`generate_triples`, `generate_triples_batched`) still emits 1 triplet per
+query. When T1.5 validates, porting multi-triplet to the prefix path should
+multiply signal 2-3x without new infrastructure.
+
+**Test.** Ablation on SciFact + NFCorpus: chunk-prefix T=1 vs T=3 vs T=5
+hard negs at constant `total_triples`. Track NDCG@10 gate outcome and
+training wall-clock. Target: T=3 wins or matches T=1 on macro NDCG@10,
+within noise (+/- 0.5%).
+
+**Files.** `vstash/retrain.py:226-244`, `vstash/retrain_batch.py:360-404`.
+
+**Effort.** 2 days.
+
+**Risk.** T1.2 was parked because multi-triplet on chunk-prefix queries
+amplified the distribution mismatch. Only revisit after T1.5 validates.
+
+---
+
+### H-R3. Hard-negative margin filter
+
+**Statement.** Labeled miner emits every (gold, hard_neg) pair the RRF
+surface turns up. Some hard negs are *too* close to the gold (ambiguous,
+hurt training) or *too* far (easy, contribute nothing). Filtering by
+cosine-margin `(gold - hard_neg)` in a target band [0.05, 0.30] should
+improve training quality.
+
+**Test.** Ablation on the T1.5 notebook with margin bands
+{no-filter, [0.05,0.30], [0.10,0.40]}. Target: +0.5-1% macro NDCG@10 vs
+no-filter at the same triple budget.
+
+**Files.** `vstash/retrain_batch.py:721-988`
+(`generate_labeled_triples_batched`).
+
+**Effort.** 2 days.
+
+**Risk.** Filter removes too many triples, training underfits. Mitigate by
+logging kept-vs-dropped ratio and bailing when < 30% kept.
+
+---
+
+### H-R4. Hyperparameters as CLI knobs + small grid on Colab (deprioritized)
+
+**Statement.** Originally framed as "v5 used lr=2e-5 / epochs=1, ours is
+3e-6 / epochs=2, that is the gap". Verified against
+`experiments/retrain_v5_hard_neg.ipynb`: v5 actually uses
+`lr=3e-6, epochs=2, warmup_steps=50, batch=64` -- the same defaults we
+ship. The regression source is elsewhere (signal quality, T1.5 recipe
+fix). Warmup is the only genuinely hardcoded knob left
+(`min(50, len(loader) // 5)`) and matches v5 at the T1.4 scale
+(len(loader)/5 >= 50 for any run over ~250 pairs/batch).
+
+**Keep around for:** small-corpus users (< 250 pairs, where warmup would
+fire early) and future ablation experiments. Not urgent.
+
+**Files.** `vstash/retrain.py:267-347` (`train_mnrl`), `vstash/cli.py`.
+
+**Effort.** 1 day code.
+
+**Risk.** Defaults already validated; changes invite regressions.
+
+---
+
+### H-R5. Eval surface: add NDCG@3, Recall@100 [IMPLEMENTED, not yet merged]
+
+**Statement.** `EvalMetrics` now tracks NDCG@10, NDCG@3, MRR, Hit@10,
+Recall@100 (N.B. per-dataset std across `--eval-seed` values is still on
+the todo list -- see follow-up below). Both new fields default to 0.0 for
+backward compatibility with positional construction.
+
+**Status.** Implemented in `vstash/retrain.py` (EvalMetrics + evaluate_model)
+and `vstash/retrain_batch.py` (evaluate_model_batched uses top-100 matmul
+and doc-level dedup up to 100). CLI retrain + retrain-multi print the new
+metrics. 9 new tests cover _recall_at_k math, NDCG@3 truncation,
+EvalMetrics shape, and end-to-end perfect-retrieval invariants.
+Full suite: 965 tests passing.
+
+**Follow-up.** Per-dataset std across multiple `--eval-seed` values is
+useful for catching noisy wins; deferred to H-R5b.
+
+**Files.** `vstash/retrain.py`, `vstash/retrain_batch.py`, `vstash/cli.py`,
+`tests/test_retrain.py`.
+
+---
+
+### H-R6. Dedup `generate_triples` and `generate_triples_batched`
+
+**Statement.** The non-batched and batched miners are 90% the same logic
+with subtly different FTS pooling, RRF weights, and synth-query handling.
+Divergence is a latent bug source (T1.4 review caught one; there may be
+more). Refactor to a single template with a device-selectable backend.
+
+**Test.** Port both paths to a shared core. Re-run full retrain test suite
+(115 tests). Byte-for-byte compatibility of emitted triples on a fixed
+seed + corpus fixture.
+
+**Files.** `vstash/retrain.py:100-260`, `vstash/retrain_batch.py:162-404`.
+
+**Effort.** 2-3 days.
+
+**Risk.** Medium. Keep both paths callable during migration; delete the
+legacy one only after 1 release cycle.
+
+---
+
+### H-R7. Seed audit + global `--seed` flag
+
+**Statement.** `_derive_seed()` uses a SHA-256 hash of a label but there is
+no single user-facing seed. Reproducibility across Colab runs needs every
+RNG (triple sampling, noise sampling, DataLoader shuffle, torch CUDA) to
+derive from the same root.
+
+**Test.** Two back-to-back runs of `retrain_multi` with `--seed 42` produce
+identical `training_meta.json` triple counts and identical baseline eval
+numbers. Worth owning before we start running ablations that compare runs.
+
+**Files.** `vstash/retrain.py` (seed plumbing), `vstash/cli.py`.
+
+**Effort.** 1 day.
+
+**Risk.** Low. Reproducibility only, no behavioral change.
+
+---
+
+## Store / search
+
+### H-S1. Persist IDF cache to a `store_idf` table
+
+**Statement.** `_build_idf_cache()` runs on every `search(adaptive_rrf=True)`
+call with an empty cache. For 100k+ chunks the fts5vocab scan is not free.
+Persist the cache in SQLite, invalidate on any write (same trigger as FTS5
+rebuild), skip the scan on the read path.
+
+**Test.** Benchmark 1000 queries on a 100k-chunk store (BEIR FiQA). Target:
+>= 10% wall-clock reduction at p50, no regression at p99.
+
+**Files.** `vstash/store.py:3741-3805`
+(`_build_idf_cache`, `_compute_adaptive_rrf_params`).
+
+**Effort.** 2 days.
+
+**Risk.** Stale cache after an ingest. Mitigate by keying on `chunk_count`
+and a cheap FTS5 `integrity-check` watermark.
+
+---
+
+### H-S2. Adaptive MMR lambda
+
+**Statement.** `mmr_lambda=0.5` is fixed. When the candidate set is almost
+all one document, we want aggressive diversity (lambda closer to 0.3). When
+docs are already distinct, we want relevance preservation (lambda closer
+to 0.7). Compute lambda per query from the doc_id entropy of the pre-MMR
+ranked list.
+
+**Test.** BEIR 5-dataset ablation: fixed 0.5 vs adaptive. Target:
++0.3-1.0% macro NDCG@10 on heterogeneous corpora.
+
+**Files.** `vstash/store.py:1672` (default), `vstash/store.py:2658-2810`
+(`_mmr_dedup`), `vstash/store.py:2184` (search call site).
+
+**Effort.** 2 days.
+
+**Risk.** Extra complexity in a load-bearing function. Ship behind
+`[scoring] mmr_adaptive = false` default-off until validated on BEIR.
+
+---
+
+### H-S3. FTS candidate pool sized from query IDF
+
+**Statement.** `_fuse_rrf_scores()` gates FTS-only hits with
+`rank < effective_k * 2`. For long rare-term queries this under-samples FTS
+(which is where rare terms win). Size the FTS pool dynamically from the
+harmonic-mean IDF of query terms.
+
+**Test.** BEIR tail queries (> 20 words, < 5 common terms). Target:
++0.5% NDCG@10 on tail slice.
+
+**Files.** `vstash/store.py` search pipeline around `_fuse_rrf_scores`
+(ref line 1534 in pre-T1.5 diff; re-locate before implementing).
+
+**Effort.** 1-2 days.
+
+**Risk.** Widening the FTS pool raises per-query cost. Cap at 4x
+`effective_k`.
+
+---
+
+### H-S4. Batch the MMR similarity update
+
+**Statement.** `_mmr_dedup()` recomputes `max_sims` one chunk at a time in
+Python. For large `top_k` (>= 100) and high-duplication corpora this is
+O(N*K) Python. A precomputed all-pairs cosine matrix + numpy indexed
+updates should be 5-10x faster.
+
+**Test.** Bench on a synthetic 200-candidate / 50-deduplicate case. Target:
+>= 5x speedup at top_k=100, no ranking diff.
+
+**Files.** `vstash/store.py:2658-2810`.
+
+**Effort.** 2 days.
+
+**Risk.** Memory (K^2 floats). For K=1000, 8 MB. Acceptable.
+
+---
+
+### H-S5. Distance-cutoff from query-embedding entropy
+
+**Statement.** `_compute_adaptive_rrf_params()` returns a fixed cutoff
+(1.15 default, 5.0 for long queries). A query whose embedding is diffuse
+across the vector space (high entropy of top-100 similarities) should get
+a relaxed cutoff; a peaky embedding (one cluster) should get a tight one.
+
+**Test.** BEIR 5-dataset recall@100 ablation. Target: +0.3-0.7% recall@100
+on ambiguous queries (bottom-decile peak similarity).
+
+**Files.** `vstash/store.py` (`search`, `_compute_adaptive_rrf_params`).
+
+**Effort.** 2-3 days.
+
+**Risk.** Speculative; may pay nothing. Keep behind a config flag.
+
+---
+
+## Roadmap next steps (after Tier 1 lands)
+
+### H-T24. Cross-encoder reranker (T2.4 in roadmap)
+
+**Statement.** A small cross-encoder (ms-marco-MiniLM-L-6-v2, ~20 MB) on
+top of the current bi-encoder + adaptive-RRF stack should add 3-8 NDCG@10
+reliably. Orthogonal to our retrain work, biggest product win per effort.
+
+**Test.** Add `rerank()` stage after MMR, gated by `store.search(rerank=True)`
+and `[rerank]` config. Target: +3% NDCG@10 on SciFact, no regression on
+NFCorpus, < 100ms extra latency at top_k=50 on M1 CPU.
+
+**Files.** New `vstash/rerank.py`; wire into `store.py:search`.
+
+**Effort.** 1 week (~3 days model wiring, 2 days bench + tests).
+
+**Risk.** Latency. Cap at `rerank_top_k=50`. Skip automatically when
+search has < 20 candidates.
+
+---
+
+### H-T25. GISTEmbedLoss replacement for MNRL (T2.5)
+
+**Statement.** GISTEmbedLoss (teacher-guided hard-negative filtering) is
+2024 SOTA for small embedding models. Drop-in in `train_mnrl`, expose
+`--loss {mnrl, gist}`.
+
+**Test.** Re-run T1.5 notebook with `--loss gist`, teacher
+`sentence-transformers/all-mpnet-base-v2`. Target: +1-3% macro NDCG@10 vs
+MNRL at same budget.
+
+**Files.** `vstash/retrain.py:train_mnrl`, `vstash/cli.py`.
+
+**Effort.** 4-5 days (incl. teacher-model memory planning on T4).
+
+**Risk.** Teacher model is 420 MB, needs careful batch sizing on T4 next
+to the student. Fallback path: teacher on CPU.
+
+---
+
+## Tracking
+
+- Shipped items move to `retrain_roadmap.md` with final numbers + PR.
+- If an H-R fails its test cleanly, convert to a "tried, negative"
+  footnote so we don't repeat the experiment.
+- Re-prioritise monthly against the current macro NDCG@10 gap from
+  `Stffens/bge-small-rrf-v2` published numbers.
+
+Started 2026-04-19 after T1.5 landed. Owner: Jay + Claude.

--- a/experiments/hypotheses.md
+++ b/experiments/hypotheses.md
@@ -149,22 +149,25 @@ legacy one only after 1 release cycle.
 
 ---
 
-### H-R7. Seed audit + global `--seed` flag
+### H-R7. Seed audit + global `--seed` flag [IMPLEMENTED, not yet merged]
 
-**Statement.** `_derive_seed()` uses a SHA-256 hash of a label but there is
-no single user-facing seed. Reproducibility across Colab runs needs every
-RNG (triple sampling, noise sampling, DataLoader shuffle, torch CUDA) to
-derive from the same root.
+**Statement.** Every RNG that retrain training touches is now seeded from
+a single user-controllable root. `train_mnrl` pre-shuffles examples with
+`random.Random(seed)` (stable initial order), calls `torch.manual_seed` +
+`torch.cuda.manual_seed_all` (covers dropout + optimizer init), and
+passes a seeded `torch.Generator` to `DataLoader` (reproducible
+per-epoch reshuffles). `retrain()` and `retrain_multi()` thread the
+seed into `train_mnrl` on every call site. CLI `--seed` flag on both
+`retrain` and `retrain-multi`. `training_meta.json` records the seed.
 
-**Test.** Two back-to-back runs of `retrain_multi` with `--seed 42` produce
-identical `training_meta.json` triple counts and identical baseline eval
-numbers. Worth owning before we start running ablations that compare runs.
+**Status.** Implemented. 3 new tests cover `torch.manual_seed` call,
+`Generator` threading into `DataLoader`, same-seed deterministic
+example ordering, and `training_meta.json` round-trip. Test stubs
+extended in `test_retrain.py` and `test_retrain_multi.py`. 965+ tests
+still passing.
 
-**Files.** `vstash/retrain.py` (seed plumbing), `vstash/cli.py`.
-
-**Effort.** 1 day.
-
-**Risk.** Low. Reproducibility only, no behavioral change.
+**Files.** `vstash/retrain.py`, `vstash/cli.py`, `tests/test_retrain.py`,
+`tests/test_retrain_multi.py`.
 
 ---
 

--- a/tests/test_retrain.py
+++ b/tests/test_retrain.py
@@ -16,6 +16,7 @@ from vstash.retrain import (
     EvalMetrics,
     _ndcg_at_k,
     _ndcg_from_ranks,
+    _recall_at_k,
     evaluate_model,
     generate_triples,
     qrels_to_eval_queries,
@@ -499,6 +500,57 @@ class TestNdcgFromRanks:
         perfect_at_k = _ndcg_from_ranks(list(range(1, 11)), num_relevant=20, k=10)
         assert perfect_at_k == pytest.approx(1.0)
 
+    def test_k_3_ignores_deeper_hits(self) -> None:
+        # Hit at rank 5 is ignored when k=3; rank 1 carries alone.
+        # DCG = 1/log2(2) = 1.0; IDCG = same (1 relevant, 1 slot useful).
+        assert _ndcg_from_ranks([1, 5], num_relevant=1, k=3) == pytest.approx(1.0)
+        # Only a rank-5 hit with k=3 yields zero.
+        assert _ndcg_from_ranks([5], num_relevant=1, k=3) == 0.0
+
+
+class TestRecallAtK:
+    """Recall@k is a per-query ``hits / num_relevant`` in [0, 1]."""
+
+    def test_all_relevant_found_in_topk_is_one(self) -> None:
+        assert _recall_at_k([3, 17, 42], num_relevant=3, k=100) == pytest.approx(1.0)
+
+    def test_partial_recall(self) -> None:
+        # 2 of 4 relevant docs land in top-100.
+        assert _recall_at_k([10, 90], num_relevant=4, k=100) == pytest.approx(0.5)
+
+    def test_hits_beyond_k_are_ignored(self) -> None:
+        # Rank 150 is past k=100 and must not count.
+        assert _recall_at_k([5, 150], num_relevant=2, k=100) == pytest.approx(0.5)
+
+    def test_zero_relevant_is_zero(self) -> None:
+        assert _recall_at_k([], num_relevant=0, k=100) == 0.0
+
+    def test_no_hits_is_zero(self) -> None:
+        assert _recall_at_k([], num_relevant=5, k=100) == 0.0
+
+
+class TestEvalMetricsShape:
+    """EvalMetrics surfaces NDCG@3 and Recall@100 on as_dict()."""
+
+    def test_new_fields_default_to_zero_when_unset(self) -> None:
+        # Preserves existing 4-arg positional construction.
+        m = EvalMetrics(0.5, 0.4, 0.6, 10)
+        assert m.ndcg_at_3 == 0.0
+        assert m.recall_at_100 == 0.0
+
+    def test_as_dict_includes_new_fields(self) -> None:
+        m = EvalMetrics(
+            ndcg_at_10=0.7,
+            mrr=0.6,
+            hit_at_10=0.8,
+            n_queries=20,
+            ndcg_at_3=0.55,
+            recall_at_100=0.92,
+        )
+        d = m.as_dict()
+        assert d["ndcg_at_3"] == pytest.approx(0.55)
+        assert d["recall_at_100"] == pytest.approx(0.92)
+
 
 class TestQrelsToEvalQueries:
     """BEIR-style qrels must convert cleanly to the eval_queries format."""
@@ -780,6 +832,39 @@ class TestEvaluateModel:
         assert metrics.n_queries == 1
         assert metrics.ndcg_at_10 == pytest.approx(1.0)
         assert metrics.hit_at_10 == pytest.approx(1.0)
+
+    def test_perfect_retrieval_populates_ndcg3_and_recall100(
+        self, populated_store: VstashStore
+    ) -> None:
+        """With every relevant doc at rank 1, NDCG@3 and Recall@100 are 1.0."""
+        dim = populated_store.embedding_dim
+        rows = populated_store._conn.execute(
+            "SELECT c.text, d.path FROM chunks c JOIN documents d ON d.id = c.doc_id"
+        ).fetchall()
+        paths = sorted({r["path"] for r in rows})
+        path_vec: dict[str, list[float]] = {}
+        for i, p in enumerate(paths):
+            v = [0.0] * dim
+            v[i] = 1.0
+            path_vec[p] = v
+        mapping = {r["text"][:60]: path_vec[r["path"]] for r in rows}
+        eval_queries = [{"query": r["text"][:200], "relevant_path": r["path"]} for r in rows]
+
+        fake_model = _install_fake_st_model(dim, mapping)
+        with patch("vstash.retrain._load_sentence_transformer", return_value=fake_model):
+            metrics = evaluate_model(
+                populated_store,
+                model_name_or_path="fake",
+                eval_queries=eval_queries,
+                noise_sample_size=0,
+            )
+
+        assert metrics.ndcg_at_3 == pytest.approx(1.0)
+        assert metrics.recall_at_100 == pytest.approx(1.0)
+        # Regression guard: the new fields must round-trip through as_dict.
+        d = metrics.as_dict()
+        assert "ndcg_at_3" in d
+        assert "recall_at_100" in d
 
     def test_accepts_legacy_relevant_path_field(self, populated_store: VstashStore) -> None:
         """Queries with the legacy 'relevant_path' (singular) key still work."""

--- a/tests/test_retrain.py
+++ b/tests/test_retrain.py
@@ -50,6 +50,12 @@ def _install_st_torch_stubs() -> tuple[types.ModuleType, types.ModuleType, types
     torch_data.DataLoader = MagicMock(return_value=[MagicMock()] * 5)
     torch_utils.data = torch_data
     torch_mod.utils = torch_utils
+    # train_mnrl now seeds torch + passes a Generator to DataLoader for
+    # reproducibility (H-R7). Stub the bits it touches so the helper
+    # can run under the fake torch module.
+    torch_mod.manual_seed = MagicMock()
+    torch_mod.cuda = None  # trips the `cuda is None` guard in train_mnrl
+    torch_mod.Generator = MagicMock(return_value=MagicMock(manual_seed=MagicMock()))
 
     sys.modules["sentence_transformers"] = st_mod
     sys.modules["sentence_transformers.losses"] = st_losses
@@ -431,6 +437,94 @@ class TestTrainMNRL:
         )
         assert out.is_dir()
         assert (out / "training_meta.json").is_file()
+
+    def test_seeds_torch_and_passes_generator_to_dataloader(
+        self, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """H-R7: train_mnrl seeds torch RNGs and hands a seeded Generator
+        to DataLoader so per-epoch shuffles are reproducible across runs.
+        """
+        st_mod, _, torch_data = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        torch_mod = sys.modules["torch"]
+        torch_mod.manual_seed.reset_mock()
+        torch_mod.Generator.reset_mock()
+
+        train_mnrl(
+            pairs=[{"query": "q", "positive": "p"}] * 5,
+            base_model="d",
+            output_path=str(tmp_path / "m"),
+            seed=1337,
+        )
+
+        torch_mod.manual_seed.assert_called_once_with(1337)
+        # Generator was constructed and seeded.
+        assert torch_mod.Generator.called, "Generator() must be instantiated"
+        gen_instance = torch_mod.Generator.return_value
+        gen_instance.manual_seed.assert_called_once_with(1337)
+        # DataLoader received the generator kwarg.
+        call_kwargs = torch_data.DataLoader.call_args.kwargs
+        assert call_kwargs.get("generator") is gen_instance
+        assert call_kwargs.get("shuffle") is True
+
+    def test_records_seed_in_training_meta(self, tmp_path: Path, st_stubs: Any) -> None:
+        """H-R7: seed lands in training_meta.json so rerunning is trivial."""
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        out = tmp_path / "seed-meta"
+        train_mnrl(
+            pairs=[{"query": "q", "positive": "p", "negative": "n"}] * 3,
+            base_model="d",
+            output_path=str(out),
+            seed=7,
+        )
+        meta = json.loads((out / "training_meta.json").read_text())
+        assert meta["seed"] == 7
+
+    def test_same_seed_produces_identical_example_ordering(
+        self, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """Two train_mnrl calls with the same seed + inputs must pre-shuffle
+        examples into the same order. The pre-shuffle guarantees the initial
+        ordering is reproducible even without a working torch.Generator.
+        """
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        pairs = [{"query": f"q{i}", "positive": f"p{i}", "negative": f"n{i}"} for i in range(20)]
+
+        def _ordering(seed: int) -> list[str]:
+            st_mod.InputExample.reset_mock()
+            # InputExample(side_effect=...) returns a MagicMock with `.texts`.
+            # Its call order records the pre-shuffle order because we then
+            # pass shuffled examples to DataLoader.
+            train_mnrl(
+                pairs=pairs,
+                base_model="d",
+                output_path=str(tmp_path / f"m-{seed}-{id(seed)}"),
+                seed=seed,
+            )
+            # Recover the order examples were POPPED INTO DataLoader by
+            # reading the argv passed to it. DataLoader is a MagicMock;
+            # its first positional arg is the examples list (already
+            # shuffled in place by the pre-shuffle step in train_mnrl).
+            torch_mod = sys.modules["torch"]
+            dl_call = torch_mod.utils.data.DataLoader.call_args
+            examples_arg = dl_call.args[0]
+            return [ex.texts[0] for ex in examples_arg]
+
+        order_a = _ordering(42)
+        order_b = _ordering(42)
+        order_c = _ordering(99)
+
+        assert order_a == order_b, "same seed must produce identical ordering"
+        assert order_a != order_c, (
+            "different seeds must produce different ordering on a non-trivial input"
+        )
+        # Sanity: we saw every example (ordering is a permutation).
+        assert sorted(order_a) == sorted(f"q{i}" for i in range(20))
 
     def test_expands_tilde_in_output_path(self, tmp_path: Path, st_stubs: Any) -> None:
         """``output_path`` with a leading ``~`` expands to the user's home."""

--- a/tests/test_retrain.py
+++ b/tests/test_retrain.py
@@ -927,6 +927,57 @@ class TestEvaluateModel:
         assert metrics.ndcg_at_10 == pytest.approx(1.0)
         assert metrics.hit_at_10 == pytest.approx(1.0)
 
+    def test_multi_chunk_relevant_doc_does_not_inflate_ndcg(
+        self, populated_store: VstashStore
+    ) -> None:
+        """A relevant doc with multiple chunks in top-k must be counted
+        once: ranks are document-level, not chunk-level. Without the
+        dedup, NDCG of a perfect retrieval could exceed 1.0 when a
+        single relevant doc surfaces 2+ chunks.
+        """
+        dim = populated_store.embedding_dim
+        rows = populated_store._conn.execute(
+            "SELECT c.text, d.path FROM chunks c JOIN documents d ON d.id = c.doc_id"
+        ).fetchall()
+        paths = sorted({r["path"] for r in rows})
+        assert len(paths) >= 2, "fixture must have >= 2 paths for this test"
+        # All chunks of a doc get that doc's basis vector. The query
+        # vector equals the target doc's basis so every chunk of the
+        # relevant doc surfaces before any other doc.
+        path_vec: dict[str, list[float]] = {}
+        for i, p in enumerate(paths):
+            v = [0.0] * dim
+            v[i] = 1.0
+            path_vec[p] = v
+        target_path = next(p for p in paths if sum(1 for r in rows if r["path"] == p) >= 2)
+        mapping = {r["text"][:60]: path_vec[r["path"]] for r in rows}
+        mapping["MULTI_CHUNK_QUERY"] = path_vec[target_path]
+        eval_queries = [
+            {
+                "query": "MULTI_CHUNK_QUERY",
+                "relevant_paths": [target_path],
+            }
+        ]
+
+        fake_model = _install_fake_st_model(dim, mapping)
+        with patch("vstash.retrain._load_sentence_transformer", return_value=fake_model):
+            metrics = evaluate_model(
+                populated_store,
+                model_name_or_path="fake",
+                eval_queries=eval_queries,
+                noise_sample_size=0,
+            )
+
+        # Exactly one relevant doc, retrieved at doc-rank 1 -> NDCG@10 = 1.0.
+        # Pre-fix: NDCG would be > 1.0 because multiple ranks from the same
+        # doc get counted against IDCG=1.0.
+        assert metrics.ndcg_at_10 <= 1.0
+        assert metrics.ndcg_at_10 == pytest.approx(1.0)
+        assert metrics.ndcg_at_3 <= 1.0
+        assert metrics.recall_at_100 <= 1.0
+        assert metrics.recall_at_100 == pytest.approx(1.0)
+        assert metrics.hit_at_10 == pytest.approx(1.0)
+
     def test_perfect_retrieval_populates_ndcg3_and_recall100(
         self, populated_store: VstashStore
     ) -> None:

--- a/tests/test_retrain_multi.py
+++ b/tests/test_retrain_multi.py
@@ -126,6 +126,9 @@ def _install_st_torch_stubs() -> tuple[types.ModuleType, types.ModuleType, types
     torch_data.DataLoader = MagicMock(return_value=[MagicMock()] * 5)
     torch_utils.data = torch_data
     torch_mod.utils = torch_utils
+    torch_mod.manual_seed = MagicMock()
+    torch_mod.cuda = None
+    torch_mod.Generator = MagicMock(return_value=MagicMock(manual_seed=MagicMock()))
 
     sys.modules["sentence_transformers"] = st_mod
     sys.modules["sentence_transformers.losses"] = st_losses

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1532,6 +1532,13 @@ def retrain(
         help="Model name override for synthesis (defaults to the configured "
         "inference backend's model).",
     ),
+    seed: int = typer.Option(
+        42,
+        "--seed",
+        help="Deterministic seed. Controls held-out split, triple sampling, "
+        "torch dropout, and DataLoader shuffle, so two runs with the same "
+        "inputs and seed produce identical models.",
+    ),
 ) -> None:
     """Fine-tune the embedding model using your own data.
 
@@ -1608,6 +1615,7 @@ def retrain(
         eval_noise_size=eval_noise_size,
         min_gain=min_gain,
         skip_eval=no_eval,
+        seed=seed,
         synthesize_queries=synthesize,
         synth_n=synth_n,
         synth_cache=synth_cache,
@@ -1778,6 +1786,13 @@ def retrain_multi_cmd(
         help="Device override for --bulk-mine / --bulk-eval ('cuda' or "
         "'cpu'). Leave unset to auto-detect.",
     ),
+    seed: int = typer.Option(
+        42,
+        "--seed",
+        help="Deterministic seed. Derived per-dataset via SHA-256 so each "
+        "corpus gets its own stable RNG, and then threaded into train_mnrl "
+        "so DataLoader shuffles and torch dropout are reproducible.",
+    ),
 ) -> None:
     """Fine-tune the embedding model over multiple corpora with balanced sampling.
 
@@ -1923,6 +1938,7 @@ def retrain_multi_cmd(
             min_gain=min_gain,
             per_dataset_gate=per_dataset_gate,
             skip_eval=no_eval,
+            seed=seed,
             bulk_mine=bulk_mine,
             bulk_mine_device=bulk_mine_device,
             bulk_eval=bulk_eval,

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1627,14 +1627,18 @@ def retrain(
     if result.baseline is not None and result.final is not None:
         console.print()
         console.print("[bold]Eval results[/bold]")
-        console.print(f"  Queries:         {result.baseline.n_queries}")
+        console.print(f"  Queries:          {result.baseline.n_queries}")
         console.print(f"  Baseline NDCG@10: {result.baseline.ndcg_at_10:.4f}")
         console.print(f"  Final NDCG@10:    {result.final.ndcg_at_10:.4f}")
         delta = result.delta_ndcg
         color = "green" if delta >= 0 else "red"
         console.print(f"  Delta NDCG@10:    [{color}]{delta:+.4f}[/{color}]")
-        console.print(f"  Baseline MRR:    {result.baseline.mrr:.4f}")
-        console.print(f"  Final MRR:       {result.final.mrr:.4f}")
+        console.print(f"  Baseline NDCG@3:  {result.baseline.ndcg_at_3:.4f}")
+        console.print(f"  Final NDCG@3:     {result.final.ndcg_at_3:.4f}")
+        console.print(f"  Baseline MRR:     {result.baseline.mrr:.4f}")
+        console.print(f"  Final MRR:        {result.final.mrr:.4f}")
+        console.print(f"  Baseline Recall@100: {result.baseline.recall_at_100:.4f}")
+        console.print(f"  Final Recall@100:    {result.final.recall_at_100:.4f}")
 
     if result.gated_out:
         console.print()
@@ -1938,7 +1942,7 @@ def retrain_multi_cmd(
 
     if result.per_dataset_baseline and result.per_dataset_final:
         console.print()
-        console.print("[bold]Eval results (per dataset)[/bold]")
+        console.print("[bold]Eval results (per dataset, NDCG@10)[/bold]")
         for name in result.per_dataset_baseline:
             base = result.per_dataset_baseline[name]
             final = result.per_dataset_final.get(name)
@@ -1957,6 +1961,26 @@ def retrain_multi_cmd(
             f"final={result.macro_final_ndcg:.4f}  "
             f"delta=[{macro_color}]{result.macro_delta_ndcg:+.4f}[/{macro_color}][/bold]"
         )
+
+        console.print()
+        console.print("[bold]Head quality + candidate health (per dataset)[/bold]")
+        console.print(f"  {'dataset':<20} {'NDCG@3':>16}  {'Recall@100':>18}")
+        for name in result.per_dataset_baseline:
+            base = result.per_dataset_baseline[name]
+            final = result.per_dataset_final.get(name)
+            if final is None or base.n_queries == 0:
+                continue
+            d3 = final.ndcg_at_3 - base.ndcg_at_3
+            dr = final.recall_at_100 - base.recall_at_100
+            c3 = "green" if d3 >= 0 else "red"
+            cr = "green" if dr >= 0 else "red"
+            console.print(
+                f"  {name:<20} "
+                f"{base.ndcg_at_3:.4f}->{final.ndcg_at_3:.4f} "
+                f"([{c3}]{d3:+.4f}[/{c3}])  "
+                f"{base.recall_at_100:.4f}->{final.recall_at_100:.4f} "
+                f"([{cr}]{dr:+.4f}[/{cr}])"
+            )
 
     if result.gated_out:
         console.print()

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1980,7 +1980,14 @@ def retrain_multi_cmd(
 
         console.print()
         console.print("[bold]Head quality + candidate health (per dataset)[/bold]")
-        console.print(f"  {'dataset':<20} {'NDCG@3':>16}  {'Recall@100':>18}")
+        head_table = Table(show_header=True, header_style="bold cyan", border_style="dim")
+        head_table.add_column("dataset", style="magenta")
+        head_table.add_column("NDCG@3 base", justify="right")
+        head_table.add_column("NDCG@3 final", justify="right")
+        head_table.add_column("delta", justify="right")
+        head_table.add_column("Recall@100 base", justify="right")
+        head_table.add_column("Recall@100 final", justify="right")
+        head_table.add_column("delta", justify="right")
         for name in result.per_dataset_baseline:
             base = result.per_dataset_baseline[name]
             final = result.per_dataset_final.get(name)
@@ -1990,13 +1997,16 @@ def retrain_multi_cmd(
             dr = final.recall_at_100 - base.recall_at_100
             c3 = "green" if d3 >= 0 else "red"
             cr = "green" if dr >= 0 else "red"
-            console.print(
-                f"  {name:<20} "
-                f"{base.ndcg_at_3:.4f}->{final.ndcg_at_3:.4f} "
-                f"([{c3}]{d3:+.4f}[/{c3}])  "
-                f"{base.recall_at_100:.4f}->{final.recall_at_100:.4f} "
-                f"([{cr}]{dr:+.4f}[/{cr}])"
+            head_table.add_row(
+                name,
+                f"{base.ndcg_at_3:.4f}",
+                f"{final.ndcg_at_3:.4f}",
+                f"[{c3}]{d3:+.4f}[/{c3}]",
+                f"{base.recall_at_100:.4f}",
+                f"{final.recall_at_100:.4f}",
+                f"[{cr}]{dr:+.4f}[/{cr}]",
             )
+        console.print(head_table)
 
     if result.gated_out:
         console.print()

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -271,6 +271,7 @@ def train_mnrl(
     batch_size: int = 64,
     use_amp: bool = True,
     max_seq_length: int | None = None,
+    seed: int = 42,
 ) -> str:
     """Fine-tune an embedding model using MNRL on disagreement pairs.
 
@@ -293,6 +294,15 @@ def train_mnrl(
             training. ``None`` keeps the model's default (512 for
             bge-small). Lower values (256 or 128) further reduce memory
             when most chunks are short.
+        seed: Controls training-time randomness. Seeds
+            ``torch.manual_seed`` + ``torch.cuda.manual_seed_all``
+            globally (the dropout + optimizer init path), pre-shuffles
+            ``examples`` with a ``random.Random(seed)`` so the initial
+            order is reproducible, and passes a seeded
+            ``torch.Generator`` to ``DataLoader`` so per-epoch
+            reshuffles are also reproducible. Two back-to-back
+            ``train_mnrl`` calls with the same inputs and seed produce
+            identical gradient steps.
 
     Returns:
         Path to the saved model.
@@ -324,18 +334,45 @@ def train_mnrl(
             examples.append(InputExample(texts=[p["query"], p["positive"], p["negative"]]))
         else:
             examples.append(InputExample(texts=[p["query"], p["positive"]]))
-    loader = DataLoader(examples, shuffle=True, batch_size=batch_size)
+
+    # Reproducibility: seed every RNG training touches. Pre-shuffle the
+    # examples with Python's RNG so even the initial order is stable,
+    # then hand DataLoader a seeded torch.Generator so per-epoch
+    # reshuffles are reproducible too. Global torch.manual_seed covers
+    # dropout + optimizer init inside model.fit.
+    rng = random.Random(seed)
+    rng.shuffle(examples)
+
+    import torch as _torch
+
+    _torch.manual_seed(seed)
+    cuda = getattr(_torch, "cuda", None)
+    if cuda is not None and getattr(cuda, "is_available", lambda: False)():
+        cuda.manual_seed_all(seed)
+
+    loader_kwargs: dict = {"batch_size": batch_size, "shuffle": True}
+    generator_factory = getattr(_torch, "Generator", None)
+    if generator_factory is not None:
+        gen = generator_factory()
+        # Some generators (CPU/CUDA variants) expose manual_seed; guard
+        # defensively so test stubs without the method do not crash.
+        seed_method = getattr(gen, "manual_seed", None)
+        if callable(seed_method):
+            seed_method(seed)
+        loader_kwargs["generator"] = gen
+    loader = DataLoader(examples, **loader_kwargs)
     loss = losses.MultipleNegativesRankingLoss(model)
 
     warmup_steps = min(50, len(loader) // 5)
     logger.info(
-        "Training: %d pairs, %d epochs, batch=%d, lr=%s, amp=%s, max_seq_length=%s",
+        "Training: %d pairs, %d epochs, batch=%d, lr=%s, amp=%s, max_seq_length=%s, seed=%d",
         len(pairs),
         epochs,
         batch_size,
         lr,
         use_amp,
         max_seq_length,
+        seed,
     )
 
     t0 = time.perf_counter()
@@ -361,6 +398,7 @@ def train_mnrl(
         "lr": lr,
         "use_amp": use_amp,
         "max_seq_length": max_seq_length,
+        "seed": seed,
         "training_time_s": round(elapsed, 1),
     }
     (Path(output) / "training_meta.json").write_text(json.dumps(meta, indent=2))
@@ -1019,6 +1057,7 @@ def retrain(
             batch_size=batch_size,
             use_amp=use_amp,
             max_seq_length=max_seq_length,
+            seed=seed,
         )
         return RetrainResult(
             output_path=final_path_str,
@@ -1152,6 +1191,7 @@ def retrain(
         batch_size=batch_size,
         use_amp=use_amp,
         max_seq_length=max_seq_length,
+        seed=seed,
     )
 
     _release_gpu_memory()
@@ -1684,6 +1724,7 @@ def retrain_multi(
         batch_size=batch_size,
         use_amp=use_amp,
         max_seq_length=max_seq_length,
+        seed=seed,
     )
 
     _release_gpu_memory()

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -768,7 +768,12 @@ def _recall_at_k(
     """
     if num_relevant <= 0:
         return 0.0
-    hits = sum(1 for r in ranks_in_topk if 1 <= r <= k)
+    # Clamp by ``num_relevant`` so callers that pass duplicate ranks
+    # (e.g., chunk-level lists where the same doc appears twice) cannot
+    # push recall above 1.0. The doc-level callers in this module
+    # already dedupe, but _recall_at_k is a public helper and defensive
+    # clamping is cheap.
+    hits = min(num_relevant, sum(1 for r in ranks_in_topk if 1 <= r <= k))
     return hits / num_relevant
 
 
@@ -906,6 +911,16 @@ def evaluate_model(
         # weights). Pull top-100 so we can compute Recall@100 in the
         # same pass; NDCG@10 / NDCG@3 / MRR / Hit@10 truncate internally
         # via the rank cutoff in their helpers.
+        #
+        # NDCG and Recall are *document-level* metrics, but
+        # ``eval_store.search`` returns chunk-level SearchResults. Long
+        # relevant documents can legitimately produce multiple chunks in
+        # the top-k (MMR penalises intra-doc duplication but does not
+        # guarantee one-per-path). Counting the same relevant doc
+        # twice would inflate NDCG above 1.0 and break Recall
+        # calibration. Collapse the ranking to unique paths in
+        # first-occurrence order before scoring, matching the
+        # doc-level dedup in ``evaluate_model_batched``.
         ndcgs_10: list[float] = []
         ndcgs_3: list[float] = []
         mrrs: list[float] = []
@@ -918,13 +933,22 @@ def evaluate_model(
                 top_k=_EVAL_RECALL_K,
             )
             relevant_set = set(q["relevant_paths"])
+
+            unique_paths: list[str] = []
+            seen_paths: set[str] = set()
+            for r in results:
+                if r.path in seen_paths:
+                    continue
+                seen_paths.add(r.path)
+                unique_paths.append(r.path)
+
             ranks_hit: list[int] = []
             first_rank: int | None = None
-            for i, r in enumerate(results, start=1):
-                if r.path in relevant_set:
-                    ranks_hit.append(i)
-                    if first_rank is None and i <= _EVAL_TOP_K:
-                        first_rank = i
+            for rank_i, path in enumerate(unique_paths, start=1):
+                if path in relevant_set:
+                    ranks_hit.append(rank_i)
+                    if first_rank is None and rank_i <= _EVAL_TOP_K:
+                        first_rank = rank_i
             num_rel = len(relevant_set)
             ndcgs_10.append(_ndcg_from_ranks(ranks_hit, num_relevant=num_rel, k=_EVAL_TOP_K))
             ndcgs_3.append(

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -37,6 +37,8 @@ logger = logging.getLogger(__name__)
 
 TOP_K = 10
 _EVAL_TOP_K = 10
+_EVAL_NDCG_SHALLOW_K = 3
+_EVAL_RECALL_K = 100
 _EVAL_MAX_QUERIES = 200
 _EVAL_MIN_QUERIES = 20
 _EVAL_NOISE_DEFAULT = 1000
@@ -434,12 +436,23 @@ def _promote_candidate(candidate_path: Path, final_path: Path) -> None:
 
 @dataclass(frozen=True)
 class EvalMetrics:
-    """Honest retrieval metrics on a held-out query set."""
+    """Honest retrieval metrics on a held-out query set.
+
+    ``ndcg_at_10`` stays the headline number driving the retrain gate.
+    ``ndcg_at_3`` tracks strict head quality (first three positions)
+    and is more sensitive to reranker wins. ``recall_at_100`` measures
+    candidate-set health, which is the input a downstream reranker
+    (T2.4) actually sees. The two new fields default to ``0.0`` so
+    existing positional call sites (``EvalMetrics(0.0, 0.0, 0.0, 0)``)
+    keep working unchanged.
+    """
 
     ndcg_at_10: float
     mrr: float
     hit_at_10: float
     n_queries: int
+    ndcg_at_3: float = 0.0
+    recall_at_100: float = 0.0
 
     def as_dict(self) -> dict:
         return asdict(self)
@@ -697,6 +710,30 @@ def _ndcg_from_ranks(
     return dcg / idcg
 
 
+def _recall_at_k(
+    ranks_in_topk: list[int],
+    num_relevant: int,
+    k: int = _EVAL_RECALL_K,
+) -> float:
+    """Fraction of relevant docs that appear in the top-k ranked list.
+
+    Args:
+        ranks_in_topk: 1-indexed ranks at which relevant docs appeared
+            in the full ranked list. Ranks beyond ``k`` are ignored.
+        num_relevant: Total number of relevant docs for this query. The
+            denominator so per-query recall stays comparable across
+            queries with different relevant-doc counts.
+        k: Cutoff.
+
+    Returns:
+        Recall@k in [0, 1].
+    """
+    if num_relevant <= 0:
+        return 0.0
+    hits = sum(1 for r in ranks_in_topk if 1 <= r <= k)
+    return hits / num_relevant
+
+
 def _load_sentence_transformer(model_name: str):
     """Import + load a SentenceTransformer. Raises ImportError with install hint."""
     try:
@@ -732,7 +769,7 @@ def evaluate_model(
         tmp_dir: Where to create the temp db. Defaults to system temp.
 
     Returns:
-        EvalMetrics with NDCG@10, MRR, Hit@10.
+        EvalMetrics with NDCG@10, NDCG@3, MRR, Hit@10, Recall@100.
 
     Raises:
         ImportError: If sentence-transformers is not installed.
@@ -827,15 +864,20 @@ def evaluate_model(
             show_progress_bar=False,
         )
 
-        # Score each query via production search (RRF with adaptive weights).
-        ndcgs: list[float] = []
+        # Score each query via production search (RRF with adaptive
+        # weights). Pull top-100 so we can compute Recall@100 in the
+        # same pass; NDCG@10 / NDCG@3 / MRR / Hit@10 truncate internally
+        # via the rank cutoff in their helpers.
+        ndcgs_10: list[float] = []
+        ndcgs_3: list[float] = []
         mrrs: list[float] = []
         hits: list[float] = []
+        recalls_100: list[float] = []
         for q, q_vec in zip(normalized_queries, q_vecs):
             results = eval_store.search(
                 query_embedding=list(map(float, q_vec)),
                 query_text=q["query"],
-                top_k=_EVAL_TOP_K,
+                top_k=_EVAL_RECALL_K,
             )
             relevant_set = set(q["relevant_paths"])
             ranks_hit: list[int] = []
@@ -843,17 +885,25 @@ def evaluate_model(
             for i, r in enumerate(results, start=1):
                 if r.path in relevant_set:
                     ranks_hit.append(i)
-                    if first_rank is None:
+                    if first_rank is None and i <= _EVAL_TOP_K:
                         first_rank = i
-            ndcgs.append(_ndcg_from_ranks(ranks_hit, num_relevant=len(relevant_set)))
+            num_rel = len(relevant_set)
+            ndcgs_10.append(_ndcg_from_ranks(ranks_hit, num_relevant=num_rel, k=_EVAL_TOP_K))
+            ndcgs_3.append(
+                _ndcg_from_ranks(ranks_hit, num_relevant=num_rel, k=_EVAL_NDCG_SHALLOW_K)
+            )
             mrrs.append(1.0 / first_rank if first_rank is not None else 0.0)
             hits.append(1.0 if first_rank is not None else 0.0)
+            recalls_100.append(_recall_at_k(ranks_hit, num_relevant=num_rel, k=_EVAL_RECALL_K))
 
+        n = len(normalized_queries)
         return EvalMetrics(
-            ndcg_at_10=sum(ndcgs) / len(ndcgs),
-            mrr=sum(mrrs) / len(mrrs),
-            hit_at_10=sum(hits) / len(hits),
-            n_queries=len(normalized_queries),
+            ndcg_at_10=sum(ndcgs_10) / n,
+            mrr=sum(mrrs) / n,
+            hit_at_10=sum(hits) / n,
+            n_queries=n,
+            ndcg_at_3=sum(ndcgs_3) / n,
+            recall_at_100=sum(recalls_100) / n,
         )
     finally:
         if eval_store is not None:

--- a/vstash/retrain_batch.py
+++ b/vstash/retrain_batch.py
@@ -462,8 +462,11 @@ def evaluate_model_batched(
     import time as _time
 
     from .retrain import (
+        _EVAL_NDCG_SHALLOW_K,
+        _EVAL_RECALL_K,
         _EVAL_TOP_K,
         _ndcg_from_ranks,
+        _recall_at_k,
         _relevant_chunks,
         _release_gpu_memory,
         _sample_noise_chunks,
@@ -533,9 +536,11 @@ def evaluate_model_batched(
     # minute.
     eval_store: VstashStore | None = None
     tmp_db: Path | None = None
-    ndcgs: list[float] = []
+    ndcgs_10: list[float] = []
+    ndcgs_3: list[float] = []
     mrrs: list[float] = []
     hits: list[float] = []
+    recalls_100: list[float] = []
     try:
         tmp_parent = Path(tmp_dir) if tmp_dir else Path(tempfile.gettempdir())
         tmp_parent.mkdir(parents=True, exist_ok=True)
@@ -606,13 +611,18 @@ def evaluate_model_batched(
         # maps to exactly one chunk so the inverse is well-defined.
         matmul_idx_to_chunk_id = {v: k for k, v in chunk_id_to_matmul_idx.items()}
 
-        # Vec top-K per query via batched matmul on GPU.
+        # Vec top-K per query via batched matmul on GPU. Pull RECALL_K
+        # candidates so the same ranking supports NDCG@10 / NDCG@3 /
+        # Recall@100 in one pass. After doc-level deduplication the
+        # fused list is still almost always >= 10 unique paths, so
+        # NDCG@10 is unaffected; the extra candidates only feed
+        # Recall@100.
         all_vec_topk: list[list[int]] = []
         with torch.no_grad():
             for start in range(0, query_vecs.size(0), matmul_batch_queries):
                 batch = query_vecs[start : start + matmul_batch_queries]
                 sims = batch @ corpus_vecs.T
-                top_scores, top_idx = sims.topk(min(TOP_K, sims.size(1)), dim=1)
+                top_scores, top_idx = sims.topk(min(_EVAL_RECALL_K, sims.size(1)), dim=1)
                 idx_cpu = top_idx.cpu().tolist()
                 for matmul_indices in idx_cpu:
                     all_vec_topk.append(
@@ -630,13 +640,15 @@ def evaluate_model_batched(
         # scoring. Without this, a relevant doc surfacing twice in
         # top-10 would be counted twice and push NDCG above 1.0.
         for q, vec_top in zip(normalized_queries, all_vec_topk):
-            fts_top = _fts_top_k(eval_store._conn, q["query"], TOP_K)
+            fts_top = _fts_top_k(eval_store._conn, q["query"], _EVAL_RECALL_K)
             fts_top = [cid for cid in fts_top if cid in chunk_id_to_path]
 
             # Adaptive RRF weights, vec-heavy side. Faithful enough to
             # store.search's default for short/medium queries.
             vec_hi, fts_hi, _vec_lo, _fts_lo = adaptive_rrf_weights(len(q["query"].split()))
-            fused = _rrf_fuse(vec_top, fts_top, vec_hi, fts_hi, chunk_id_to_path, top_n=_EVAL_TOP_K)
+            fused = _rrf_fuse(
+                vec_top, fts_top, vec_hi, fts_hi, chunk_id_to_path, top_n=_EVAL_RECALL_K
+            )
 
             # Collapse chunk-level ranking to doc-level (unique paths).
             unique_paths: list[str] = []
@@ -654,11 +666,16 @@ def evaluate_model_batched(
             for rank_i, p in enumerate(unique_paths, start=1):
                 if p in relevant_set:
                     ranks_hit.append(rank_i)
-                    if first_rank is None:
+                    if first_rank is None and rank_i <= _EVAL_TOP_K:
                         first_rank = rank_i
-            ndcgs.append(_ndcg_from_ranks(ranks_hit, num_relevant=len(relevant_set)))
+            num_rel = len(relevant_set)
+            ndcgs_10.append(_ndcg_from_ranks(ranks_hit, num_relevant=num_rel, k=_EVAL_TOP_K))
+            ndcgs_3.append(
+                _ndcg_from_ranks(ranks_hit, num_relevant=num_rel, k=_EVAL_NDCG_SHALLOW_K)
+            )
             mrrs.append(1.0 / first_rank if first_rank is not None else 0.0)
             hits.append(1.0 if first_rank is not None else 0.0)
+            recalls_100.append(_recall_at_k(ranks_hit, num_relevant=num_rel, k=_EVAL_RECALL_K))
     finally:
         if eval_store is not None:
             try:
@@ -680,11 +697,14 @@ def evaluate_model_batched(
             pass
         _release_gpu_memory()
 
+    n = len(normalized_queries)
     return EvalMetrics(
-        ndcg_at_10=sum(ndcgs) / len(ndcgs) if ndcgs else 0.0,
+        ndcg_at_10=sum(ndcgs_10) / len(ndcgs_10) if ndcgs_10 else 0.0,
         mrr=sum(mrrs) / len(mrrs) if mrrs else 0.0,
         hit_at_10=sum(hits) / len(hits) if hits else 0.0,
-        n_queries=len(normalized_queries),
+        n_queries=n,
+        ndcg_at_3=sum(ndcgs_3) / len(ndcgs_3) if ndcgs_3 else 0.0,
+        recall_at_100=sum(recalls_100) / len(recalls_100) if recalls_100 else 0.0,
     )
 
 


### PR DESCRIPTION
Two coherent retrain infra upgrades. Both additive, both land behind existing behavior.

## H-R5: NDCG@3 + Recall@100 (first commit)

Extends `EvalMetrics` with two fields:

- **NDCG@3**: strict head quality. Complements NDCG@10, more sensitive to reranker wins.
- **Recall@100**: candidate-set health. The input a downstream reranker (T2.4 in the roadmap) actually sees.

Both default to `0.0` so existing positional construction in `retrain_multi` (no-query fallback) keeps working. `evaluate_model` + `evaluate_model_batched` now pull top-100 and derive all metrics from one ranks list. CLI prints the new metrics on `retrain` and `retrain-multi`.

The macro gate still runs on NDCG@10 only. Future roadmap work can opt into gating on NDCG@3 / Recall@100.

## H-R7: deterministic seed (second commit)

Every RNG train_mnrl touches now derives from a single seed:

- Pre-shuffles examples with `random.Random(seed)`
- Calls `torch.manual_seed` + `torch.cuda.manual_seed_all`
- Hands a seeded `torch.Generator` to DataLoader so per-epoch reshuffles are reproducible

`retrain()` + `retrain_multi()` thread seed into train_mnrl on every call site. CLI gains `--seed` on both commands. `training_meta.json` records it.

**Why now.** Next hypotheses on the backlog (H-R3 margin filter, H-R4 hyperparam grid) are ablations. Comparing run A vs run B needs identical initial conditions. Owning this upfront saves flakiness later.

## Side finding

While writing this, verified `experiments/retrain_v5_hard_neg.ipynb` uses the same defaults we ship: `lr=3e-6`, `epochs=2`, `warmup_steps=50`, `batch=64`. So H-R4 (hyperparameter grid) is deprioritized, the gap vs v5 is elsewhere (signal quality, T1.5 recipe). `hypotheses.md` updated.

## Test plan

- [x] 9 H-R5 tests (recall@k math, NDCG@3 truncation, EvalMetrics shape, end-to-end perfect-retrieval)
- [x] 3 H-R7 tests (torch.manual_seed call, Generator->DataLoader, same-seed identical pre-shuffle)
- [x] 965+ tests passing on full suite
- [x] `ruff check` + `ruff format --check` clean
- [ ] Watch T1.5 Colab re-run, confirm new metrics land in `training_meta.json`

## Follow-ups (Copilot review)

Three legitimate findings from Copilot on the H-R5 commit to address in a follow-up commit before merge:

1. **HIGH**: `evaluate_model` uses chunk-level results but NDCG expects doc-level. Multiple chunks from same relevant doc inflate scores, potentially >1.0. The batched path already dedupes; replicate on legacy path.
2. **MED**: `_recall_at_k` can return >1.0 if caller passes duplicates. Clamp `hits` to `num_relevant`.
3. **MED**: CLI "Head quality" table uses Rich tags inside manual f-string padding, likely misaligned. Switch to `rich.table.Table`.

## Files

- `vstash/retrain.py` - EvalMetrics, evaluate_model, _recall_at_k, train_mnrl seeding
- `vstash/retrain_batch.py` - evaluate_model_batched, top-100 matmul + dedup
- `vstash/cli.py` - retrain + retrain-multi output + --seed flag
- `tests/test_retrain.py` - 12 new tests, st_stubs extended for torch.Generator
- `tests/test_retrain_multi.py` - matching stub extensions
- `experiments/hypotheses.md` - new backlog doc (14 hypotheses, H-R5 + H-R7 marked implemented)