### PR TITLE
chore(hypotheses): sync status + park SIGreg as H-T26

### DIFF
--- a/experiments/hypotheses.md
+++ b/experiments/hypotheses.md
@@ -45,7 +45,7 @@ further down this document and in
 
 ## Retrain (signal quality + training)
 
-### H-R1. Labeled queries should be the default path when qrels exist
+### H-R1. Labeled queries should be the default path when qrels exist [SHIPPED 2026-04-21; PR #257]
 
 **Statement.** `retrain_multi(..., training_queries_by_dataset=...)` currently
 opts in to the v5 recipe. If the user passes eval_queries with BEIR-style
@@ -145,7 +145,7 @@ fire early) and future ablation experiments. Not urgent.
 
 ---
 
-### H-R5. Eval surface: add NDCG@3, Recall@100 [IMPLEMENTED, not yet merged]
+### H-R5. Eval surface: add NDCG@3, Recall@100 [SHIPPED; merged in develop]
 
 **Statement.** `EvalMetrics` now tracks NDCG@10, NDCG@3, MRR, Hit@10,
 Recall@100 (N.B. per-dataset std across `--eval-seed` values is still on
@@ -187,7 +187,7 @@ legacy one only after 1 release cycle.
 
 ---
 
-### H-R7. Seed audit + global `--seed` flag [IMPLEMENTED, not yet merged]
+### H-R7. Seed audit + global `--seed` flag [SHIPPED; merged in develop]
 
 **Statement.** Every RNG that retrain training touches is now seeded from
 a single user-controllable root. `train_mnrl` pre-shuffles examples with
@@ -415,6 +415,55 @@ MNRL at same budget.
 
 **Risk.** Teacher model is 420 MB, needs careful batch sizing on T4 next
 to the student. Fallback path: teacher on CPU.
+
+---
+
+### H-T26. SIGreg (Sketched Isotropic Gaussian Regularization) as an MNRL auxiliary loss [PARKED; speculative, out-of-domain]
+
+**Statement.** LeJEPA (Balestriero + LeCun, arxiv 2511.08544, Nov 2025)
+introduces SIGreg, a regularizer that projects embeddings onto random
+1D directions and forces each marginal to match an isotropic Gaussian
+via the Epps-Pulley statistical test. In SSL pre-training (JEPA +
+ImageNet) SIGreg replaces stop-gradient, teacher-student, negative-
+sampling and whitening. Hypothesis: adding SIGreg as a small auxiliary
+loss to MNRL during vstash retrain would preserve bge-small's
+isotropic latent space, resisting the over-clustering that T1.4
+diagnosed on SciFact-only training and could help transfer to
+distant query distributions (FiQA).
+
+**Test.** Paired ablation on BEIR 3-dataset (T1.5 recipe baseline
+vs baseline + SIGreg). Train one run with ``sigreg_weight=0.0`` and
+one with a small sweep (``[0.01, 0.1, 0.3]``). Success bar: macro
+NDCG@10 +0.5pp over baseline with NFCorpus holding or gaining (no
+FiQA regression).
+
+**Files.** Would touch ``vstash/retrain.py:train_mnrl`` (new loss
+term) + new ``vstash/retrain_sigreg.py`` helper for sliced projection
++ Epps-Pulley test (Python/torch, ~100 LOC, no PyPI package exists
+under this name at 2026-04-21).
+
+**Effort.** 3-5 days: ~1 day implementation, ~1 day
+hyperparam sweep, ~1 day Colab GPU + writeup, + slack.
+
+**Risk / why parked (2026-04-21 investigation).**
+1. Distinct problem. SIGreg targets **SSL collapse prevention** in
+   pre-training. vstash retrain is **supervised contrastive fine-
+   tuning**; MNRL with in-batch negatives already prevents collapse
+   by construction. The core failure mode SIGreg was built for
+   does not apply.
+2. Zero evidence in retrieval. The paper validates on ImageNet SSL
+   only. No MTEB / BEIR / text-retrieval ablation is published.
+3. Misaligned with current bottleneck. H-R9 and experiment B showed
+   vstash's remaining NFCorpus / FiQA gap is a **signal-quality**
+   problem (distribution mismatch). SIGreg optimises **training
+   stability**, which is orthogonal.
+4. Opportunity cost. H-R1 / H-R8 / #157 all have direct evidence
+   of value; SIGreg is pure speculation that costs ~1 week of
+   Colab time to test.
+
+**Revisit condition.** A follow-up paper validates SIGreg on
+MTEB / BEIR fine-tuning. Until then, this is a literature pointer,
+not a queued experiment.
 
 ---
 

--- a/tests/test_retrain_batch.py
+++ b/tests/test_retrain_batch.py
@@ -624,6 +624,44 @@ class TestRetrainMultiH_R1AutoTrainingQueries:
         finally:
             s1.close()
 
+    def test_labeled_mode_promotes_eval_queries(self, tmp_path: Path) -> None:
+        """training_pair_source='labeled' with eval queries (no explicit
+        training) must promote them like auto -- only the prefix fallback
+        is forbidden under labeled. gemini-code-assist flagged this on
+        PR #257: original code raised ValueError even when eval queries
+        existed, which contradicted the 'requires training OR eval' spec."""
+        from vstash.retrain import retrain_multi
+
+        s1, _s2 = self._stores(tmp_path)
+        eval_qs = {"a": [{"query": "eval-only-labeled", "relevant_paths": ["/s1/0"]}]}
+        try:
+            with (
+                patch(
+                    "vstash.retrain_batch.generate_labeled_triples_batched",
+                    return_value=list(self._labeled_triple),
+                ) as mock_labeled,
+                patch("vstash.retrain.train_mnrl"),
+            ):
+                retrain_multi(
+                    {"a": s1},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=2,
+                    sampling="uniform",
+                    skip_eval=True,
+                    eval_queries_by_dataset=eval_qs,
+                    training_pair_source="labeled",
+                )
+
+            assert mock_labeled.call_count == 1
+            passed = (
+                mock_labeled.call_args_list[0].kwargs.get("labeled_queries")
+                or mock_labeled.call_args_list[0].args[2]
+            )
+            assert passed[0]["query"] == "eval-only-labeled"
+        finally:
+            s1.close()
+
     def test_labeled_mode_errors_when_no_labels(self, tmp_path: Path) -> None:
         """training_pair_source='labeled' must raise when a dataset has
         neither explicit training queries nor eval queries."""

--- a/tests/test_retrain_batch.py
+++ b/tests/test_retrain_batch.py
@@ -487,6 +487,211 @@ class TestRetrainMultiBulkMine:
             s1.close()
 
 
+class TestRetrainMultiH_R1AutoTrainingQueries:
+    """H-R1 (2026-04-21): when training_pair_source='auto' (default) and
+    a dataset has eval_queries but no explicit training_queries, reuse
+    eval queries as training queries and route through the labeled-
+    batched miner. Removes the 2026-04-18 footgun where a user passed
+    eval qrels and silently trained on chunk-prefixes."""
+
+    _labeled_triple = [
+        {"query": "q1", "positive": "p1", "negative": "n1"},
+    ]
+
+    def _stores(self, tmp_path: Path) -> tuple[VstashStore, VstashStore]:
+        s1 = _mk_store(
+            str(tmp_path / "s1.db"),
+            [(f"/s1/{i}", f"S1 {i}", f"s1 chunk {i}") for i in range(8)],
+        )
+        s2 = _mk_store(
+            str(tmp_path / "s2.db"),
+            [(f"/s2/{i}", f"S2 {i}", f"s2 chunk {i}") for i in range(8)],
+        )
+        return s1, s2
+
+    def test_auto_promotes_eval_to_training_when_no_explicit(self, tmp_path: Path) -> None:
+        """Given eval_queries_by_dataset and no training_queries_by_dataset,
+        retrain_multi (auto) must call the labeled-batched miner with the
+        eval queries and must NOT call the chunk-prefix miner."""
+        from vstash.retrain import retrain_multi
+
+        s1, s2 = self._stores(tmp_path)
+        eval_qs = {
+            "a": [{"query": "q-a", "relevant_paths": ["/s1/0"]}],
+            "b": [{"query": "q-b", "relevant_paths": ["/s2/0"]}],
+        }
+        try:
+            with (
+                patch(
+                    "vstash.retrain_batch.generate_labeled_triples_batched",
+                    return_value=list(self._labeled_triple),
+                ) as mock_labeled,
+                patch("vstash.retrain_batch.generate_triples_batched") as mock_batched,
+                patch("vstash.retrain.generate_triples") as mock_plain,
+                patch("vstash.retrain.train_mnrl"),
+                patch("vstash.retrain.evaluate_model"),
+            ):
+                retrain_multi(
+                    {"a": s1, "b": s2},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=4,
+                    sampling="uniform",
+                    skip_eval=True,
+                    eval_queries_by_dataset=eval_qs,
+                )
+
+            assert mock_labeled.call_count == 2
+            assert mock_batched.call_count == 0
+            assert mock_plain.call_count == 0
+            labeled_qs_per_call = [
+                c.kwargs.get("labeled_queries") or c.args[2]
+                for c in mock_labeled.call_args_list
+            ]
+            flat = [q["query"] for qs in labeled_qs_per_call for q in qs]
+            assert "q-a" in flat and "q-b" in flat
+        finally:
+            s1.close()
+            s2.close()
+
+    def test_explicit_training_queries_override_auto(self, tmp_path: Path) -> None:
+        """When both eval_queries and explicit training_queries are
+        provided, the explicit set wins and the eval queries are NOT
+        promoted for training."""
+        from vstash.retrain import retrain_multi
+
+        s1, _s2 = self._stores(tmp_path)
+        eval_qs = {"a": [{"query": "eval-only", "relevant_paths": ["/s1/0"]}]}
+        explicit_qs = {"a": [{"query": "train-only", "relevant_paths": ["/s1/1"]}]}
+        try:
+            with (
+                patch(
+                    "vstash.retrain_batch.generate_labeled_triples_batched",
+                    return_value=list(self._labeled_triple),
+                ) as mock_labeled,
+                patch("vstash.retrain.train_mnrl"),
+            ):
+                retrain_multi(
+                    {"a": s1},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=2,
+                    sampling="uniform",
+                    skip_eval=True,
+                    eval_queries_by_dataset=eval_qs,
+                    training_queries_by_dataset=explicit_qs,
+                )
+
+            assert mock_labeled.call_count == 1
+            (call,) = mock_labeled.call_args_list
+            passed = call.kwargs.get("labeled_queries") or call.args[2]
+            assert [q["query"] for q in passed] == ["train-only"]
+        finally:
+            s1.close()
+
+    def test_prefix_mode_forces_chunk_prefix_even_with_eval(self, tmp_path: Path) -> None:
+        """training_pair_source='prefix' must NOT promote eval queries,
+        even when they exist. Opt-in legacy path for users who want
+        chunk-prefix training on a labeled corpus."""
+        from vstash.retrain import retrain_multi
+
+        s1, _s2 = self._stores(tmp_path)
+        eval_qs = {"a": [{"query": "q-a", "relevant_paths": ["/s1/0"]}]}
+        try:
+            with (
+                patch(
+                    "vstash.retrain_batch.generate_labeled_triples_batched",
+                ) as mock_labeled,
+                patch(
+                    "vstash.retrain.generate_triples",
+                    return_value=list(self._labeled_triple),
+                ) as mock_plain,
+                patch("vstash.retrain.train_mnrl"),
+            ):
+                retrain_multi(
+                    {"a": s1},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=2,
+                    sampling="uniform",
+                    skip_eval=True,
+                    eval_queries_by_dataset=eval_qs,
+                    training_pair_source="prefix",
+                )
+
+            assert mock_labeled.call_count == 0
+            assert mock_plain.call_count == 1
+        finally:
+            s1.close()
+
+    def test_labeled_mode_errors_when_no_labels(self, tmp_path: Path) -> None:
+        """training_pair_source='labeled' must raise when a dataset has
+        neither explicit training queries nor eval queries."""
+        from vstash.retrain import retrain_multi
+
+        s1, _s2 = self._stores(tmp_path)
+        try:
+            with pytest.raises(ValueError, match="requires training or eval queries"):
+                retrain_multi(
+                    {"a": s1},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=2,
+                    sampling="uniform",
+                    skip_eval=True,
+                    training_pair_source="labeled",
+                )
+        finally:
+            s1.close()
+
+    def test_mixed_sources_in_one_call(self, tmp_path: Path, caplog: Any) -> None:
+        """One retrain_multi call can resolve different datasets via
+        different sources: explicit training for A, auto-from-eval for
+        B. Both must land on the labeled-batched miner, and the H-R1
+        warning must mention only the auto-promoted dataset."""
+        import logging as _logging
+
+        from vstash.retrain import retrain_multi
+
+        s1, s2 = self._stores(tmp_path)
+        explicit_a = [{"query": "train-a", "relevant_paths": ["/s1/0"]}]
+        eval_b = [{"query": "eval-b", "relevant_paths": ["/s2/0"]}]
+        try:
+            caplog.set_level(_logging.WARNING, logger="vstash.retrain")
+            with (
+                patch(
+                    "vstash.retrain_batch.generate_labeled_triples_batched",
+                    return_value=list(self._labeled_triple),
+                ) as mock_labeled,
+                patch("vstash.retrain.generate_triples") as mock_plain,
+                patch("vstash.retrain.train_mnrl"),
+            ):
+                retrain_multi(
+                    {"a": s1, "b": s2},
+                    base_model="dummy",
+                    output_path=str(tmp_path / "model"),
+                    total_triples=4,
+                    sampling="uniform",
+                    skip_eval=True,
+                    eval_queries_by_dataset={"b": eval_b},
+                    training_queries_by_dataset={"a": explicit_a},
+                )
+
+            assert mock_labeled.call_count == 2
+            assert mock_plain.call_count == 0
+            passed = [
+                (c.kwargs.get("labeled_queries") or c.args[2])[0]["query"]
+                for c in mock_labeled.call_args_list
+            ]
+            assert set(passed) == {"train-a", "eval-b"}
+            warnings = [r.message for r in caplog.records if r.levelno == _logging.WARNING]
+            assert any("auto-promoted" in m and "'b'" in m for m in warnings)
+            assert not any("'a'" in m for m in warnings if "auto-promoted" in m)
+        finally:
+            s1.close()
+            s2.close()
+
+
 # ------------------------------------------------------------------ #
 # Shared constants + approximation parity                              #
 # ------------------------------------------------------------------ #
@@ -841,6 +1046,7 @@ class TestRetrainMultiBulkEval:
                     eval_queries_by_dataset={"a": eval_queries},
                     bulk_eval=True,
                     bulk_mine_device="cpu",
+                    training_pair_source="prefix",  # isolate: test only exercises bulk_eval
                 )
 
             assert mock_batched.call_count == 2  # baseline + final
