### PR TITLE
fix(store): defer flat snapvec save (kills O(N²) per-doc ingest)

### DIFF
--- a/tests/test_snapvec_backend.py
+++ b/tests/test_snapvec_backend.py
@@ -171,3 +171,101 @@ class TestSnapvecDimMismatch:
         assert store2._snap.dim == 64
         assert len(store2._snap) == 0  # rebuilt empty
         store2.close()
+
+
+class TestSnapvecDeferredSave:
+    """Flat snapvec now defers ``_save_snapvec`` to ``close()``. These
+    tests lock in the contract and the crash-recovery path that
+    rebuilds ``.snpv`` from ``vec_chunks`` when the deferred write
+    never happened."""
+
+    def test_add_document_does_not_write_snpv_before_close(self, snap_store, tmp_path):
+        """Writing through ``add_document`` does not touch the .snpv
+        file on disk until ``close()``. Regression guard for the
+        O(N^2) per-doc-ingest bug (2026-04-19)."""
+        db_path = tmp_path / "snap_test.db"
+        snpv_path = db_path.with_suffix(".snpv")
+        # Empty store just got its initial empty .snpv written.
+        initial_mtime = snpv_path.stat().st_mtime if snpv_path.exists() else None
+
+        for i in range(20):
+            snap_store.add_document(
+                path=f"/defer/doc{i}.md",
+                title=f"doc{i}",
+                chunks=[f"chunk text {i}"],
+                embeddings=[np.random.default_rng(i).standard_normal(DIM).tolist()],
+            )
+
+        # The ONLY expected write to .snpv during add_document is the
+        # initial empty-index save inside ``_init_snapvec``. After that
+        # every add_document must set ``_snap_dirty`` and not touch disk.
+        assert snap_store._snap_dirty is True
+        if initial_mtime is not None:
+            assert snpv_path.stat().st_mtime == initial_mtime, (
+                "flat snapvec must not rewrite .snpv on every add_document; "
+                "expected a single deferred flush via _checkpoint_snapvec / close()"
+            )
+
+        # Explicit checkpoint flushes dirty state to disk.
+        snap_store._checkpoint_snapvec()
+        assert snap_store._snap_dirty is False
+        assert snpv_path.exists()
+
+    def test_close_flushes_pending_writes(self, tmp_path):
+        """``close()`` must call ``_checkpoint_snapvec`` so that a
+        clean shutdown persists every in-memory vector."""
+        db = str(tmp_path / "close_flush.db")
+        store = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+        for i in range(10):
+            store.add_document(
+                path=f"/flush/doc{i}.md",
+                title=f"doc{i}",
+                chunks=[f"flush chunk {i}"],
+                embeddings=[np.random.default_rng(i).standard_normal(DIM).tolist()],
+            )
+        assert store._snap_dirty is True
+        store.close()
+
+        # Reopen and verify all 10 docs survived.
+        reopened = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+        assert len(reopened._snap) == 10
+        reopened.close()
+
+    def test_crash_recovery_rebuilds_from_vec_chunks(self, tmp_path):
+        """Simulate a crash between ``add_document`` and ``close()`` by
+        intentionally skipping ``_checkpoint_snapvec`` on the first
+        handle. On next open, ``_init_snapvec`` must detect the
+        staleness (snap len < vec_chunks count) and rebuild the flat
+        index from ``vec_chunks`` so no vectors are silently lost."""
+        db = str(tmp_path / "crash_recovery.db")
+        store = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+        for i in range(15):
+            store.add_document(
+                path=f"/crash/doc{i}.md",
+                title=f"doc{i}",
+                chunks=[f"crash chunk {i}"],
+                embeddings=[np.random.default_rng(i).standard_normal(DIM).tolist()],
+            )
+        # "Crash": close the sqlite connection but NEVER flush the
+        # deferred .snpv. The on-disk .snpv is the initial empty one
+        # that got written at _init_snapvec time.
+        store._conn.close()
+        # Avoid any further finalisation on this handle.
+        store._snap = None
+
+        # Reopen and verify recovery.
+        recovered = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+        assert recovered._snap is not None
+        # All 15 vectors must be back in the in-memory index, populated
+        # by _rebuild_snapvec_from_vec_chunks.
+        assert len(recovered._snap) == 15
+        recovered.close()
+
+    def test_rebuild_helper_is_idempotent(self, populated_snap_store, tmp_path):
+        """Calling ``_rebuild_snapvec_from_vec_chunks`` twice in a row
+        produces the same state."""
+        populated_snap_store._checkpoint_snapvec()
+        first = populated_snap_store._rebuild_snapvec_from_vec_chunks()
+        second = populated_snap_store._rebuild_snapvec_from_vec_chunks()
+        assert first == second
+        assert first > 0

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -474,7 +474,13 @@ class VstashStore:
         }
 
     def _init_snapvec(self) -> None:
