### PR TITLE
feat(retrain): H-R8 labeled queries + bulk_mine on single-corpus retrain

### DIFF
--- a/tests/test_retrain.py
+++ b/tests/test_retrain.py
@@ -1213,6 +1213,7 @@ class TestRetrainOrchestration:
                 base_model="dummy",
                 output_path=str(tmp_path / "m"),
                 eval_queries=external,
+                training_pair_source="prefix",  # isolate: test checks eval-split bypass, not training path
             )
 
         # split_corpus_for_eval must be bypassed when external queries supplied.
@@ -1306,3 +1307,261 @@ class TestRetrainOrchestration:
         assert (final_path / "existing.txt").read_text() == "previous good model"
         # No leftover backup.
         assert not (tmp_path / "m.old").exists()
+
+
+class TestRetrainH_R8LabeledAutoTrainingQueries:
+    """H-R8 (2026-04-21): single-corpus retrain gets the same
+    labeled-queries + auto-promote pattern that H-R1 landed on
+    retrain_multi. Single-store users with BEIR qrels no longer need
+    to wrap their store in a one-element dict to reach the batched
+    labeled miner."""
+
+    _labeled_triple = [{"query": "q1", "positive": "p1", "negative": "n1"}] * 15
+
+    def test_explicit_training_queries_route_to_labeled_miner(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        explicit = [
+            {"query": f"train-q{i}", "relevant_paths": [f"/p{i}"]} for i in range(25)
+        ]
+        baseline = EvalMetrics(ndcg_at_10=0.5, mrr=0.5, hit_at_10=0.6, n_queries=25)
+        final = EvalMetrics(ndcg_at_10=0.6, mrr=0.6, hit_at_10=0.7, n_queries=25)
+
+        with (
+            patch(
+                "vstash.retrain_batch.generate_labeled_triples_batched",
+                return_value=list(self._labeled_triple),
+            ) as mock_labeled,
+            patch("vstash.retrain.generate_triples") as mock_plain,
+            patch(
+                "vstash.retrain.evaluate_model",
+                side_effect=[baseline, final],
+            ),
+            patch("vstash.retrain.split_corpus_for_eval", return_value=(set(), explicit)),
+        ):
+            retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                training_queries=explicit,
+            )
+
+        assert mock_labeled.call_count == 1
+        assert mock_plain.call_count == 0
+
+    def test_auto_promotes_eval_queries_to_training(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any, caplog: Any
+    ) -> None:
+        """Default behavior: eval_queries flow into training_queries
+        unless the user says otherwise. Mirrors H-R1 on retrain_multi."""
+        import logging as _logging
+
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        eval_qs = [
+            {"query": f"eval-q{i}", "relevant_paths": [f"/p{i}"]} for i in range(25)
+        ]
+        baseline = EvalMetrics(ndcg_at_10=0.5, mrr=0.5, hit_at_10=0.6, n_queries=25)
+        final = EvalMetrics(ndcg_at_10=0.6, mrr=0.6, hit_at_10=0.7, n_queries=25)
+
+        caplog.set_level(_logging.WARNING, logger="vstash.retrain")
+        with (
+            patch(
+                "vstash.retrain_batch.generate_labeled_triples_batched",
+                return_value=list(self._labeled_triple),
+            ) as mock_labeled,
+            patch("vstash.retrain.generate_triples") as mock_plain,
+            patch(
+                "vstash.retrain.evaluate_model",
+                side_effect=[baseline, final],
+            ),
+        ):
+            retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                eval_queries=eval_qs,
+            )
+
+        assert mock_labeled.call_count == 1
+        passed = (
+            mock_labeled.call_args_list[0].kwargs.get("labeled_queries")
+            or mock_labeled.call_args_list[0].args[2]
+        )
+        assert passed[0]["query"] == "eval-q0"
+        assert mock_plain.call_count == 0
+        warnings = [r.message for r in caplog.records if r.levelno == _logging.WARNING]
+        assert any("auto-promoted" in m for m in warnings)
+
+    def test_prefix_mode_forces_chunk_prefix_even_with_eval(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        eval_qs = [{"query": f"q{i}", "relevant_paths": [f"/p{i}"]} for i in range(25)]
+        baseline = EvalMetrics(ndcg_at_10=0.5, mrr=0.5, hit_at_10=0.6, n_queries=25)
+        final = EvalMetrics(ndcg_at_10=0.6, mrr=0.6, hit_at_10=0.7, n_queries=25)
+
+        with (
+            patch(
+                "vstash.retrain_batch.generate_labeled_triples_batched",
+            ) as mock_labeled,
+            patch(
+                "vstash.retrain.generate_triples",
+                return_value=list(self._labeled_triple),
+            ) as mock_plain,
+            patch(
+                "vstash.retrain.evaluate_model",
+                side_effect=[baseline, final],
+            ),
+        ):
+            retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                eval_queries=eval_qs,
+                training_pair_source="prefix",
+            )
+
+        assert mock_labeled.call_count == 0
+        assert mock_plain.call_count == 1
+
+    def test_labeled_mode_errors_when_no_labels_skip_eval_path(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """No labels + empty corpus-split eval set -> fallback hits
+        skip_eval branch, which refuses labeled mode with a clear error."""
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        with (
+            patch("vstash.retrain.split_corpus_for_eval", return_value=(set(), [])),
+            patch("vstash.retrain.evaluate_model") as mock_eval,
+        ):
+            with pytest.raises(ValueError, match="requires training_queries or eval_queries"):
+                retrain(
+                    populated_store,
+                    base_model="dummy",
+                    output_path=str(tmp_path / "m"),
+                    training_pair_source="labeled",
+                )
+        assert mock_eval.call_count == 0
+
+    def test_labeled_mode_errors_on_normal_path_too(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """W2 (code review): the previous skip_eval-path test relied on
+        the insufficient-eval fallback to reach the error. This test
+        exercises the normal-path resolver directly: pass ENOUGH
+        corpus-split queries to bypass the fallback, then assert that
+        labeled mode still raises when no labels are supplied.
+        cos(retrain.py:1250) chains explicit -> auto-from-eval ->
+        labeled-errors on the non-skip_eval branch."""
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        # split_corpus_for_eval returns enough queries to pass
+        # _EVAL_MIN_QUERIES, so the function does NOT fall back to
+        # skip_eval. eval_queries is None -> those split queries are
+        # NOT eligible for auto-promotion (user-supplied only rule).
+        fake_split_queries = [
+            {"query": f"split-q{i}", "relevant_paths": [f"/p{i}"]}
+            for i in range(30)
+        ]
+        with (
+            patch(
+                "vstash.retrain.split_corpus_for_eval",
+                return_value=(set(), fake_split_queries),
+            ),
+            patch("vstash.retrain.evaluate_model") as mock_eval,
+        ):
+            with pytest.raises(ValueError, match="requires training_queries or eval_queries"):
+                retrain(
+                    populated_store,
+                    base_model="dummy",
+                    output_path=str(tmp_path / "m"),
+                    training_pair_source="labeled",
+                )
+        # Baseline eval runs before the resolver (line ~1216), so one
+        # call is expected. The resolver raises before the final-eval call.
+        assert mock_eval.call_count == 1
+
+    def test_auto_promotion_survives_insufficient_eval_fallback(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """W1 (code review): when eval_queries has < _EVAL_MIN_QUERIES
+        entries, retrain recurses into skip_eval=True. Without the W1
+        fix the labels are silently dropped in the recursive call and
+        training falls back to chunk-prefix -- the H-R1 footgun
+        relocated. With the fix, the fallback promotes eval_queries to
+        training_queries before recursing, so labeled training still
+        happens."""
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        # Fewer than _EVAL_MIN_QUERIES (=20) so the fallback fires.
+        short_eval = [
+            {"query": f"eval-q{i}", "relevant_paths": [f"/p{i}"]}
+            for i in range(10)
+        ]
+        with (
+            patch(
+                "vstash.retrain_batch.generate_labeled_triples_batched",
+                return_value=list(self._labeled_triple),
+            ) as mock_labeled,
+            patch("vstash.retrain.generate_triples") as mock_plain,
+            patch("vstash.retrain.train_mnrl"),
+        ):
+            retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                eval_queries=short_eval,
+                # Default training_pair_source='auto'.
+            )
+
+        assert mock_labeled.call_count == 1
+        assert mock_plain.call_count == 0
+        passed = (
+            mock_labeled.call_args_list[0].kwargs.get("labeled_queries")
+            or mock_labeled.call_args_list[0].args[2]
+        )
+        assert passed[0]["query"] == "eval-q0"
+
+    def test_bulk_mine_routes_chunk_prefix_to_batched(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        baseline = EvalMetrics(ndcg_at_10=0.5, mrr=0.5, hit_at_10=0.6, n_queries=25)
+        final = EvalMetrics(ndcg_at_10=0.6, mrr=0.6, hit_at_10=0.7, n_queries=25)
+
+        with (
+            patch(
+                "vstash.retrain_batch.generate_triples_batched",
+                return_value=list(self._labeled_triple),
+            ) as mock_batched,
+            patch("vstash.retrain.generate_triples") as mock_plain,
+            patch(
+                "vstash.retrain.evaluate_model",
+                side_effect=[baseline, final],
+            ),
+        ):
+            retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                bulk_mine=True,
+                bulk_mine_device="cpu",
+                training_pair_source="prefix",  # keep us on the chunk-prefix path
+            )
+
+        assert mock_batched.call_count == 1
+        assert mock_plain.call_count == 0
+        assert mock_batched.call_args_list[0].kwargs.get("device") == "cpu"

--- a/tests/test_retrain.py
+++ b/tests/test_retrain.py
@@ -1533,6 +1533,41 @@ class TestRetrainH_R8LabeledAutoTrainingQueries:
         )
         assert passed[0]["query"] == "eval-q0"
 
+    def test_explicit_empty_training_queries_respects_intent(
+        self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
+    ) -> None:
+        """gemini review on PR #259: ``training_queries=[]`` is a user
+        signal ("use labeled path with no queries"), NOT a cue to fall
+        back to prefix. None-vs-empty distinction: the explicit empty
+        list flows into the labeled miner, produces 0 pairs, and the
+        ``< 10 pairs`` gate returns a clean gated_out result -- not a
+        silent chunk-prefix run."""
+        st_mod, _, _ = st_stubs
+        st_mod.SentenceTransformer.return_value = MagicMock()
+
+        with (
+            patch(
+                "vstash.retrain_batch.generate_labeled_triples_batched",
+                return_value=[],
+            ) as mock_labeled,
+            patch("vstash.retrain.generate_triples") as mock_plain,
+            patch("vstash.retrain.train_mnrl") as mock_train,
+            patch("vstash.retrain.split_corpus_for_eval", return_value=(set(), [])),
+        ):
+            result = retrain(
+                populated_store,
+                base_model="dummy",
+                output_path=str(tmp_path / "m"),
+                training_queries=[],  # explicit empty list
+                skip_eval=True,
+            )
+
+        assert mock_labeled.call_count == 1  # labeled path, not prefix
+        assert mock_plain.call_count == 0
+        assert mock_train.call_count == 0  # zero pairs -> no training call
+        assert result.n_pairs == 0
+        assert result.output_path is None  # clean gated_out, not a silent chunk-prefix save
+
     def test_bulk_mine_routes_chunk_prefix_to_batched(
         self, populated_store: VstashStore, tmp_path: Path, st_stubs: Any
     ) -> None:

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -17,6 +17,7 @@ Commands:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import click
@@ -1539,6 +1540,38 @@ def retrain(
         "torch dropout, and DataLoader shuffle, so two runs with the same "
         "inputs and seed produce identical models.",
     ),
+    training_queries: str | None = typer.Option(
+        None,
+        "--training-queries",
+        help="Path to a JSONL file of labeled training queries (shape per "
+        "line: {query, relevant_paths}). When set, routes through the "
+        "labeled-batched miner (v5 recipe) instead of chunk-prefix "
+        "pseudo-queries. H-R8 (2026-04-21).",
+    ),
+    training_pair_source: str = typer.Option(
+        "auto",
+        "--training-pair-source",
+        help="Resolution policy when --training-queries is not set. "
+        "'auto' (default, H-R8) reuses --eval-queries as training "
+        "queries when present, falling back to chunk-prefix otherwise. "
+        "'labeled' errors if no labels. 'prefix' forces chunk-prefix.",
+        click_type=click.Choice(["auto", "labeled", "prefix"]),
+    ),
+    bulk_mine: bool = typer.Option(
+        False,
+        "--bulk-mine/--no-bulk-mine",
+        help="Route chunk-prefix mining through the GPU-batched miner "
+        "(retrain_batch.generate_triples_batched). 20-50x faster than "
+        "the default per-query path on FiQA-sized corpora, at the cost "
+        "of holding the full corpus in GPU memory for a moment. "
+        "Ignored when labeled queries are used (labeled path is always batched).",
+    ),
+    bulk_mine_device: str | None = typer.Option(
+        None,
+        "--bulk-mine-device",
+        help="Device override for --bulk-mine / the labeled-batched miner "
+        "('cuda' or 'cpu'). Leave unset to auto-detect.",
+    ),
 ) -> None:
     """Fine-tune the embedding model using your own data.
 
@@ -1603,6 +1636,41 @@ def retrain(
         )
     console.print()
 
+    loaded_training_queries: list[dict] | None = None
+    if training_queries:
+        path = Path(training_queries).expanduser()
+        if not path.exists():
+            console.print(
+                f"[red]x[/red] --training-queries: file not found: {path}"
+            )
+            raise typer.Exit(code=1)
+        try:
+            with path.open() as fh:
+                loaded_training_queries = [json.loads(line) for line in fh if line.strip()]
+        except (OSError, json.JSONDecodeError) as exc:
+            console.print(
+                f"[red]x[/red] --training-queries: failed to parse {path}: {exc}. "
+                f"Expected JSONL (one {{'query': ..., 'relevant_paths': [...]}} per line)."
+            )
+            raise typer.Exit(code=1) from exc
+        # Shape validation: each record must be a dict with query +
+        # relevant_paths. A common mistake is passing a JSON-array-per-file
+        # (``queries.json`` instead of ``queries.jsonl``), which would parse
+        # as one list entry and crash opaquely inside the miner.
+        for i, q in enumerate(loaded_training_queries):
+            if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
+                console.print(
+                    f"[red]x[/red] --training-queries: line {i + 1} is not a "
+                    "valid query record. Each line must be a JSON object with "
+                    "'query' and 'relevant_paths' fields. If you have a single "
+                    "JSON array, convert to JSONL (one object per line)."
+                )
+                raise typer.Exit(code=1)
+        console.print(
+            f"  Training queries: [cyan]{len(loaded_training_queries)} labeled[/cyan] "
+            f"from {path}"
+        )
+
     result = run_retrain(
         store,
         base_model=model_name,
@@ -1620,6 +1688,10 @@ def retrain(
         synth_n=synth_n,
         synth_cache=synth_cache,
         synth_model=synth_model,
+        training_queries=loaded_training_queries,
+        training_pair_source=training_pair_source,  # type: ignore[arg-type]
+        bulk_mine=bulk_mine,
+        bulk_mine_device=bulk_mine_device,
         cfg=cfg,
     )
 

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -1071,12 +1071,15 @@ def retrain(
         # eval_queries is not applicable here (skip_eval=True implies
         # no eval), so only the explicit training_queries branch and
         # the prefix/bulk fallbacks fire.
-        if training_pair_source == "labeled" and not training_queries:
+        # Same None-vs-empty distinction as the normal path: an explicit
+        # empty list is a user signal to use the labeled path (and gate
+        # out cleanly on zero pairs), not a cue to fall back to prefix.
+        if training_pair_source == "labeled" and training_queries is None:
             raise ValueError(
                 "training_pair_source='labeled' requires training_queries or "
                 "eval_queries; neither was provided."
             )
-        if training_queries:
+        if training_queries is not None:
             from .retrain_batch import generate_labeled_triples_batched
 
             pairs = generate_labeled_triples_batched(
@@ -1181,6 +1184,12 @@ def retrain(
         # branch silently drops the labels (only checks training_queries,
         # not eval_queries) and the user gets a chunk-prefix run under a
         # flag labeled "auto" -- the exact H-R1 footgun, just relocated.
+        # None vs empty: if user explicitly passed training_queries=[],
+        # honor that -- the recursive skip_eval call will hit the
+        # ``training_queries is not None`` branch, miner will return 0
+        # pairs, and the gate will report the empty-label run. Only
+        # promote from eval_queries when training_queries was NOT
+        # specified (None).
         fallback_training = training_queries
         if (
             fallback_training is None
@@ -1260,8 +1269,15 @@ def retrain(
 
     # H-R8 (2026-04-21): resolve the effective labeled training queries.
     # Mirrors the H-R1 policy on retrain_multi but over a single store.
+    # ``training_queries is not None`` (not falsy): an empty list is a
+    # user-supplied "labeled path, zero queries" signal, distinct from
+    # ``None`` which means "not specified, apply the auto/prefix rules".
+    # An empty list will flow into generate_labeled_triples_batched,
+    # produce zero pairs, and the ``len(pairs) < 10`` gate will raise a
+    # clear "not enough training pairs" error -- respecting intent
+    # instead of silently falling back to chunk-prefix.
     effective_training_queries: list[dict] | None
-    if training_queries:
+    if training_queries is not None:
         effective_training_queries = list(training_queries)
         pair_source = "explicit"
     elif training_pair_source in ("auto", "labeled") and eval_queries:

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -1001,6 +1001,10 @@ def retrain(
     synth_n: int = 2,
     synth_cache: str | Path | None = None,
     synth_model: str | None = None,
+    training_queries: list[dict] | None = None,
+    training_pair_source: TrainingPairSource = "auto",
+    bulk_mine: bool = False,
+    bulk_mine_device: str | None = None,
     cfg: "VstashConfig | None" = None,
 ) -> RetrainResult:
     """Full eval-gated retrain pipeline.