@@ -883,6 +1089,7 @@ class TestRetrainMultiBulkEval:
                     sampling="uniform",
                     eval_queries_by_dataset={"a": eval_queries},
                     bulk_eval=False,
+                    training_pair_source="prefix",  # isolate: test only exercises bulk_eval
                 )
 
             assert mock_batched.call_count == 0

--- a/tests/test_retrain_multi.py
+++ b/tests/test_retrain_multi.py
@@ -456,6 +456,7 @@ def test_eval_queries_by_dataset_skips_internal_split(
             sampling="uniform",
             eval_queries_by_dataset={"small": labeled_small, "medium": labeled_medium},
             min_gain=0.0,
+            training_pair_source="prefix",  # isolate: test exercises eval split, not train path
         )
 
     # Only the "big" dataset (not passed) should trigger split_corpus_for_eval.

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1793,6 +1793,16 @@ def retrain_multi_cmd(
         "corpus gets its own stable RNG, and then threaded into train_mnrl "
         "so DataLoader shuffles and torch dropout are reproducible.",
     ),
+    training_pair_source: str = typer.Option(
+        "auto",
+        "--training-pair-source",
+        help="Resolution policy for per-dataset training queries. "
+        "'auto' (default, H-R1) reuses eval labels as training queries "
+        "when present, falling back to chunk-prefix otherwise. "
+        "'labeled' errors if any dataset lacks labels. "
+        "'prefix' forces chunk-prefix even when eval labels exist.",
+        click_type=click.Choice(["auto", "labeled", "prefix"]),
+    ),
 ) -> None:
     """Fine-tune the embedding model over multiple corpora with balanced sampling.
 
@@ -1942,6 +1952,7 @@ def retrain_multi_cmd(
             bulk_mine=bulk_mine,
             bulk_mine_device=bulk_mine_device,
             bulk_eval=bulk_eval,
+            training_pair_source=training_pair_source,  # type: ignore[arg-type]
             cfg=cfg,
         )
     finally:

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -1623,11 +1623,15 @@ def retrain_multi(
     eval_training_source = eval_queries_by_dataset or {}
     training_by_ds: dict[str, list[dict]] = {}
     pair_source_by_ds: dict[str, str] = {}
+    # ``labeled`` implies promotion too -- it just forbids the prefix
+    # fallback. Both ``auto`` and ``labeled`` promote eval queries when
+    # present; only ``prefix`` skips the promotion step entirely.
+    auto_promote = training_pair_source in ("auto", "labeled")
     for name in stores_dict:
         if name in explicit_training and explicit_training[name]:
             training_by_ds[name] = explicit_training[name]
             pair_source_by_ds[name] = "explicit"
-        elif training_pair_source == "auto" and name in eval_training_source and eval_training_source[name]:
+        elif auto_promote and name in eval_training_source and eval_training_source[name]:
             training_by_ds[name] = list(eval_training_source[name])
             pair_source_by_ds[name] = "auto-from-eval"
         elif training_pair_source == "labeled":

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -1294,6 +1294,7 @@ def retrain(
 
 
 SamplingStrategy = Literal["uniform", "proportional", "temperature"]
+TrainingPairSource = Literal["auto", "labeled", "prefix"]
 
 
 def compute_triple_budget(
@@ -1436,6 +1437,7 @@ def retrain_multi(
     bulk_mine_device: str | None = None,
     bulk_eval: bool = False,
     training_queries_by_dataset: dict[str, list[dict]] | None = None,
+    training_pair_source: TrainingPairSource = "auto",
     cfg: "VstashConfig | None" = None,
 ) -> MultiRetrainResult:
     """Fine-tune an embedding model over N corpora with balanced sampling.