-        """Load or create the SnapIndex for the snapvec backend."""
+        """Load or create the SnapIndex for the snapvec backend.
+
+        If the on-disk ``.snpv`` is out of sync with ``vec_chunks``
+        (e.g. a process crashed between ``add_document`` and
+        ``close()`` with deferred save active), rebuild the flat
+        index from ``vec_chunks``, which is the source of truth.
+        """
         if not _HAS_SNAPVEC:
             logger.warning(
                 "snapvec backend requested but snapvec is not installed. "
@@ -484,10 +490,17 @@ class VstashStore:
             return
 
         path = self._snapvec_path
+        # ``loaded_clean`` == True when we have a SnapIndex whose on-disk
+        # dim matches ``self.embedding_dim``. Only in that case is the
+        # stale-vs-fresh comparison against ``vec_chunks`` meaningful. If
+        # dim mismatched or the file was corrupt, we already reset to an
+        # empty index and the user needs ``vstash reindex`` to rebuild
+        # with the new model; shoving old-dim vectors through the flat
+        # crash-recovery path would crash with a shape mismatch.
+        loaded_clean = False
         if path.exists():
             try:
                 self._snap = SnapIndex.load(str(path))
-                # Verify dimension match
                 if self._snap.dim != self.embedding_dim:
                     logger.warning(
                         "SnapIndex dim=%d != embedding_dim=%d. Rebuilding index.",
@@ -495,7 +508,9 @@ class VstashStore:
                         self.embedding_dim,
                     )
                     self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
-                    self._save_snapvec()
+                    self._snap.save(str(self._snapvec_path))
+                else:
+                    loaded_clean = True
             except Exception:
                 logger.warning(
                     "Failed to load SnapIndex from %s — creating empty. "
@@ -504,30 +519,100 @@ class VstashStore:
                     exc_info=True,
                 )
                 self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
-                self._save_snapvec()
+                self._snap.save(str(self._snapvec_path))
         else:
             self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
+            # Fresh in-memory index with matching dim; safe to check
+            # staleness and rebuild from vec_chunks if needed (e.g.
+            # user deleted the .snpv companion but kept the .db).
+            loaded_clean = True
+
+        # Staleness check: flat snapvec defers save until close() /
+        # checkpoint, so a crash mid-session can leave ``.snpv`` with
+        # fewer rows than ``vec_chunks``. Detect and rebuild so users
+        # do not silently lose vectors from the last write burst.
+        if loaded_clean and self._vector_backend == "snapvec" and self._snap is not None:
+            try:
+                sqlite_n = int(
+                    self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0]
+                )
+            except sqlite3.Error:
+                sqlite_n = 0
+            snap_n = len(self._snap)
+            if sqlite_n > snap_n:
+                logger.info(
+                    "SnapIndex has %d vectors but vec_chunks has %d. Rebuilding flat "
+                    "snapvec index from SQLite (crash recovery).",
+                    snap_n,
+                    sqlite_n,
+                )
+                self._rebuild_snapvec_from_vec_chunks()
+
+    def _rebuild_snapvec_from_vec_chunks(self, batch_size: int = 10_000) -> int:
+        """Rebuild the flat SnapIndex from ``vec_chunks`` source-of-truth.
+
+        Used for crash recovery when ``_init_snapvec`` detects staleness
+        and as the ``fit_snapvec`` analogue to ``fit_ivfpq``. Returns the
+        number of vectors indexed.
+        """
+        if self._snap is None:
+            raise RuntimeError("snapvec backend not initialised")
+        self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
+
+        offset = 0
+        total = 0
+        while True:
+            rows = self._conn.execute(
+                "SELECT rowid, embedding FROM vec_chunks ORDER BY rowid "
+                "LIMIT ? OFFSET ?",
+                [batch_size, offset],
+            ).fetchall()
+            if not rows:
+                break
+            rowids = [int(r["rowid"]) for r in rows]
+            vectors = np.asarray(
+                [_deserialize(r["embedding"]) for r in rows], dtype=np.float32
+            )
+            self._snap.add_batch(rowids, vectors)
+            offset += batch_size
+            total += len(rows)
+
+        # Immediately persist the rebuilt index so subsequent opens do
+        # not re-run the rebuild unnecessarily.
+        self._snap.save(str(self._snapvec_path))
+        self._snap_dirty = False
+        logger.info("Rebuilt flat snapvec index with %d vectors", total)
+        return total
 
     def _save_snapvec(self) -> None:
