### PR TITLE
fix(store): coalesce snapvec add_batch in add_documents_batch (O(N²) → O(N))

### DIFF
--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1158,6 +1158,15 @@ class VstashStore:
         with self._write_lock:
             self._conn.execute("BEGIN IMMEDIATE")
             pending_fts: list[tuple[int, str]] = []
+            # Coalesce every doc's vectors and rowids into one buffer so
+            # we hand ``SnapIndex.add_batch`` a single (N, dim) array at
+            # the end. Its internal ``np.vstack`` is O(total_size + new)
+            # per call, so calling it N times with size-1 inputs during
+            # the loop would be O(N^2) memory copies (measured: 500k
+            # docs via the old path took ~11 minutes of pure RAM
+            # memcpy). One final batch drops the cost to O(N).
+            pending_snap_rowids: list[int] = []
+            pending_snap_vecs: list[np.ndarray] = []
             try:
                 now_iso = datetime.now(timezone.utc).isoformat()
 
@@ -1236,9 +1245,22 @@ class VstashStore:
                         )
 
                     if self._snap is not None:
-                        snap_vecs = np.array(embeddings, dtype=np.float32)
-                        self._snap.add_batch(rowids, snap_vecs)
-                        self._snap_dirty = True
+                        pending_snap_rowids.extend(rowids)
+                        pending_snap_vecs.append(
+                            np.asarray(embeddings, dtype=np.float32)
+                        )
+
+                # ONE coalesced add_batch for the whole transaction's
+                # worth of vectors instead of one per document. Avoids
+                # the quadratic np.vstack inside SnapIndex.add_batch.
+                if self._snap is not None and pending_snap_rowids:
+                    all_snap_vecs = (
+                        pending_snap_vecs[0]
+                        if len(pending_snap_vecs) == 1
+                        else np.concatenate(pending_snap_vecs, axis=0)
+                    )
+                    self._snap.add_batch(pending_snap_rowids, all_snap_vecs)
+                    self._snap_dirty = True
 
                 self._conn.commit()
                 if pending_fts:


### PR DESCRIPTION
## Summary

``add_documents_batch`` was calling ``SnapIndex.add_batch`` once per document. Internally ``add_batch`` grows ``_indices`` via ``np.vstack([existing, new])``, which is O(current + new) per call. N docs = O(N²) memcpy.

Fix: accumulate rowids + vectors across the whole doc loop and call ``SnapIndex.add_batch`` ONCE at the end. No public API change.

## Numbers

| N | before (O(N²) path) | after (coalesced) | speedup |
|---|---|---|---|
| 100k | 35 s | 9.2 s | 3.8x |
| 500k | 679 s | 78 s | **8.7x** |

Gain grows with N. The 500k ingest dropped from 11 minutes to 78 seconds on this commit.

## Why this was hidden

Two compounding bugs fixed in the last two PRs were masking each other:

1. PR #250 killed the per-doc ``_save_snapvec`` writing (O(N) disk I/O per call at flat snapvec).
2. Even after that, ``add_documents_batch`` still exposed the quadratic memcpy inside ``add_batch``'s ``np.vstack`` because it called the function N times.

Users running ``add_documents_batch`` today thought they were getting linear ingest. They were, for the SQLite side. But the in-memory snapvec accumulator was quietly O(N²).

## Test plan

- [x] 138 existing tests (tests/test_snapvec*, tests/test_store*) pass.
- [x] 100k + 500k smoke measurements above confirm the speedup.
- [x] Transactional semantics unchanged: the single coalesced add_batch happens inside the existing BEGIN/COMMIT block so a rollback drops both SQLite rows and snap state atomically.
- [x] ruff check + ruff format clean.

## Follow-up

- Upstream fix in ``snapvec`` package itself: teach ``SnapIndex.add_batch`` to preallocate with geometric growth (double capacity when full) instead of ``np.vstack`` every time. That would make the per-call path O(N) amortised regardless of call count, and benefit single ``add_document`` users too. Out of scope for this PR; this PR removes the user-visible symptom.
- Refresh the pipeline bench JSONs once this lands; the 500k flat snapvec number of 679 s becomes obsolete.