@@ -1479,14 +1481,32 @@ def retrain_multi(
             ``bulk_mine=False``.
         training_queries_by_dataset: Optional per-dataset labeled
             training queries, shape ``{alias: [{query, relevant_paths},
-            ...]}``. When set, the batched miner uses these real
-            queries (and their gold docs as positives) instead of the
-            default chunk-prefix pseudo-queries. Required to reproduce
-            the ``Stffens/bge-small-rrf-v2`` recipe (v5 notebook), which
-            trained on BEIR ``queries.jsonl`` + qrels. Implies
-            ``bulk_mine=True`` because the labeled-query path only
-            exists in ``retrain_batch``. Datasets missing from the map
-            fall back to the legacy chunk-prefix flow.
+            ...]}``. Explicit override: when set for a dataset, the
+            batched miner uses these real queries (and their gold
+            docs as positives) instead of the chunk-prefix
+            pseudo-queries. Implies ``bulk_mine=True`` because the
+            labeled-query path only exists in ``retrain_batch``.
+            Datasets missing from the map follow ``training_pair_source``.
+        training_pair_source: Resolution policy when
+            ``training_queries_by_dataset`` does not cover a dataset:
+            - ``"auto"`` (default, H-R1 ships 2026-04-21): reuse
+              ``eval_queries_by_dataset[dataset]`` as training queries
+              when present. Only USER-SUPPLIED eval queries are
+              promoted; queries produced internally by
+              ``split_corpus_for_eval`` never are (those would just
+              reintroduce the chunk-prefix signal under a new name).
+              Falls back to chunk-prefix when no eval labels exist.
+              This removes the 2026-04-18 footgun where a user passed
+              eval qrels but silently trained on chunk-prefixes
+              (-5.15% macro run).
+            - ``"labeled"``: require labels (either explicit training
+              queries or eval queries) for every dataset. Raises if a
+              dataset has neither.
+            - ``"prefix"``: force the legacy chunk-prefix / synth path
+              for every dataset that does not have explicit training
+              queries, even when eval labels exist. Opt-in for users
+              who intentionally want chunk-prefix training on a
+              labeled corpus.
         bulk_eval: Route baseline + final eval through
             ``retrain_batch.evaluate_model_batched`` which replaces
             the per-query ``eval_store.search`` scan with one GPU