-        """Persist the snapvec index to disk. Called after successful SQLite commit.
+        """Mark the in-memory snapvec index dirty; flush deferred to
+        ``close()`` / ``_checkpoint_snapvec()``.
 
-        Flat SnapIndex is small and cheap to rewrite on every commit.
-        IVFPQ with keep_full_precision=True can be 80+ MB at 100K
-        vectors — rewriting on each add_document would thrash disk.
-        For IVFPQ we mark the index dirty in memory and flush on
-        ``close()`` (or on an explicit checkpoint). SQLite's vec_chunks
-        stays the source of truth, so a crash at worst loses the most
-        recent post-fit adds and the operator can re-run
-        ``vstash snapvec fit`` to rebuild.
+        Historically the flat backend wrote ``.snpv`` on every call
+        (typically one per ``add_document``). That is a full-file
+        rewrite and costs ~1.25 ms/MB on Apple Silicon (memory
+        bandwidth). In tight per-doc ingest loops the OS page cache
+        hides the cost at small N, but once the file grows past the
+        kernel's dirty-page absorption budget (roughly a few tens of
+        MB in practice), every save starts paying real disk I/O and
+        the sum becomes quadratic. Observed on 2026-04-19: a 100k
+        per-doc ingest on flat snapvec took 40+ minutes of pure
+        ``.snpv`` rewrites.
+
+        Fix: mirror the ivfpq pattern and defer the flush for both
+        backends. ``vec_chunks`` is the SQLite source of truth, so a
+        process crash before the deferred flush runs is recoverable
+        via ``_rebuild_snapvec_from_vec_chunks`` (``_init_snapvec``
+        detects the staleness on next open and rebuilds
+        automatically).
+
+        Callers that want a synchronous flush can invoke
+        ``_checkpoint_snapvec()`` directly (``close()`` does this on
+        teardown).
         """
         if self._snap is None:
             return
-        if self._vector_backend == "snapvec-ivfpq":
-            # Defer to close() / explicit checkpoint.
-            self._snap_dirty = True
-            return
-        self._snap.save(str(self._snapvec_path))
-        self._snap_dirty = False
+        self._snap_dirty = True
 
     def _checkpoint_snapvec(self) -> None:
         """Flush the in-memory snapvec index to disk if dirty."""
@@ -4133,10 +4218,13 @@ class VstashStore:
         """
         import contextlib
 
-        # Flush any pending snapvec writes before tearing down.  For the
-        # flat backend this is usually a no-op (_save_snapvec already ran
-        # on every commit); for snapvec-ivfpq it is the primary save
-        # point, so the IVFPQ file only hits disk once per session.
+        # Flush any pending snapvec writes before tearing down. Both
+        # the flat and ivfpq backends now defer ``.snpv`` / ivfpq
+        # writes until here (or an explicit ``_checkpoint_snapvec``
+        # call), so the file hits disk once per session instead of
+        # once per ``add_document``. Crash recovery is handled on
+        # next open by ``_init_snapvec`` comparing the stored index
+        # length against ``vec_chunks`` and rebuilding if stale.
         with contextlib.suppress(Exception):
             self._checkpoint_snapvec()
 


