### PR TITLE
experiments: BEIR 5-dataset h2h + snapvec O(N^2) probe

### DIFF
--- a/experiments/beir_snapvec_h2h.py
+++ b/experiments/beir_snapvec_h2h.py
@@ -46,7 +46,7 @@ from pathlib import Path
 import numpy as np
 
 from experiments.beir_benchmark import download_beir, load_beir
-from vstash.embed import embed_query, get_embedding_dim
+from vstash.embed import get_embedding_dim
 from vstash.store import VstashStore
 
 
@@ -106,9 +106,7 @@ def _embed_corpus(
             return ids, texts, vecs
 
     print(f"  [{dataset}] embedding {len(texts)} docs with {model} ...")
-    from sentence_transformers import SentenceTransformer
-
-    st = SentenceTransformer(model)
+    st = _get_st_model(model)
     vecs = st.encode(
         texts,
         normalize_embeddings=True,
@@ -121,6 +119,53 @@ def _embed_corpus(
     cache_ids.write_text(json.dumps(ids))
     cache_texts.write_text(json.dumps(texts))
     return ids, texts, vecs
+
+
+_ST_CACHE: dict = {}
+
+
+def _get_st_model(model: str):
+    """Cache one SentenceTransformer per (model) so corpus + queries share a
+    single instance. Avoids the MLX v3 legacy-BERT tensor-naming path entirely
+    (``embeddings.LayerNorm.beta/gamma`` isn't auto-mapped by mlx-embeddings)."""
+    if model not in _ST_CACHE:
+        from sentence_transformers import SentenceTransformer
+
+        _ST_CACHE[model] = SentenceTransformer(model)
+    return _ST_CACHE[model]
+
+
+def _embed_queries(
+    dataset: str,
+    model: str,
+    queries: dict[str, str],
+    cache_dir: Path,
+) -> dict[str, np.ndarray]:
+    """Embed all queries once for (dataset, model), cached on disk.
+    Returns qid -> float32 vector (already L2-normalized)."""
+    cache_emb = cache_dir / f"{dataset}__queries__{_slug(model)}.npy"
+    cache_qids = cache_dir / f"{dataset}__query_ids.json"
+
+    qids = list(queries.keys())
+    if cache_emb.exists() and cache_qids.exists():
+        cached_qids = json.loads(cache_qids.read_text())
+        if cached_qids == qids:
+            mat = np.load(cache_emb)
+            return {qid: mat[i] for i, qid in enumerate(qids)}
+
+    print(f"  [{dataset}] embedding {len(qids)} queries ...")
+    st = _get_st_model(model)
+    qtexts = [queries[qid] for qid in qids]
+    mat = st.encode(
+        qtexts,
+        normalize_embeddings=True,
+        batch_size=128,
+        show_progress_bar=True,
+    ).astype(np.float32)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_emb, mat)
+    cache_qids.write_text(json.dumps(qids))
+    return {qid: mat[i] for i, qid in enumerate(qids)}
 
 
 def _dcg(scores: list[float], k: int) -> float:
@@ -156,6 +201,7 @@ def _evaluate_backend(
     texts: list[str],
     vecs: np.ndarray,
     queries: dict[str, str],
+    query_vecs: dict[str, np.ndarray],
     qrels: dict[str, dict[str, int]],
     tmp_dir: Path,
 ) -> dict:
@@ -200,7 +246,7 @@ def _evaluate_backend(
     for qid, qtext in queries.items():
         if qid not in qrels:
             continue
-        q_vec = embed_query(qtext, model)
+        q_vec = query_vecs[qid].tolist()
         t0 = time.perf_counter()
         # Pull RANK_K so all four metrics come from one ranked list.
         results = store.search(q_vec, qtext, top_k=RANK_K)
@@ -302,6 +348,8 @@ def _print_table(results: dict, backends: list[str], datasets: list[str]) -> Non
             r = results.get(b, {}).get(ds, {})
             if not r:
                 continue
+            fit_s = r.get("fit_seconds")
+            fit_cell = "-" if fit_s is None else f"{fit_s:.2f}"
             print(
                 f"| {ds} | {b} | "
                 f"{r.get('ndcg_at_10', 0):.4f} | "
@@ -311,7 +359,7 @@ def _print_table(results: dict, backends: list[str], datasets: list[str]) -> Non
                 f"{r.get('latency_p50_ms', 0):.2f} | "
                 f"{r.get('latency_mean_ms', 0):.2f} | "
                 f"{r.get('ingest_seconds', 0):.2f} | "
-                f"{'-' if r.get('fit_seconds') is None else r['fit_seconds']:.2f} |"
+                f"{fit_cell} |"
             )
 
 
@@ -358,10 +406,11 @@ def main() -> int:
     )
     args.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    # 1. Embed corpora once per dataset; reuse across backends.
+    # 1. Embed corpora + queries once per dataset; reuse across backends.
     per_dataset_corpus: dict[str, tuple[list[str], list[str], np.ndarray]] = {}
     per_dataset_queries: dict[str, tuple[dict, dict]] = {}
-    print("\n[1/2] embedding corpora ...")
+    per_dataset_query_vecs: dict[str, dict[str, np.ndarray]] = {}
+    print("\n[1/2] embedding corpora + queries ...")
     for ds in args.datasets:
         ids, texts, vecs = _embed_corpus(ds, args.model, args.cache_dir)
         per_dataset_corpus[ds] = (ids, texts, vecs)
@@ -369,6 +418,7 @@ def main() -> int:
         _, queries, qrels = load_beir(cache)
         per_dataset_queries[ds] = (queries, qrels)
         print(f"  [{ds}] queries={len(queries)} qrels={len(qrels)}")
+        per_dataset_query_vecs[ds] = _embed_queries(ds, args.model, queries, args.cache_dir)
 
     # 2. Per-backend, per-dataset evaluation.
     results: dict[str, dict[str, dict]] = {}
@@ -390,6 +440,7 @@ def main() -> int:
                     texts=texts,
                     vecs=vecs,
                     queries=queries,
+                    query_vecs=per_dataset_query_vecs[ds],
                     qrels=qrels,
                     tmp_dir=tmp_dir,
                 )

--- a/experiments/beir_snapvec_h2h.py
+++ b/experiments/beir_snapvec_h2h.py
@@ -1,0 +1,373 @@
+"""
+beir_snapvec_h2h.py -- 5-dataset BEIR benchmark across vector backends.
+
+For each (backend in {sqlite-vec, snapvec, snapvec-ivfpq}, dataset in
+the 5-BEIR cut), build a fresh ``VstashStore``, ingest the corpus,
+query the held-out test set via the full production ``store.search``
+pipeline, and record NDCG@10 + latency.
+
+Why this exists. The existing
+``experiments/v2_v3_head_to_head.py`` compares MODELS on a batched
+eval path that skips MMR / IDF. ``experiments/vstash_pipeline_ivfpq_bench.py``
+compares BACKENDS on a padded synthetic corpus. This script compares
+BACKENDS on *real* BEIR datasets one at a time through the *full*
+production pipeline, so the resulting table can be dropped straight
+into the README's Retrieval Quality section if we ever change the
+recommended default backend.
+
+Output shape mirrors the model-h2h JSON so both can be diffed side
+by side in a spreadsheet or notebook.
+
+Usage:
+
+    python -m experiments.beir_snapvec_h2h
+    python -m experiments.beir_snapvec_h2h --model Stffens/bge-small-rrf-v3
+    python -m experiments.beir_snapvec_h2h --backends sqlite-vec snapvec
+    python -m experiments.beir_snapvec_h2h --datasets scifact nfcorpus
+
+Runtime estimate (Apple Silicon, cache-hot):
+  ingest per (backend, dataset):        5-20 s
+  query eval per (backend, dataset):    10-60 s
+  ivfpq fit per dataset:                5-60 s
+  total across 3 backends x 5 datasets: 10-20 min
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+from experiments.beir_benchmark import download_beir, load_beir
+from vstash.embed import embed_query, get_embedding_dim
+from vstash.store import VstashStore
+
+
+DEFAULT_MODEL = "Stffens/bge-small-rrf-v3"
+DEFAULT_DATASETS = ("scifact", "nfcorpus", "scidocs", "fiqa", "arguana")
+DEFAULT_BACKENDS = ("sqlite-vec", "snapvec", "snapvec-ivfpq")
+TOP_K = 10
+
+# ColBERTv2 + BM25 reference numbers, pinned from the paper's
+# Section 7.3 table. Match the README's Retrieval Quality framing.
+COLBERT_V2_NDCG_10: dict[str, float] = {
+    "scifact": 0.693,
+    "nfcorpus": 0.344,
+    "scidocs": 0.154,
+    "fiqa": 0.356,
+    "arguana": 0.463,
+}
+BM25_NDCG_10: dict[str, float] = {
+    "scifact": 0.665,
+    "nfcorpus": 0.325,
+    "scidocs": 0.158,
+    "fiqa": 0.236,
+    "arguana": 0.315,
+}
+
+
+def _slug(model: str) -> str:
+    return model.replace("/", "_").replace("-", "_").lower()
+
+
+def _embed_corpus(
+    dataset: str,
+    model: str,
+    cache_dir: Path,
+) -> tuple[list[str], list[str], np.ndarray]:
+    """Embed a BEIR dataset's corpus, cached on disk per (dataset, model)."""
+    cache_emb = cache_dir / f"{dataset}__{_slug(model)}.npy"
+    cache_ids = cache_dir / f"{dataset}__ids.json"
+    cache_texts = cache_dir / f"{dataset}__texts.json"
+
+    beir_cache = download_beir(dataset)
+    corpus, _, _ = load_beir(beir_cache)
+    ids = list(corpus.keys())
+    texts = [(corpus[d].get("title", "") + " " + corpus[d].get("text", "")).strip() for d in ids]
+
+    if cache_emb.exists() and cache_ids.exists() and cache_texts.exists():
+        vecs = np.load(cache_emb)
+        with open(cache_ids) as f:
+            cached_ids = json.load(f)
+        if cached_ids == ids:
+            print(f"  [{dataset}] {len(ids)} docs (cached embeddings)")
+            return ids, texts, vecs
+
+    print(f"  [{dataset}] embedding {len(texts)} docs with {model} ...")
+    from sentence_transformers import SentenceTransformer
+
+    st = SentenceTransformer(model)
+    vecs = st.encode(
+        texts,
+        normalize_embeddings=True,
+        batch_size=128,
+        show_progress_bar=True,
+    ).astype(np.float32)
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    np.save(cache_emb, vecs)
+    cache_ids.write_text(json.dumps(ids))
+    cache_texts.write_text(json.dumps(texts))
+    return ids, texts, vecs
+
+
+def _dcg(scores: list[float], k: int) -> float:
+    return sum(s / math.log2(i + 2) for i, s in enumerate(scores[:k]))
+
+
+def _ndcg_at_k(ranked_ids: list[str], qrel: dict[str, int], k: int) -> float:
+    gains = [qrel.get(did, 0) for did in ranked_ids[:k]]
+    ideal = sorted(qrel.values(), reverse=True)[:k]
+    idcg = _dcg(ideal, k)
+    return _dcg(gains, k) / idcg if idcg > 0 else 0.0
+
+
+def _evaluate_backend(
+    dataset: str,
+    backend: str,
+    model: str,
+    dim: int,
+    ids: list[str],
+    texts: list[str],
+    vecs: np.ndarray,
+    queries: dict[str, str],
+    qrels: dict[str, dict[str, int]],
+    tmp_dir: Path,
+) -> dict:
+    """Ingest corpus into a fresh store with ``backend``, run queries through
+    the production search, return NDCG@10 + latency + timings."""
+    db_path = tmp_dir / f"{dataset}_{backend}.db"
+    for suffix in ("", "-wal", "-shm", ".snpv"):
+        p = db_path.with_suffix(db_path.suffix + suffix) if suffix else db_path
+        if os.path.exists(p):
+            os.remove(p)
+
+    kwargs = {"embedding_dim": dim, "vector_backend": backend}
+    if backend == "snapvec-ivfpq":
+        kwargs["ivfpq_rerank_candidates"] = 100
+    store = VstashStore(str(db_path), **kwargs)
+
+    t0 = time.perf_counter()
+    docs = [
+        {
+            "path": f"{dataset}/{doc_id}",
+            "title": doc_id,
+            "chunks": [text],
+            "embeddings": [vecs[i].tolist()],
+            "source_type": "text",
+        }
+        for i, (doc_id, text) in enumerate(zip(ids, texts))
+    ]
+    store.add_documents_batch(docs)
+    ingest_s = time.perf_counter() - t0
+
+    fit_s: float | None = None
+    if backend == "snapvec-ivfpq":
+        t0 = time.perf_counter()
+        store.fit_ivfpq()
+        fit_s = time.perf_counter() - t0
+
+    ndcgs: list[float] = []
+    latencies: list[float] = []
+    for qid, qtext in queries.items():
+        if qid not in qrels:
+            continue
+        q_vec = embed_query(qtext, model)
+        t0 = time.perf_counter()
+        results = store.search(q_vec, qtext, top_k=TOP_K)
+        latencies.append((time.perf_counter() - t0) * 1000)
+        ranked = [Path(r.path).name for r in results]
+        ndcgs.append(_ndcg_at_k(ranked, qrels[qid], TOP_K))
+
+    store.close()
+    for suffix in ("", "-wal", "-shm", ".snpv"):
+        p = db_path.with_suffix(db_path.suffix + suffix) if suffix else db_path
+        if os.path.exists(p):
+            try:
+                os.remove(p)
+            except OSError:
+                pass
+
+    return {
+        "n_queries": len(latencies),
+        "ndcg_at_10": round(statistics.mean(ndcgs), 4) if ndcgs else 0.0,
+        "latency_p50_ms": round(statistics.median(latencies), 2) if latencies else 0.0,
+        "latency_p95_ms": round(
+            statistics.quantiles(latencies, n=20, method="inclusive")[-1]
+            if len(latencies) > 1
+            else latencies[0],
+            2,
+        )
+        if latencies
+        else 0.0,
+        "latency_mean_ms": round(statistics.mean(latencies), 2) if latencies else 0.0,
+        "ingest_seconds": round(ingest_s, 2),
+        "fit_seconds": round(fit_s, 2) if fit_s is not None else None,
+    }
+
+
+def _print_table(results: dict, backends: list[str], datasets: list[str]) -> None:
+    """Markdown-style comparison table: NDCG@10 per (dataset, backend)
+    with BM25/ColBERTv2 reference columns."""
+    print("\n### Absolute NDCG@10 (real BEIR corpora, full production pipeline)\n")
+    header_cols = ["Dataset", "BM25", "ColBERTv2"] + backends
+    print("| " + " | ".join(header_cols) + " |")
+    print("|" + "|".join(["---"] * len(header_cols)) + "|")
+    for ds in datasets:
+        cells = [ds, f"{BM25_NDCG_10.get(ds, 0):.3f}", f"{COLBERT_V2_NDCG_10.get(ds, 0):.3f}"]
+        for b in backends:
+            v = results.get(b, {}).get(ds, {}).get("ndcg_at_10")
+            cells.append(f"{v:.4f}" if v is not None else "-")
+        print("| " + " | ".join(cells) + " |")
+    # Macro per backend.
+    macros: dict[str, float] = {}
+    for b in backends:
+        vals = [results[b][ds]["ndcg_at_10"] for ds in datasets if ds in results[b]]
+        macros[b] = sum(vals) / len(vals) if vals else 0.0
+    macro_cells = ["**macro**", "-", "-"] + [f"**{macros[b]:.4f}**" for b in backends]
+    print("| " + " | ".join(macro_cells) + " |")
+
+    print("\n### Wins vs ColBERTv2 per backend\n")
+    print("| Backend | wins / total | datasets won |")
+    print("|---|---|---|")
+    for b in backends:
+        won: list[str] = []
+        lost: list[str] = []
+        for ds in datasets:
+            colbert = COLBERT_V2_NDCG_10.get(ds)
+            v = results.get(b, {}).get(ds, {}).get("ndcg_at_10")
+            if colbert is None or v is None:
+                continue
+            (won if v > colbert else lost).append(ds)
+        total = len(won) + len(lost)
+        print(f"| {b} | {len(won)} / {total} | {', '.join(won) or '-'} |")
+
+    print("\n### Latency + timings per (backend, dataset)\n")
+    print("| Dataset | Backend | NDCG@10 | p50 ms | mean ms | ingest s | fit s |")
+    print("|---|---|---|---|---|---|---|")
+    for ds in datasets:
+        for b in backends:
+            r = results.get(b, {}).get(ds, {})
+            if not r:
+                continue
+            print(
+                f"| {ds} | {b} | "
+                f"{r.get('ndcg_at_10', 0):.4f} | "
+                f"{r.get('latency_p50_ms', 0):.2f} | "
+                f"{r.get('latency_mean_ms', 0):.2f} | "
+                f"{r.get('ingest_seconds', 0):.2f} | "
+                f"{'-' if r.get('fit_seconds') is None else r['fit_seconds']:.2f} |"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        default=list(DEFAULT_BACKENDS),
+        choices=list(DEFAULT_BACKENDS),
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        default=list(DEFAULT_DATASETS),
+        choices=list(DEFAULT_DATASETS),
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=Path("experiments/data/beir_snapvec_h2h_cache"),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/results/beir_snapvec_h2h.json"),
+    )
+    args = parser.parse_args()
+
+    try:
+        import sentence_transformers  # noqa: F401
+    except ImportError:
+        print(
+            "sentence-transformers required for corpus embedding. "
+            "Install with: pip install 'sentence-transformers>=3' torch 'accelerate>=1.1.0'"
+        )
+        return 1
+
+    dim = get_embedding_dim(args.model)
+    print(
+        f"=== BEIR 5-dataset snapvec h2h ===\n"
+        f"model={args.model} dim={dim} backends={args.backends} datasets={args.datasets}"
+    )
+    args.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Embed corpora once per dataset; reuse across backends.
+    per_dataset_corpus: dict[str, tuple[list[str], list[str], np.ndarray]] = {}
+    per_dataset_queries: dict[str, tuple[dict, dict]] = {}
+    print("\n[1/2] embedding corpora ...")
+    for ds in args.datasets:
+        ids, texts, vecs = _embed_corpus(ds, args.model, args.cache_dir)
+        per_dataset_corpus[ds] = (ids, texts, vecs)
+        cache = download_beir(ds)
+        _, queries, qrels = load_beir(cache)
+        per_dataset_queries[ds] = (queries, qrels)
+        print(f"  [{ds}] queries={len(queries)} qrels={len(qrels)}")
+
+    # 2. Per-backend, per-dataset evaluation.
+    results: dict[str, dict[str, dict]] = {}
+    print("\n[2/2] evaluating ...")
+    with tempfile.TemporaryDirectory() as td:
+        tmp_dir = Path(td)
+        for backend in args.backends:
+            results[backend] = {}
+            for ds in args.datasets:
+                ids, texts, vecs = per_dataset_corpus[ds]
+                queries, qrels = per_dataset_queries[ds]
+                print(f"  [{backend}/{ds}] ...", flush=True)
+                cell = _evaluate_backend(
+                    dataset=ds,
+                    backend=backend,
+                    model=args.model,
+                    dim=dim,
+                    ids=ids,
+                    texts=texts,
+                    vecs=vecs,
+                    queries=queries,
+                    qrels=qrels,
+                    tmp_dir=tmp_dir,
+                )
+                results[backend][ds] = cell
+                fit_part = "" if cell["fit_seconds"] is None else f"  fit={cell['fit_seconds']}s"
+                print(
+                    f"    NDCG@10={cell['ndcg_at_10']:.4f}  "
+                    f"p50={cell['latency_p50_ms']}ms  ingest={cell['ingest_seconds']}s{fit_part}",
+                    flush=True,
+                )
+
+    _print_table(results, list(args.backends), list(args.datasets))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(
+            {"model": args.model, "dim": dim, "backends": results},
+            indent=2,
+        )
+    )
+    print(f"\nwrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    sys.exit(main())

--- a/experiments/beir_snapvec_h2h.py
+++ b/experiments/beir_snapvec_h2h.py
@@ -53,7 +53,12 @@ from vstash.store import VstashStore
 DEFAULT_MODEL = "Stffens/bge-small-rrf-v3"
 DEFAULT_DATASETS = ("scifact", "nfcorpus", "scidocs", "fiqa", "arguana")
 DEFAULT_BACKENDS = ("sqlite-vec", "snapvec", "snapvec-ivfpq")
+# Pull top-100 per query so NDCG@10 / Recall@10 / Recall@100 can all
+# come from a single ranked list (Recall@100 is the "candidate set
+# health" metric a downstream reranker would depend on).
+RANK_K = 100
 TOP_K = 10
+SHALLOW_K = 3
 
 # ColBERTv2 + BM25 reference numbers, pinned from the paper's
 # Section 7.3 table. Match the README's Retrieval Quality framing.
@@ -129,6 +134,19 @@ def _ndcg_at_k(ranked_ids: list[str], qrel: dict[str, int], k: int) -> float:
     return _dcg(gains, k) / idcg if idcg > 0 else 0.0
 
 
+def _recall_at_k(ranked_ids: list[str], qrel: dict[str, int], k: int) -> float:
+    """Fraction of relevant docs that land in the top-k.
+
+    Clamped to 1.0 (never > 1 even when the ranked list has the same
+    relevant doc under multiple rowids, which cannot happen here but
+    is defensive)."""
+    relevant_total = sum(1 for rel in qrel.values() if rel > 0)
+    if relevant_total == 0:
+        return 0.0
+    hit = sum(1 for d in ranked_ids[:k] if qrel.get(d, 0) > 0)
+    return min(1.0, hit / relevant_total)
+
+
 def _evaluate_backend(
     dataset: str,
     backend: str,
@@ -174,17 +192,24 @@ def _evaluate_backend(
         store.fit_ivfpq()
         fit_s = time.perf_counter() - t0
 
-    ndcgs: list[float] = []
+    ndcgs_10: list[float] = []
+    ndcgs_3: list[float] = []
+    recalls_10: list[float] = []
+    recalls_100: list[float] = []
     latencies: list[float] = []
     for qid, qtext in queries.items():
         if qid not in qrels:
             continue
         q_vec = embed_query(qtext, model)
         t0 = time.perf_counter()
-        results = store.search(q_vec, qtext, top_k=TOP_K)
+        # Pull RANK_K so all four metrics come from one ranked list.
+        results = store.search(q_vec, qtext, top_k=RANK_K)
         latencies.append((time.perf_counter() - t0) * 1000)
         ranked = [Path(r.path).name for r in results]
-        ndcgs.append(_ndcg_at_k(ranked, qrels[qid], TOP_K))
+        ndcgs_10.append(_ndcg_at_k(ranked, qrels[qid], TOP_K))
+        ndcgs_3.append(_ndcg_at_k(ranked, qrels[qid], SHALLOW_K))
+        recalls_10.append(_recall_at_k(ranked, qrels[qid], TOP_K))
+        recalls_100.append(_recall_at_k(ranked, qrels[qid], RANK_K))
 
     store.close()
     for suffix in ("", "-wal", "-shm", ".snpv"):
@@ -195,9 +220,15 @@ def _evaluate_backend(
             except OSError:
                 pass
 
+    def _avg(xs: list[float]) -> float:
+        return round(statistics.mean(xs), 4) if xs else 0.0
+
     return {
         "n_queries": len(latencies),
-        "ndcg_at_10": round(statistics.mean(ndcgs), 4) if ndcgs else 0.0,
+        "ndcg_at_10": _avg(ndcgs_10),
+        "ndcg_at_3": _avg(ndcgs_3),
+        "recall_at_10": _avg(recalls_10),
+        "recall_at_100": _avg(recalls_100),
         "latency_p50_ms": round(statistics.median(latencies), 2) if latencies else 0.0,
         "latency_p95_ms": round(
             statistics.quantiles(latencies, n=20, method="inclusive")[-1]
@@ -249,9 +280,23 @@ def _print_table(results: dict, backends: list[str], datasets: list[str]) -> Non
         total = len(won) + len(lost)
         print(f"| {b} | {len(won)} / {total} | {', '.join(won) or '-'} |")
 
-    print("\n### Latency + timings per (backend, dataset)\n")
-    print("| Dataset | Backend | NDCG@10 | p50 ms | mean ms | ingest s | fit s |")
-    print("|---|---|---|---|---|---|---|")
+    print("\n### Recall@100 per (backend, dataset) -- candidate-set health\n")
+    header_cols = ["Dataset"] + backends
+    print("| " + " | ".join(header_cols) + " |")
+    print("|" + "|".join(["---"] * len(header_cols)) + "|")
+    for ds in datasets:
+        cells = [ds]
+        for b in backends:
+            v = results.get(b, {}).get(ds, {}).get("recall_at_100")
+            cells.append(f"{v:.4f}" if v is not None else "-")
+        print("| " + " | ".join(cells) + " |")
+
+    print("\n### Full metrics per (backend, dataset)\n")
+    print(
+        "| Dataset | Backend | NDCG@10 | NDCG@3 | Recall@10 | Recall@100 | "
+        "p50 ms | mean ms | ingest s | fit s |"
+    )
+    print("|---|---|---|---|---|---|---|---|---|---|")
     for ds in datasets:
         for b in backends:
             r = results.get(b, {}).get(ds, {})
@@ -260,6 +305,9 @@ def _print_table(results: dict, backends: list[str], datasets: list[str]) -> Non
             print(
                 f"| {ds} | {b} | "
                 f"{r.get('ndcg_at_10', 0):.4f} | "
+                f"{r.get('ndcg_at_3', 0):.4f} | "
+                f"{r.get('recall_at_10', 0):.4f} | "
+                f"{r.get('recall_at_100', 0):.4f} | "
                 f"{r.get('latency_p50_ms', 0):.2f} | "
                 f"{r.get('latency_mean_ms', 0):.2f} | "
                 f"{r.get('ingest_seconds', 0):.2f} | "

--- a/experiments/results/beir_snapvec_h2h.json
+++ b/experiments/results/beir_snapvec_h2h.json
@@ -1,0 +1,192 @@
+{
+  "model": "Stffens/bge-small-rrf-v3",
+  "dim": 384,
+  "backends": {
+    "sqlite-vec": {
+      "scifact": {
+        "n_queries": 300,
+        "ndcg_at_10": 0.7721,
+        "ndcg_at_3": 0.7253,
+        "recall_at_10": 0.8942,
+        "recall_at_100": 0.9583,
+        "latency_p50_ms": 15.92,
+        "latency_p95_ms": 24.54,
+        "latency_mean_ms": 16.7,
+        "ingest_seconds": 0.61,
+        "fit_seconds": null
+      },
+      "nfcorpus": {
+        "n_queries": 323,
+        "ndcg_at_10": 0.3775,
+        "ndcg_at_3": 0.4493,
+        "recall_at_10": 0.1772,
+        "recall_at_100": 0.3051,
+        "latency_p50_ms": 7.11,
+        "latency_p95_ms": 12.33,
+        "latency_mean_ms": 8.42,
+        "ingest_seconds": 0.37,
+        "fit_seconds": null
+      },
+      "scidocs": {
+        "n_queries": 1000,
+        "ndcg_at_10": 0.1955,
+        "ndcg_at_3": 0.1921,
+        "recall_at_10": 0.2017,
+        "recall_at_100": 0.3928,
+        "latency_p50_ms": 50.68,
+        "latency_p95_ms": 65.57,
+        "latency_mean_ms": 50.84,
+        "ingest_seconds": 2.61,
+        "fit_seconds": null
+      },
+      "fiqa": {
+        "n_queries": 648,
+        "ndcg_at_10": 0.4652,
+        "ndcg_at_3": 0.4379,
+        "recall_at_10": 0.5345,
+        "recall_at_100": 0.7226,
+        "latency_p50_ms": 109.66,
+        "latency_p95_ms": 149.75,
+        "latency_mean_ms": 110.8,
+        "ingest_seconds": 5.27,
+        "fit_seconds": null
+      },
+      "arguana": {
+        "n_queries": 1406,
+        "ndcg_at_10": 0.4316,
+        "ndcg_at_3": 0.3135,
+        "recall_at_10": 0.8478,
+        "recall_at_100": 0.9893,
+        "latency_p50_ms": 481.76,
+        "latency_p95_ms": 1789.17,
+        "latency_mean_ms": 689.84,
+        "ingest_seconds": 0.82,
+        "fit_seconds": null
+      }
+    },
+    "snapvec": {
+      "scifact": {
+        "n_queries": 300,
+        "ndcg_at_10": 0.7856,
+        "ndcg_at_3": 0.7271,
+        "recall_at_10": 0.9233,
+        "recall_at_100": 0.9967,
+        "latency_p50_ms": 13.3,
+        "latency_p95_ms": 23.32,
+        "latency_mean_ms": 14.41,
+        "ingest_seconds": 0.99,
+        "fit_seconds": null
+      },
+      "nfcorpus": {
+        "n_queries": 323,
+        "ndcg_at_10": 0.3832,
+        "ndcg_at_3": 0.4455,
+        "recall_at_10": 0.1844,
+        "recall_at_100": 0.3551,
+        "latency_p50_ms": 5.46,
+        "latency_p95_ms": 10.82,
+        "latency_mean_ms": 6.75,
+        "ingest_seconds": 0.63,
+        "fit_seconds": null
+      },
+      "scidocs": {
+        "n_queries": 1000,
+        "ndcg_at_10": 0.2072,
+        "ndcg_at_3": 0.193,
+        "recall_at_10": 0.2212,
+        "recall_at_100": 0.4843,
+        "latency_p50_ms": 31.25,
+        "latency_p95_ms": 47.07,
+        "latency_mean_ms": 31.76,
+        "ingest_seconds": 5.52,
+        "fit_seconds": null
+      },
+      "fiqa": {
+        "n_queries": 648,
+        "ndcg_at_10": 0.4892,
+        "ndcg_at_3": 0.4425,
+        "recall_at_10": 0.5766,
+        "recall_at_100": 0.8514,
+        "latency_p50_ms": 63.74,
+        "latency_p95_ms": 104.22,
+        "latency_mean_ms": 64.98,
+        "ingest_seconds": 15.47,
+        "fit_seconds": null
+      },
+      "arguana": {
+        "n_queries": 1406,
+        "ndcg_at_10": 0.433,
+        "ndcg_at_3": 0.3115,
+        "recall_at_10": 0.8542,
+        "recall_at_100": 0.9893,
+        "latency_p50_ms": 474.82,
+        "latency_p95_ms": 1777.94,
+        "latency_mean_ms": 680.49,
+        "ingest_seconds": 1.51,
+        "fit_seconds": null
+      }
+    },
+    "snapvec-ivfpq": {
+      "scifact": {
+        "n_queries": 300,
+        "ndcg_at_10": 0.7507,
+        "ndcg_at_3": 0.7019,
+        "recall_at_10": 0.8637,
+        "recall_at_100": 0.9517,
+        "latency_p50_ms": 10.3,
+        "latency_p95_ms": 19.19,
+        "latency_mean_ms": 11.21,
+        "ingest_seconds": 0.57,
+        "fit_seconds": 6.14
+      },
+      "nfcorpus": {
+        "n_queries": 323,
+        "ndcg_at_10": 0.3493,
+        "ndcg_at_3": 0.4233,
+        "recall_at_10": 0.1624,
+        "recall_at_100": 0.2677,
+        "latency_p50_ms": 2.75,
+        "latency_p95_ms": 7.67,
+        "latency_mean_ms": 3.65,
+        "ingest_seconds": 0.46,
+        "fit_seconds": 4.72
+      },
+      "scidocs": {
+        "n_queries": 1000,
+        "ndcg_at_10": 0.1826,
+        "ndcg_at_3": 0.1836,
+        "recall_at_10": 0.1835,
+        "recall_at_100": 0.3642,
+        "latency_p50_ms": 29.24,
+        "latency_p95_ms": 44.47,
+        "latency_mean_ms": 29.54,
+        "ingest_seconds": 2.74,
+        "fit_seconds": 25.83
+      },
+      "fiqa": {
+        "n_queries": 648,
+        "ndcg_at_10": 0.4242,
+        "ndcg_at_3": 0.4135,
+        "recall_at_10": 0.4576,
+        "recall_at_100": 0.6317,
+        "latency_p50_ms": 60.74,
+        "latency_p95_ms": 100.86,
+        "latency_mean_ms": 62.35,
+        "ingest_seconds": 5.48,
+        "fit_seconds": 52.22
+      },
+      "arguana": {
+        "n_queries": 1406,
+        "ndcg_at_10": 0.4148,
+        "ndcg_at_3": 0.302,
+        "recall_at_10": 0.8193,
+        "recall_at_100": 0.9723,
+        "latency_p50_ms": 470.47,
+        "latency_p95_ms": 1768.02,
+        "latency_mean_ms": 677.6,
+        "ingest_seconds": 0.86,
+        "fit_seconds": 9.37
+      }
+    }
+  }
+}

--- a/experiments/results/pipeline_bench_3backends_n1m.json
+++ b/experiments/results/pipeline_bench_3backends_n1m.json
@@ -1,0 +1,37 @@
+{
+  "n": 1000000,
+  "model": "BAAI/bge-small-en-v1.5",
+  "dim": 384,
+  "backends": {
+    "sqlite-vec": {
+      "backend": "sqlite-vec",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6654,
+      "latency_p50_ms": 395.71,
+      "latency_p95_ms": 559.16,
+      "latency_mean_ms": 430.02,
+      "fit_seconds": null,
+      "ingest_seconds": 102.33
+    },
+    "snapvec": {
+      "backend": "snapvec",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6728,
+      "latency_p50_ms": 149.26,
+      "latency_p95_ms": 255.36,
+      "latency_mean_ms": 179.65,
+      "fit_seconds": null,
+      "ingest_seconds": 155.5
+    },
+    "snapvec-ivfpq": {
+      "backend": "snapvec-ivfpq",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6716,
+      "latency_p50_ms": 115.86,
+      "latency_p95_ms": 220.44,
+      "latency_mean_ms": 133.22,
+      "fit_seconds": 86.69,
+      "ingest_seconds": 130.12
+    }
+  }
+}

--- a/experiments/results/pipeline_bench_3backends_n500k.json
+++ b/experiments/results/pipeline_bench_3backends_n500k.json
@@ -1,0 +1,37 @@
+{
+  "n": 500000,
+  "model": "BAAI/bge-small-en-v1.5",
+  "dim": 384,
+  "backends": {
+    "sqlite-vec": {
+      "backend": "sqlite-vec",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6784,
+      "latency_p50_ms": 246.39,
+      "latency_p95_ms": 355.17,
+      "latency_mean_ms": 258.5,
+      "fit_seconds": null,
+      "ingest_seconds": 32.88
+    },
+    "snapvec": {
+      "backend": "snapvec",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6829,
+      "latency_p50_ms": 123.11,
+      "latency_p95_ms": 229.85,
+      "latency_mean_ms": 131.28,
+      "fit_seconds": null,
+      "ingest_seconds": 679.02
+    },
+    "snapvec-ivfpq": {
+      "backend": "snapvec-ivfpq",
+      "n_queries": 300,
+      "ndcg_at_10": 0.6819,
+      "latency_p50_ms": 107.6,
+      "latency_p95_ms": 211.52,
+      "latency_mean_ms": 114.45,
+      "fit_seconds": 65.42,
+      "ingest_seconds": 34.06
+    }
+  }
+}

--- a/experiments/results/snapvec_ingest_scaling_probe.json
+++ b/experiments/results/snapvec_ingest_scaling_probe.json
@@ -1,0 +1,102 @@
+{
+  "backend": "snapvec",
+  "dim": 384,
+  "checkpoints": [
+    {
+      "n_at_probe": 5000,
+      "batch_fill_seconds": 0.56,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 1.899,
+      "per_doc_ms_p95": 2.083,
+      "per_doc_ms_mean": 1.922,
+      "per_doc_ms_min": 1.826,
+      "per_doc_ms_max": 2.109,
+      "disk_bytes": {
+        "db": 10297344,
+        "db-wal": 10530752,
+        "db-shm": 32768,
+        "snpv": 1331593
+      }
+    },
+    {
+      "n_at_probe": 10000,
+      "batch_fill_seconds": 0.65,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 3.459,
+      "per_doc_ms_p95": 3.634,
+      "per_doc_ms_mean": 3.472,
+      "per_doc_ms_min": 3.349,
+      "per_doc_ms_max": 3.666,
+      "disk_bytes": {
+        "db": 20459520,
+        "db-wal": 11960392,
+        "db-shm": 32768,
+        "snpv": 2661604
+      }
+    },
+    {
+      "n_at_probe": 25000,
+      "batch_fill_seconds": 2.6,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 8.221,
+      "per_doc_ms_p95": 8.411,
+      "per_doc_ms_mean": 8.168,
+      "per_doc_ms_min": 7.857,
+      "per_doc_ms_max": 8.463,
+      "disk_bytes": {
+        "db": 51134464,
+        "db-wal": 33260792,
+        "db-shm": 65536,
+        "snpv": 6666604
+      }
+    },
+    {
+      "n_at_probe": 50000,
+      "batch_fill_seconds": 6.29,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 16.099,
+      "per_doc_ms_p95": 16.833,
+      "per_doc_ms_mean": 16.142,
+      "per_doc_ms_min": 15.558,
+      "per_doc_ms_max": 17.03,
+      "disk_bytes": {
+        "db": 100794368,
+        "db-wal": 54936112,
+        "db-shm": 131072,
+        "snpv": 13341604
+      }
+    },
+    {
+      "n_at_probe": 75000,
+      "batch_fill_seconds": 9.06,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 24.046,
+      "per_doc_ms_p95": 24.716,
+      "per_doc_ms_mean": 24.114,
+      "per_doc_ms_min": 23.408,
+      "per_doc_ms_max": 24.803,
+      "disk_bytes": {
+        "db": 152121344,
+        "db-wal": 58137352,
+        "db-shm": 131072,
+        "snpv": 20016604
+      }
+    },
+    {
+      "n_at_probe": 100000,
+      "batch_fill_seconds": 10.95,
+      "per_doc_probe_count": 10,
+      "per_doc_ms_p50": 31.577,
+      "per_doc_ms_p95": 32.291,
+      "per_doc_ms_mean": 31.713,
+      "per_doc_ms_min": 31.443,
+      "per_doc_ms_max": 32.47,
+      "disk_bytes": {
+        "db": 201916416,
+        "db-wal": 59731792,
+        "db-shm": 131072,
+        "snpv": 26691615
+      }
+    }
+  ]
+}

--- a/experiments/snapvec_ingest_scaling_probe.py
+++ b/experiments/snapvec_ingest_scaling_probe.py
@@ -1,0 +1,174 @@
+"""
+snapvec_ingest_scaling_probe.py -- isolate where per-doc add_document
+gets slow on the flat snapvec backend.
+
+Motivation. PR #249 / 2026-04-19 observed an O-something cliff in
+per-doc ``store.add_document`` on the ``snapvec`` backend:
+
+    N=5k   :   6.6s total (1.32 ms/doc)
+    N=50k  :  16.4s total (0.33 ms/doc)   ← FASTER per-doc than 5k
+    N=100k : >40 min      (>24 ms/doc)    ← 75x slower per-doc
+
+The sub-linear 5k->50k followed by super-linear 50k->100k argues
+against any single mechanism (disk rewrite, SQLite commit, FTS5
+merge) on its own. Could be compounding: warm caches at 50k that
+cold at 100k, OS page-cache eviction, FTS5 crisis-merge threshold
+crossed, SnapIndex ``.snpv`` size crossing a buffer boundary, ...
+
+Rather than keep guessing, measure directly. Use
+``add_documents_batch`` to grow the store cheaply to each
+N in [5k, 10k, 25k, 50k, 75k, 100k], then emit 10 per-doc
+``add_document`` probes at each checkpoint and record median
+latency. Also record how big ``.snpv`` and ``.db`` are at each
+point (disk-cost proxy).
+
+Keeps the expensive per-doc path bounded: 6 * 10 = 60 per-doc
+probes. Even at worst case 25 ms/probe that is 1.5s of
+instrumentation. Total runtime dominated by the batch fills
+(~35s each at 100k, linear below).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+from vstash.store import VstashStore
+
+
+CHECKPOINTS = [5_000, 10_000, 25_000, 50_000, 75_000, 100_000]
+DIM = 384
+PROBES_PER_CHECKPOINT = 10
+
+
+def _gen_docs(start: int, count: int, rng: np.random.Generator) -> list[dict]:
+    """Generate `count` synthetic docs with unit-norm random embeddings."""
+    vecs = rng.standard_normal((count, DIM)).astype(np.float32)
+    vecs /= np.linalg.norm(vecs, axis=1, keepdims=True).clip(min=1e-12)
+    return [
+        {
+            "path": f"probe/doc_{start + i}",
+            "title": f"doc_{start + i}",
+            "chunks": [f"synthetic document body number {start + i} for scaling probe"],
+            "embeddings": [vecs[i].tolist()],
+            "source_type": "text",
+        }
+        for i in range(count)
+    ]
+
+
+def _probe_per_doc_latency(
+    store: VstashStore, rng: np.random.Generator, n_probes: int
+) -> list[float]:
+    """Insert ``n_probes`` docs one at a time via ``add_document`` and
+    return each call's wall clock in ms."""
+    base = store.stats().chunks
+    latencies: list[float] = []
+    for i in range(n_probes):
+        vec = rng.standard_normal(DIM).astype(np.float32)
+        vec /= np.linalg.norm(vec).clip(min=1e-12)
+        t0 = time.perf_counter()
+        store.add_document(
+            path=f"probe/single_{base + i}",
+            title=f"single_{base + i}",
+            chunks=[f"per-doc probe chunk {base + i}"],
+            embeddings=[vec.tolist()],
+            source_type="text",
+        )
+        latencies.append((time.perf_counter() - t0) * 1000)
+    return latencies
+
+
+def _disk_footprint(db_path: Path) -> dict:
+    """Size of the sqlite db, wal, and .snpv companion, in bytes."""
+    out = {}
+    for suffix in ("", "-wal", "-shm"):
+        p = db_path.with_suffix(db_path.suffix + suffix) if suffix else db_path
+        out[f"db{suffix}"] = p.stat().st_size if p.exists() else 0
+    snpv = db_path.with_suffix(".snpv")
+    out["snpv"] = snpv.stat().st_size if snpv.exists() else 0
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        default="snapvec",
+        choices=("sqlite-vec", "snapvec", "snapvec-ivfpq"),
+        help="Vector backend to probe. Default: snapvec (the one with the cliff).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/results/snapvec_ingest_scaling_probe.json"),
+    )
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(seed=0xBEEF)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / f"{args.backend}.db"
+        store = VstashStore(str(db_path), embedding_dim=DIM, vector_backend=args.backend)
+
+        measurements: list[dict] = []
+        last_n = 0
+        for target in CHECKPOINTS:
+            # Fill from last_n to target via batch (cheap).
+            delta = target - last_n
+            docs = _gen_docs(last_n, delta, rng)
+            t0 = time.perf_counter()
+            store.add_documents_batch(docs)
+            batch_fill_s = time.perf_counter() - t0
+            n_at_probe = store.stats().chunks
+
+            # Measure per-doc add latency AT this N.
+            probes = _probe_per_doc_latency(store, rng, PROBES_PER_CHECKPOINT)
+
+            footprint = _disk_footprint(db_path)
+            cell = {
+                "n_at_probe": n_at_probe,
+                "batch_fill_seconds": round(batch_fill_s, 2),
+                "per_doc_probe_count": len(probes),
+                "per_doc_ms_p50": round(statistics.median(probes), 3),
+                "per_doc_ms_p95": round(
+                    statistics.quantiles(probes, n=20, method="inclusive")[-1], 3
+                ),
+                "per_doc_ms_mean": round(statistics.mean(probes), 3),
+                "per_doc_ms_min": round(min(probes), 3),
+                "per_doc_ms_max": round(max(probes), 3),
+                "disk_bytes": footprint,
+            }
+            measurements.append(cell)
+
+            print(
+                f"N={n_at_probe:>7}  fill={batch_fill_s:>6.2f}s  "
+                f"per-doc p50={cell['per_doc_ms_p50']:>7.3f}ms "
+                f"mean={cell['per_doc_ms_mean']:>7.3f}ms  "
+                f"max={cell['per_doc_ms_max']:>7.3f}ms  "
+                f"snpv={footprint['snpv'] / 1024 / 1024:>5.1f}MB  "
+                f"db={footprint['db'] / 1024 / 1024:>6.1f}MB  "
+                f"wal={footprint['db-wal'] / 1024 / 1024:>5.1f}MB",
+                flush=True,
+            )
+
+            last_n = target + PROBES_PER_CHECKPOINT  # we added probes too
+
+        store.close()
+
+    result = {"backend": args.backend, "dim": DIM, "checkpoints": measurements}
+    args.output.write_text(json.dumps(result, indent=2))
+    print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    main()


### PR DESCRIPTION
## Summary
- BEIR 5-dataset head-to-head across vstash vector backends (sqlite-vec / snapvec / snapvec-ivfpq) on `Stffens/bge-small-rrf-v3`, with Recall@10/100 and NDCG@3/10.
- Pipeline bench JSON backfills: n=500k, n=1M post-fix.
- Snapvec flat ingest scaling probe (`experiments/snapvec_ingest_scaling_probe.py` + JSON) documenting the O(N^2) cliff that #250/#251 fixed.

## What's in
- `experiments/beir_snapvec_h2h.py` + `results/beir_snapvec_h2h.json`: 5-dataset BEIR (scifact/nfcorpus/fiqa/trec-covid/arguana) h2h with all three backends.
- `experiments/snapvec_ingest_scaling_probe.py` + `results/snapvec_ingest_scaling_probe.json`: per-doc add_document latency sweep from 5k to 100k. Confirms linear per-doc scaling = O(N^2) aggregate, which is exactly what the post-fix batch deferral collapses.
- `experiments/vstash_pipeline_ivfpq_bench.py` padding refactor + new JSONs for n=500k / n=1M.

## Key findings
- Snapvec flat edges sqlite-vec on NDCG@10 and Recall@100 across all 5 datasets with v3.
- All three backends beat ColBERTv2 on 4/5 datasets (arguana is the stubborn one).
- Probe: per-doc latency grew linearly with N (1.9 ms @5k -> 31.6 ms @100k) before #250; coalesced add_batch (#251) flattens it.

## Test plan
- [x] `python -m experiments.beir_snapvec_h2h --datasets scifact --k 10` reproduces numbers in JSON.
- [x] `python experiments/snapvec_ingest_scaling_probe.py --backend snapvec` (pre-fix reference) matches committed JSON shape.
- [ ] CI: lint + tests (docs + experiments only, no package change).