### PR TITLE
docs: retrain evolution narrative (README + docs/retrain.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![python](https://img.shields.io/badge/python-3.10+-blue)]()
 [![tests](https://img.shields.io/badge/tests-900+_passing-brightgreen)]()
 
-**Local document memory with hybrid retrieval.** Single SQLite file. Zero cloud dependencies for search. Beats ColBERTv2 on SciFact, NFCorpus, SciDocs, and FiQA ([BEIR](https://github.com/beir-cellar/beir), 4 of 5 datasets). Under 60 ms p50 at 50K chunks.
+**Local document memory with hybrid retrieval.** Single SQLite file. Zero cloud dependencies for search. Beats ColBERTv2 on **5/5 [BEIR](https://github.com/beir-cellar/beir) datasets** with the tuned [`bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) model. Under 60 ms p50 at 50K chunks on an Apple Silicon laptop.
 
 ```bash
 pip install vstash
@@ -17,15 +17,15 @@ vstash search "what's the main argument?"
 
 ## Retrieval Quality
 
-| Dataset | Docs | vstash (v3) | ColBERTv2 | BM25 | vs ColBERTv2 |
-|---------|:----:|:-----------:|:---------:|:----:|:------------:|
-| SciFact | 5.2K | **0.9361** | 0.693 | 0.665 | **+35.1%** |
-| NFCorpus | 3.6K | **0.3927** | 0.344 | 0.325 | **+14.2%** |
-| SciDocs | 25.7K | **0.3693** | 0.154 | 0.158 | **+139.8%** |
-| FiQA | 57.6K | **0.7506** | 0.356 | 0.236 | **+110.8%** |
-| ArguAna | 8.7K | **0.7540** | 0.463 | 0.315 | **+62.9%** |
+| Dataset | Docs | vstash (v3) | ColBERTv2 | BM25 | Δ vs ColBERTv2 |
+|---------|:----:|:-----------:|:---------:|:----:|:--------------:|
+| SciFact | 5.2K | **0.9361** | 0.693 | 0.665 | **+0.243** |
+| NFCorpus | 3.6K | **0.3927** | 0.344 | 0.325 | **+0.049** |
+| SciDocs | 25.7K | **0.3693** | 0.154 | 0.158 | **+0.215** |
+| FiQA | 57.6K | **0.7506** | 0.356 | 0.236 | **+0.395** |
+| ArguAna | 8.7K | **0.7540** | 0.463 | 0.315 | **+0.291** |
 
-*NDCG@10 on [BEIR](https://github.com/beir-cellar/beir) via the current vstash retrieval pipeline (RRF hybrid + adaptive weights + doc-level dedup, 2026-04-19). Tuned model: [`Stffens/bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) (33M params, 384d). v3 beats ColBERTv2 on **5/5 BEIR datasets** and improves macro NDCG@10 by +1.6 absolute over [`bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2). See [experiments/results/v2_v3_head_to_head.json](experiments/results/v2_v3_head_to_head.json) for the full apples-to-apples table and reproduce via `python -m experiments.v2_v3_head_to_head`.*
+*Absolute NDCG@10 on [BEIR](https://github.com/beir-cellar/beir) via the full production retrieval pipeline (RRF hybrid + adaptive weights + MMR dedup + IDF, 2026-04-19). Tuned model: [`Stffens/bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) (33M params, 384d). v3 beats ColBERTv2 on **5/5 BEIR datasets** and improves macro NDCG@10 by +0.016 absolute over [`bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) (0.6405 vs 0.6246). Training-time eval uses a batched path that skips MMR/IDF for speed; absolute NDCG@10 differs by a few percent vs the production numbers above, but baseline-vs-final deltas are preserved. See [experiments/results/v2_v3_head_to_head.json](experiments/results/v2_v3_head_to_head.json) for the full table (reproduce via `python -m experiments.v2_v3_head_to_head`) and the methodological note in [experiments/hypotheses.md](experiments/hypotheses.md) for the pipeline-shift caveat.*
 
 ---
 
@@ -206,7 +206,7 @@ Adaptive RRF, self-supervised embedding refinement, a negative result on post-RR
 |---|---|---|
 | [BEIR Benchmark](experiments/beir_benchmark.py) | Beats ColBERTv2 on 4/5 BEIR datasets (SciFact, NFCorpus, SciDocs, FiQA) | `python -m experiments.beir_benchmark --no-chroma` |
 | [Retrain (eval-gated)](docs/retrain.md) | Fine-tune your embedding model on your own corpus, refuses regressions | `vstash retrain --help` |
-| [Pipeline latency](experiments/vstash_pipeline_ivfpq_bench.py) | Under 60 ms p50 @ 50K, 0.80x with snapvec-ivfpq @ 100K | `python -m experiments.vstash_pipeline_ivfpq_bench --n 100000` |
+| [Pipeline latency](experiments/vstash_pipeline_ivfpq_bench.py) | Under 60 ms p50 @ 50K, 0.80x with snapvec-ivfpq @ 100K (Apple Silicon laptop) | `python -m experiments.vstash_pipeline_ivfpq_bench --n 100000` |
 | [Relevance Signal](experiments/relevance_signal_beir.py) | F1=0.996 cross-domain | `python -m experiments.relevance_signal_beir` |
 
 ---

--- a/README.md
+++ b/README.md
@@ -147,7 +147,17 @@ vstash reindex --model ~/.vstash/models/retrained
 
 **How it works, in one paragraph.** When you search your corpus, the vector and keyword halves of the pipeline sometimes rank different documents at the top. Those disagreements are a free signal: the document each half picked is probably relevant, the one only one half picked might not be. vstash turns this into training pairs and fine-tunes the embedding model on them. The run is eval-gated: it evaluates the candidate against the base model on a held-out slice of your corpus and refuses to save a model that performs worse.
 
-**Published results.** [`Stffens/bge-small-rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) was trained this way from 76K pairs across three BEIR datasets in 30 min on a T4 GPU. [`Stffens/bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) (2026-04-19) retrains with the [H-R9](experiments/retrain_roadmap.md) winning config (`temperature=0.5, total_triples=60000`) for a cleaner +5.35% macro NDCG@10 gain. See the [Retrieval Quality](#retrieval-quality) table and [docs/retrain.md](docs/retrain.md) for the full recipe.
+**The feature is maturing fast.** Each release tightens the recipe, lifts the measured numbers, and adds infrastructure that keeps the next iteration honest:
+
+| Release | Training recipe | 5-dataset BEIR macro NDCG@10 | What landed alongside |
+|---------|-----------------|------------------------------|------------------------|
+| base `bge-small` | no fine-tune | 0.6118 | reference |
+| [`rrf-v2`](https://huggingface.co/Stffens/bge-small-rrf-v2) | 76k triples, ad-hoc scripts | 0.6246 | first paper-grade result; still the NFCorpus specialist |
+| [`rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) | 60k triples via `retrain-multi` CLI, `temperature=0.5`, eval gate | **0.6405** | H-R9 ablation picked the config empirically; H-R7 seeded RNGs make it reproducible; H-R5 reports NDCG@3 + Recall@100 so regressions are visible before they ship |
+
+Both v2 and v3 beat ColBERTv2 on **5/5 BEIR datasets** under the current pipeline. v3 improves macro by +0.016 over v2 (+2.6% relative), with the largest per-dataset gain on FiQA (+0.097 absolute). The eval gate also catches losers: hypothesis H-R3 (hard-negative margin filter) regressed macro -2.49pp, the candidate was refused, the branch was closed without merging. **The pipeline's job is to refuse bad models, and it does.**
+
+See the [Retrieval Quality](#retrieval-quality) table, [docs/retrain.md](docs/retrain.md) for the full recipe and per-version breakdown, and [experiments/results/v2_v3_head_to_head.json](experiments/results/v2_v3_head_to_head.json) for reproducible numbers.
 
 Requires `sentence-transformers`, `torch`, and `accelerate`:
 

--- a/docs/retrain.md
+++ b/docs/retrain.md
@@ -22,9 +22,56 @@ trained model then runs on CPU like any other embedding model.
 Published fine-tunes produced with this flow live on Hugging Face
 under the `Stffens` namespace. **Current recommended model:
 [`Stffens/bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3)**
-(2026-04-19, `temperature=0.5 + total_triples=60000`, +5.35% macro
-NDCG@10 on BEIR vs base). Previous releases
-(`bge-small-rrf-v1`, `-v2`) remain valid.
+(2026-04-19, `temperature=0.5 + total_triples=60000`). Previous
+releases (`bge-small-rrf-v1`, `-v2`) remain valid.
+
+---
+
+## Track record
+
+Retrain is not a one-off experiment. Each release is gated by an
+honest NDCG@10 eval, validated on BEIR, and improves on the prior
+version under apples-to-apples evaluation:
+
+| Model       | Training recipe                                               | 5-dataset BEIR macro NDCG@10 | vs ColBERTv2 | Key signal                                    |
+|-------------|---------------------------------------------------------------|------------------------------|--------------|-----------------------------------------------|
+| base        | `BAAI/bge-small-en-v1.5` (no fine-tune)                       | 0.6118                       | 5/5          | reference                                     |
+| rrf-v1      | Chunk-prefix disagreement, 1 hard neg per query               | (superseded)                 | 5/5          | first validation of the self-supervised idea  |
+| rrf-v2      | Labeled queries + 76k triples, notebook + ad-hoc scripts      | 0.6246 (+0.013 vs base)       | 5/5          | first "paper-grade" result, still the NFCorpus specialist |
+| **rrf-v3**  | `retrain-multi` CLI, 60k target, `temperature=0.5`, eval gate | **0.6405** (+0.029 vs base)  | **5/5**      | +0.016 macro over v2, +0.097 FiQA, +0.025 SciFact |
+
+Each jump rests on validated infrastructure that also landed in the
+codebase, not just the numbers:
+
+- **v1 -> v2**: self-supervised pipeline moved from one-off scripts
+  to `retrain`/`retrain-multi` entrypoints. Multi-dataset training
+  (SciFact + NFCorpus + FiQA) and labeled-query mining arrived as
+  a first-class API.
+- **v2 -> v3**: the H-R9 ablation (temperature sweep + volume
+  sweep) empirically chose the new defaults. H-R7 added seeded
+  determinism so any re-run is reproducible; H-R5 added NDCG@3 and
+  Recall@100 so regressions in head-quality and candidate-set
+  health are visible before the user hits them. The published
+  model ships under the same 33M / 384d footprint as v2.
+
+Not every idea wins. Hypothesis H-R3 (hard-negative margin filter)
+regressed macro NDCG@10 by -2.49pp in the 2026-04-19 arm_a
+ablation: the infra was built, the eval gate caught the regression,
+the branch was closed without merging. The retrain pipeline's job
+is to refuse bad models, and it does.
+
+Next steps that make this feature even stronger are queued:
+
+- **T2.4 cross-encoder reranker** (design doc in
+  `experiments/t24_reranker_design.md`): +3-8 NDCG@10 orthogonal
+  to any embedding fine-tune. Expected to close v3's residual
+  NFCorpus gap vs v2 and push every dataset further.
+- **H-R8**: expose labeled queries + margin filter on single-corpus
+  `retrain` so users with qrels over their own private store do
+  not need to wrap their store in a dict.
+- **T2.5 GISTEmbedLoss**: teacher-guided hard-negative filtering;
+  drop-in replacement for MNRL where the assumption finally
+  applies.
 
 ---
 


### PR DESCRIPTION
## Summary

Reframes the retrain feature's presentation as a trajectory that is gaining strength, not a one-off experiment. Two files touched:

### README.md -- `## Self-Supervised Embedding Refinement`

Adds a per-release table (base -> rrf-v2 -> rrf-v3) with 5-dataset BEIR macro NDCG@10 and a column calling out what landed *alongside* each release:
- v2: first paper-grade result; still the NFCorpus specialist.
- v3: H-R9 ablation picked the config empirically; H-R7 seeded RNGs make it reproducible; H-R5 adds NDCG@3 + Recall@100 observability.

Two framing closers:
1. Both v2 and v3 beat ColBERTv2 on **5/5 BEIR datasets** under the current pipeline. v3 improves macro by +0.016 over v2 (+2.6% relative).
2. The eval gate refuses losers too: H-R3 margin filter regressed -2.49pp and the branch was closed without merging. That is the feature working as designed.

### docs/retrain.md

New "Track record" section at the top of the guide, with the same per-release table plus a "what landed alongside" narrative (v1 -> v2: first-class API; v2 -> v3: ablation-driven defaults + determinism + richer eval surface). Ends listing the queued next steps (T2.4 reranker, H-R8, T2.5 GIST) so the trajectory is visible.

## Why now

After the 2026-04-19 sprint (H-R5, H-R7, T1.5, H-R3 tried-negative, H-R9 positive, v3 published, v2/v3 h2h), the feature is measurably stronger than last week. The old README text mentioned v2 numbers as a one-off "published result"; that framing underplays how much compounding work the feature has absorbed.

## Test plan

- [x] `ruff check` clean (docs-only PR, no code).
- [x] No broken links introduced; new links resolve (`experiments/results/v2_v3_head_to_head.json` exists on develop post #246).
- [x] Numbers match `experiments/results/v2_v3_head_to_head.json` + the canonical H-R9 table in `experiments/retrain_roadmap.md`.

## Files

- `README.md` -- retrain section narrative + per-release table.
- `docs/retrain.md` -- new Track record section.