### PR DESCRIPTION
## Summary

Per-doc ``store.add_document`` on the flat ``snapvec`` backend was O(N²) on disk I/O because ``_save_snapvec`` rewrote the full ``.snpv`` file on every commit. This patch defers the save to ``close()`` / ``_checkpoint_snapvec``, mirroring the pattern ``snapvec-ivfpq`` already used. Per-doc ingest drops from O(N²) to O(N).

## Context

Found while running the N=100k pipeline bench on the flat snapvec backend. Per-doc ingest hung for 40+ min. A dedicated probe (``experiments/snapvec_ingest_scaling_probe.py``, shipped on a sibling bench branch) measured per-doc latency perfectly linear in the .snpv file size:

| N | per-doc p50 | .snpv size | ms/MB |
|---|---|---|---|
| 5k | 1.90 ms | 1.3 MB | 1.46 |
| 50k | 16.10 ms | 12.7 MB | 1.27 |
| 100k | 31.58 ms | 25.5 MB | 1.24 |

~1.25 ms/MB = 800 MB/s, i.e. memory-bandwidth. Writing a 25 MB file 100k times = 2.5 TB. At small N the OS page cache absorbed consecutive rewrites; past ~50k-100k the cache budget collapsed and the quadratic emerged in full.

## What changes

1. **``_save_snapvec`` just marks dirty.** No disk write per ``add_document``.
2. **``close()`` / ``_checkpoint_snapvec`` is the single flush.** Flat and ivfpq both use it now; ivfpq already did.
3. **``_init_snapvec`` detects staleness on open.** Compares ``len(self._snap)`` vs ``SELECT COUNT(*) FROM vec_chunks``. If stale (crash between ``add_document`` and ``close()``, or user deleted the ``.snpv`` companion), rebuilds automatically.
4. **New ``_rebuild_snapvec_from_vec_chunks`` helper.** Streams vec_chunks in 10k batches, replays through ``SnapIndex.add_batch``, saves. Returns rebuilt count.
5. **Dim-mismatch and corrupt-file paths skip rebuild** (they should stay empty until ``vstash reindex`` runs).

## Before / after

Measured on this laptop (Apple Silicon), current commit:

- **10k per-doc ``add_document`` loop**: 2.5 s total (0.25 ms/doc). The O(N²) path at N=10k extrapolates to ~35 s. **14x faster.**
- **``close()`` with 10k dirty vectors**: 10 ms (one ``.snpv`` write).
- **100k per-doc loop** (not yet benchmarked on this branch, but the theoretical model predicts ~25-30 s vs the 40+ min on develop).

## Recovery semantics

Before this change, a clean process exit wrote ``.snpv`` continuously, so "crash recovery" was rarely exercised. Now, if a process crashes between ``add_document`` and ``close()``, the .snpv on disk lags vec_chunks. The staleness check on next open automatically triggers a rebuild from vec_chunks (the SQLite source of truth). No user-visible data loss.

## Test plan

New tests under ``TestSnapvecDeferredSave`` in ``tests/test_snapvec_backend.py``:

- [x] ``test_add_document_does_not_write_snpv_before_close`` -- regression guard that the O(N²) bug cannot come back.
- [x] ``test_close_flushes_pending_writes`` -- clean-shutdown path still persists everything.
- [x] ``test_crash_recovery_rebuilds_from_vec_chunks`` -- simulates a process crash without ``close()``, verifies next open rebuilds all vectors.
- [x] ``test_rebuild_helper_is_idempotent`` -- the public rebuild is stable.

Full suite: 138 tests passing (``tests/test_snapvec*``, ``tests/test_store*``). Ruff clean.

## Follow-ups (not this PR)

- Refresh ``experiments/results/pipeline_bench_3backends_*.json`` with the fixed code path. The 500k flat ingest of 679 s (in the sibling bench branch) should collapse to ~60 s because ``add_documents_batch`` already behaved this way (single save at end); the per-doc path now matches.
- ``docs/configuration.md`` backend recommendation to reflect the new flat-snapvec performance: flat is now a viable per-doc ingest path for all sizes below the ivfpq crossover (~500k).