@@ -1588,9 +1608,55 @@ def retrain_multi(
     # Triple generation per dataset. Datasets with labeled training
     # queries route through the v5-faithful ``generate_labeled_triples_batched``
     # path; the rest fall back to chunk-prefix / synth.
+    #
+    # H-R1 default (2026-04-21): when ``training_pair_source="auto"`` and
+    # a dataset has no explicit training queries, promote its eval queries
+    # (if present) to training queries automatically. This removes the
+    # 2026-04-18 footgun where BEIR qrels were silently ignored for
+    # training and the corpus trained on chunk-prefixes (-5.15% macro run).
     all_pairs: list[dict] = []
     per_dataset_pairs: dict[str, int] = {}
-    training_by_ds = training_queries_by_dataset or {}
+    explicit_training = training_queries_by_dataset or {}
+    # Only USER-SUPPLIED eval queries are eligible for auto-promotion.
+    # ``eval_training_source[name]`` can be ``None`` or ``[]`` if a caller
+    # passes a partial map; the ``and`` chain below handles both.
+    eval_training_source = eval_queries_by_dataset or {}
+    training_by_ds: dict[str, list[dict]] = {}
+    pair_source_by_ds: dict[str, str] = {}
+    for name in stores_dict:
+        if name in explicit_training and explicit_training[name]:
+            training_by_ds[name] = explicit_training[name]
+            pair_source_by_ds[name] = "explicit"
+        elif training_pair_source == "auto" and name in eval_training_source and eval_training_source[name]:
+            training_by_ds[name] = list(eval_training_source[name])
+            pair_source_by_ds[name] = "auto-from-eval"
+        elif training_pair_source == "labeled":
+            raise ValueError(
+                f"training_pair_source='labeled' requires training or eval "
+                f"queries for dataset '{name}'; neither was provided."
+            )
+        else:
+            pair_source_by_ds[name] = "prefix"
+    # Emit a one-shot warning when auto fires for at least one dataset,
+    # so users upgrading past the H-R1 ship can see that their eval
+    # queries are now flowing into training too. Escalated from info to
+    # warning because this is a semantic default change (2026-04-18
+    # footgun).
+    promoted_ds = [n for n, src in pair_source_by_ds.items() if src == "auto-from-eval"]
+    if promoted_ds:
+        logger.warning(
+            "retrain_multi (H-R1, shipped 2026-04-21): auto-promoted "
+            "eval_queries_by_dataset to training queries for datasets %s. "
+            "This replaces the chunk-prefix training signal and fixes the "
+            "2026-04-18 -5.15%% footgun. Pass training_pair_source='prefix' "
+            "to keep the legacy chunk-prefix training path.",
+            promoted_ds,
+        )
+    logger.info(
+        "retrain_multi pair source resolution (training_pair_source=%s): %s",
+        training_pair_source,
+        pair_source_by_ds,
+    )
     for name, store in stores_dict.items():
         n_queries = budget.get(name, 0)
         if n_queries <= 0:


### PR DESCRIPTION
Doc-only update.

## Status sync
- **H-R1** -> [SHIPPED 2026-04-21; PR #257]. Labeled queries auto-promote.
- **H-R5** (NDCG@3 + Recall@100) and **H-R7** (--seed flag) were already in develop; mark [SHIPPED; merged in develop]. The old label was stale.

## New: H-T26 -- SIGreg parked
Sketched Isotropic Gaussian Regularization (LeJEPA, arxiv 2511.08544, Nov 2025) was investigated on 2026-04-21 and parked with reasons:
1. SIGreg targets SSL collapse prevention; vstash retrain is supervised contrastive, MNRL+in-batch negatives prevent collapse by construction.
2. Paper validates on ImageNet SSL; zero published retrieval / BEIR / MTEB evidence.
3. Bottleneck is signal quality (distribution mismatch on NFCorpus / FiQA), not training stability.
4. ~1 week of Colab spend to test vs ~1 day of direct wins elsewhere (H-R8 / #157).

Revisit condition documented.