@@ -1033,6 +1037,26 @@ def retrain(
             pseudo-queries are still derived from the full store (no
             exclusion), which is correct because external eval docs
             typically have no chunk overlap with training.
+        training_queries: Optional explicit labeled training queries,
+            shape ``[{query, relevant_paths}, ...]``. When set, routes
+            through ``generate_labeled_triples_batched`` (v5 recipe).
+            Equivalent to ``training_queries_by_dataset={store: [...]}``
+            on ``retrain_multi``. H-R8 (2026-04-21).
+        training_pair_source: Resolution policy mirroring ``retrain_multi``
+            (H-R1). ``"auto"`` (default) promotes ``eval_queries`` to
+            training when no explicit ``training_queries`` is passed;
+            ``"labeled"`` requires labels and errors if none exist;
+            ``"prefix"`` forces the chunk-prefix path even when eval
+            labels are present. Only USER-SUPPLIED ``eval_queries`` are
+            eligible for auto-promotion (the internal
+            ``split_corpus_for_eval`` output is not, to avoid
+            reintroducing the chunk-prefix signal under a new name).
+        bulk_mine: Route chunk-prefix mining through
+            ``retrain_batch.generate_triples_batched`` (GPU matmul).
+            Ignored when labeled training queries are used (the labeled
+            path is always batched). H-R8.
+        bulk_mine_device: ``"cuda" | "cpu" | None`` override for the
+            batched miners. ``None`` = auto-detect.
 
     Returns:
         RetrainResult with baseline, final, delta, and final path.
@@ -1041,28 +1065,72 @@ def retrain(
     final_path_str = str(Path(output_path).expanduser())
 
     if skip_eval:
-        training_chunks = sample_training_chunks(store, max_queries=max_queries, seed=seed)
-        synth_map: dict[int, list[str]] = {}
-        if synthesize_queries and training_chunks:
-            if cfg is None:
-                raise ValueError("synthesize_queries=True requires the ``cfg`` argument.")
-            from .retrain_synth import synthesize_queries as _synth_queries
-
-            synth_map = _synth_queries(
-                training_chunks,
-                cfg=cfg,
-                n_per_chunk=synth_n,
-                cache_path=synth_cache,
-                model=synth_model,
+        # H-R8: honor labeled-query + bulk_mine flags in the skip-eval
+        # path too, so users can do ``retrain(training_queries=...,
+        # skip_eval=True)`` for a smoke run. Auto-promotion from
+        # eval_queries is not applicable here (skip_eval=True implies
+        # no eval), so only the explicit training_queries branch and
+        # the prefix/bulk fallbacks fire.
+        if training_pair_source == "labeled" and not training_queries:
+            raise ValueError(
+                "training_pair_source='labeled' requires training_queries or "
+                "eval_queries; neither was provided."
             )
-        pairs = generate_triples(
-            store,
-            base_model,
-            max_queries=max_queries,
-            seed=seed,
-            synthesized_queries=synth_map or None,
-            pre_sampled_chunks=training_chunks,
-        )
+        if training_queries:
+            from .retrain_batch import generate_labeled_triples_batched
+
+            pairs = generate_labeled_triples_batched(
+                store,
+                base_model,
+                labeled_queries=list(training_queries),
+                max_queries=max_queries,
+                device=bulk_mine_device,
+            )
+            if len(pairs) > max_queries:
+                generated = len(pairs)
+                rng = random.Random(seed)
+                keep_indices = sorted(rng.sample(range(generated), max_queries))
+                pairs = [pairs[i] for i in keep_indices]
+        else:
+            training_chunks = sample_training_chunks(
+                store, max_queries=max_queries, seed=seed
+            )
+            synth_map: dict[int, list[str]] = {}
+            if synthesize_queries and training_chunks:
+                if cfg is None:
+                    raise ValueError(
+                        "synthesize_queries=True requires the ``cfg`` argument."
+                    )
+                from .retrain_synth import synthesize_queries as _synth_queries
+
+                synth_map = _synth_queries(
+                    training_chunks,
+                    cfg=cfg,
+                    n_per_chunk=synth_n,
+                    cache_path=synth_cache,
+                    model=synth_model,
+                )
+            if bulk_mine:
+                from .retrain_batch import generate_triples_batched
+
+                pairs = generate_triples_batched(
+                    store,
+                    base_model,
+                    max_queries=max_queries,
+                    seed=seed,
+                    synthesized_queries=synth_map or None,
+                    pre_sampled_chunks=training_chunks,
+                    device=bulk_mine_device,
+                )
+            else:
+                pairs = generate_triples(
+                    store,
+                    base_model,
+                    max_queries=max_queries,
+                    seed=seed,
+                    synthesized_queries=synth_map or None,
+                    pre_sampled_chunks=training_chunks,
+                )
         if not pairs:
             return RetrainResult(
                 output_path=None,
@@ -1107,6 +1175,19 @@ def retrain(
             len(effective_queries),
             _EVAL_MIN_QUERIES,
         )
+        # W1 (code review): when falling back to skip_eval, promote
+        # eval_queries to training_queries BEFORE recursing if the caller
+        # asked for auto/labeled resolution. Otherwise the skip_eval
+        # branch silently drops the labels (only checks training_queries,
+        # not eval_queries) and the user gets a chunk-prefix run under a
+        # flag labeled "auto" -- the exact H-R1 footgun, just relocated.
+        fallback_training = training_queries
+        if (
+            fallback_training is None
+            and training_pair_source in ("auto", "labeled")
+            and eval_queries
+        ):
+            fallback_training = list(eval_queries)
         return retrain(
             store,
             base_model=base_model,
@@ -1124,6 +1205,10 @@ def retrain(
             synth_n=synth_n,
             synth_cache=synth_cache,
             synth_model=synth_model,
+            training_queries=fallback_training,
+            training_pair_source=training_pair_source,
+            bulk_mine=bulk_mine,
+            bulk_mine_device=bulk_mine_device,
             cfg=cfg,
         )
 
@@ -1173,15 +1258,93 @@ def retrain(
             len(training_chunks),
         )
 
-    pairs = generate_triples(
-        store,
-        base_model,
-        max_queries=max_queries,
-        seed=seed,
-        exclude_chunk_ids=reserved_ids,
-        synthesized_queries=synth_map or None,
-        pre_sampled_chunks=training_chunks,
-    )
+    # H-R8 (2026-04-21): resolve the effective labeled training queries.
+    # Mirrors the H-R1 policy on retrain_multi but over a single store.
+    effective_training_queries: list[dict] | None
+    if training_queries:
+        effective_training_queries = list(training_queries)
+        pair_source = "explicit"
+    elif training_pair_source in ("auto", "labeled") and eval_queries:
+        # Only USER-SUPPLIED eval_queries are eligible for auto-promotion;
+        # the split_corpus_for_eval output (used when eval_queries is
+        # None) never is, because those are chunk-prefix pseudo-queries
+        # by construction.
+        effective_training_queries = list(eval_queries)
+        pair_source = "auto-from-eval"
+        logger.warning(
+            "retrain (H-R8, shipped 2026-04-21): auto-promoted "
+            "eval_queries to training queries (%d labeled queries). "
+            "Pass training_pair_source='prefix' to keep the legacy "
+            "chunk-prefix training path.",
+            len(effective_training_queries),
+        )
+    elif training_pair_source == "labeled":
+        raise ValueError(
+            "training_pair_source='labeled' requires training_queries or "
+            "eval_queries; neither was provided."
+        )
+    else:
+        effective_training_queries = None
+        pair_source = "prefix"
+
+    if effective_training_queries is not None:
+        from .retrain_batch import generate_labeled_triples_batched
+
+        # Note: margin_min / margin_max filter args (originally part of
+        # the H-R8 spec) are not threaded yet because the supporting
+        # infrastructure was on PR #245 (H-R3) which closed without
+        # merge. When H-R3 is cherry-picked for a different use case
+        # (continual retrain, cross-encoder reranking), add them to
+        # both generate_labeled_triples_batched and this call site.
+        logger.info(
+            "retrain: labeled-query path (%s) with %d queries",
+            pair_source,
+            len(effective_training_queries),
+        )
+        pairs = generate_labeled_triples_batched(
+            store,
+            base_model,
+            labeled_queries=effective_training_queries,
+            max_queries=max_queries,
+            device=bulk_mine_device,
+        )
+        # Same downsampling convention as retrain_multi: the labeled
+        # miner can emit |gold| * |hard_neg| triples per query, which
+        # may far exceed max_queries. Keep the budget meaningful.
+        if len(pairs) > max_queries:
+            generated = len(pairs)
+            rng = random.Random(seed)
+            keep_indices = sorted(rng.sample(range(generated), max_queries))
+            pairs = [pairs[i] for i in keep_indices]
+            logger.info(
+                "labeled-query path: downsampled %d -> %d pairs to respect max_queries.",
+                generated,
+                max_queries,
+            )
+    elif bulk_mine:
+        from .retrain_batch import generate_triples_batched
+
+        logger.info("retrain: chunk-prefix path via bulk_mine (GPU matmul).")
+        pairs = generate_triples_batched(
+            store,
+            base_model,
+            max_queries=max_queries,
+            seed=seed,
+            exclude_chunk_ids=reserved_ids,
+            synthesized_queries=synth_map or None,
+            pre_sampled_chunks=training_chunks,
+            device=bulk_mine_device,
+        )
+    else:
+        pairs = generate_triples(
+            store,
+            base_model,
+            max_queries=max_queries,
+            seed=seed,
+            exclude_chunk_ids=reserved_ids,
+            synthesized_queries=synth_map or None,
+            pre_sampled_chunks=training_chunks,
+        )
     if len(pairs) < 10:
         logger.warning(
             "Only %d training pairs generated (need >= 10). Skipping training.", len(pairs)


### PR DESCRIPTION
Ports H-R1's pattern to ``retrain()`` so single-store BEIR-with-qrels
users no longer need to wrap in a dict to reach the labeled miner.

## What changed

- ``vstash.retrain.retrain()`` gains ``training_queries``,
  ``training_pair_source="auto"``, ``bulk_mine``, ``bulk_mine_device``.
  Same explicit > auto-from-eval > labeled-errors > prefix chain as
  retrain_multi.
- ``vstash retrain`` CLI gains ``--training-queries``,
  ``--training-pair-source``, ``--bulk-mine/--no-bulk-mine``,
  ``--bulk-mine-device``. JSONL loader shape-validates per line.
- 7 new tests + 1 pinned migration.

## Not included (deliberate)

``margin_min`` / ``margin_max`` (mentioned in H-R8 spec) are not
threaded because the supporting infra on PR #245 (H-R3) closed without
merge after -2.49pp ablation. Docstring comment points at the closed
branch for future cherry-pick.

## Pre-merge review

Code-reviewer subagent (per CLAUDE.md) flagged three ``worth fixing``
items, all addressed:
- **W1**: insufficient-eval fallback silently dropped labels under
  ``auto``. Fixed + regression test.
- **W2**: original labeled-error test only covered skip_eval path.
  Added normal-path variant.
- **W3**: CLI JSONL loader crashed opaquely on JSON-array-per-file.
  Fixed with shape validation + pointed error.

Full suite: 984 passed. ruff clean.

## Test plan
- [x] ``pytest tests/test_retrain.py -k H_R8`` (7 passed).
- [x] ``pytest tests/`` full suite (984 passed).
- [x] ``ruff check vstash/ tests/``.
- [ ] Smoke ``vstash retrain --training-queries beir_scifact_train.jsonl`` on a local cache before merging.