### PR TITLE
⚡ Bolt: [performance improvement] Precompute MMR loop invariants

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Optimize SQLite compound key fetches with CTE VALUES
 **Learning:** When retrieving a sparse set of rows matched on compound keys (like `doc_id` and `seq`), using a range query like `BETWEEN` retrieves all intermediate rows unnecessarily, which can be massively inefficient. Iterative fetches are also slow due to N+1 queries.
 **Action:** Chunk the input keys to stay within parameter limits (`_SQLITE_PARAM_BATCH`), and use a Common Table Expression (CTE) with a `VALUES` clause (`WITH targets(doc_id, seq) AS (VALUES ...)`) joined to the target tables to fetch exactly the rows needed in batches.
+
+## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
+**Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
+**Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -2860,6 +2860,10 @@ class VstashStore:
         # hoist would do (flagged in the #167 review).
         norm_scores = [(s - s_min) / s_range for s in scores]
 
+        # Precompute invariant MMR relevance terms to avoid O(K * N) recalculations
+        relevance_terms = [mmr_lambda * ns for ns in norm_scores]
+        penalty_multiplier = 1.0 - mmr_lambda
+
         # Extract values into fast lists for index-based access
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
@@ -2876,12 +2880,9 @@ class VstashStore:
             best_mmr = -float("inf")
 
             for idx in remaining:
-                norm_score = norm_scores[idx]
-
-                # Diversity penalty: only against same-document selections.
                 max_sim = max_sims[idx]
 
-                mmr_score = mmr_lambda * norm_score - (1 - mmr_lambda) * max_sim
+                mmr_score = relevance_terms[idx] - penalty_multiplier * max_sim
                 if mmr_score > best_mmr:
                     best_mmr = mmr_score
                     best_idx = idx


### PR DESCRIPTION
💡 What: Precomputed the `mmr_lambda * norm_score` and `1.0 - mmr_lambda` terms outside the $O(K \times N)$ inner loop in `vstash.store.VstashStore._mmr_dedup`.
🎯 Why: In greedy MMR selection algorithms, repeatedly calculating these invariant products per-item inside nested loops drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant argument, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
📊 Impact: Eliminates $O(K \times N)$ redundant multiplications and subtractions in pure Python, directly reducing overhead during heavy RAG reranking workflows with high N.
🔬 Measurement: Verified that tests pass via `python -m pytest tests/` and code style passes via `python -m ruff check .`. No functional regressions.

---
*PR created automatically by Jules for task [699257949369237291](https://jules.google.com/task/699257949369237291) started by @stffns*