### PR TITLE
feat(cli): vstash why -- miss analysis as a first-class CLI (#157 part 1)

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -206,10 +206,28 @@ A sustained non-zero rate on this counter means the vector candidate pool is con
 # How often has this fired since process start?
 vstash stats --detailed --json | jq '.metrics.counters.adaptive_rrf_vector_empty_fallback_total'
 
-# For a specific query, run miss_analysis() from the SDK and look for
-# the "adaptive_fallback" stage in the trace — if present, the query
-# hit the fallback path.
+# For a specific query that missed an expected doc, use `vstash why`:
+vstash why "my query" --expect path/to/expected/doc.md
+
+# Prints a stage-by-stage pipeline trace (vector_search -> distance_cutoff
+# -> fts_search -> rrf_fusion -> recency_boost -> mmr_dedup -> top_k_cutoff)
+# with the stage that dropped the expected chunk highlighted, plus the
+# actual top-k for contrast and rule-based suggestions. Issue #157 /
+# 2026-04-21.
+#
+# --json emits the raw MissAnalysis for piping:
+vstash why "my query" --expect path/to/doc.md --json | jq .suggestions
+
+# The Python SDK ``VstashStore.miss_analysis()`` is still available for
+# programmatic use.
 ```
+
+**Planned follow-ups for #157** (not yet shipped):
+- Auto-log a lightweight `miss_analysis_hint` into `search_events` when
+  a search returns empty or entirely low-tier results, so `vstash why`
+  can be invoked post-hoc without the caller having re-run the query.
+- `/debug/why` JSON/HTML route on `vstash serve` for a browser-native
+  debug surface.
 
 **Prometheus alerting suggestion:**
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -119,6 +119,114 @@ class TestAskErrorPaths:
         empty_store.close()
 
 
+class TestWhyCommand:
+    """Test 'vstash why' command (issue #157 / H-WHY)."""
+
+    def _patch_embed(self, monkeypatch) -> None:
+        """Stub embed_query so tests do not download a real model."""
+        import vstash.cli as cli_mod
+
+        def _fake(query: str, model: str) -> list[float]:
+            # Match populated_store's chunk dim; use a deterministic vector
+            # close to one of the ingested chunks so the trace has content.
+            return [0.3] * 384
+
+        monkeypatch.setattr(cli_mod, "embed_query", _fake)
+
+    def test_why_requires_expect_or_expect_chunk_id(self, monkeypatch) -> None:
+        """vstash why without --expect / --expect-chunk-id errors cleanly."""
+        self._patch_embed(monkeypatch)
+        result = runner.invoke(app, ["why", "python programming"])
+        assert result.exit_code == 1
+        assert "--expect" in result.stdout
+
+    def test_why_with_existing_path_prints_trace(self, monkeypatch) -> None:
+        """vstash why <query> --expect <path> prints a pipeline trace
+        table and exits with appearance-aware code."""
+        self._patch_embed(monkeypatch)
+        result = runner.invoke(
+            app,
+            [
+                "why",
+                "python programming",
+                "--expect",
+                "/test/python_guide.md",
+                "--top-k",
+                "5",
+            ],
+        )
+        # Exit 0 if the expected doc appeared in top-k, 2 if not. Both are
+        # valid in the sense that the command ran end-to-end.
+        assert result.exit_code in (0, 2)
+        assert "Pipeline trace" in result.stdout
+        # Stage column must include at least one of the known stages.
+        assert any(
+            stage in result.stdout
+            for stage in (
+                "vector_search",
+                "distance_cutoff",
+                "fts_search",
+                "rrf_fusion",
+                "top_k_cutoff",
+            )
+        )
+
+    def test_why_with_unknown_path_errors_gracefully(self, monkeypatch) -> None:
+        """An unknown --expect path surfaces the ValueError from
+        miss_analysis as a clean CLI error (not a traceback)."""
+        self._patch_embed(monkeypatch)
+        result = runner.invoke(
+            app,
+            ["why", "python", "--expect", "/does/not/exist.md"],
+        )
+        assert result.exit_code == 1
+        # The store raises "No chunks found for path: ..."; the CLI wraps
+        # it with a red 'x' marker.
+        assert "No chunks found" in result.stdout or "not found" in result.stdout.lower()
+
+    def test_why_json_error_path_returns_json(self, monkeypatch) -> None:
+        """Code-review W1: when --json is set, error outputs must still be
+        valid JSON so piped consumers (jq / scripts) do not choke on Rich
+        markup text. Mirrors the ``vstash search --miss --json`` contract."""
+        import json as _json
+
+        self._patch_embed(monkeypatch)
+        # Trigger the "no --expect, no --expect-chunk-id" error path.
+        result = runner.invoke(app, ["why", "q", "--json"])
+        assert result.exit_code == 1
+        data = _json.loads(result.stdout)
+        assert "error" in data
+        assert "--expect" in data["error"]
+
+        # Also trigger the unknown-path error path.
+        result = runner.invoke(
+            app,
+            ["why", "q", "--expect", "/nope.md", "--json"],
+        )
+        assert result.exit_code == 1
+        data = _json.loads(result.stdout)
+        assert "error" in data
+
+    def test_why_json_output_is_parseable(self, monkeypatch) -> None:
+        """--json emits a single JSON document matching the MissAnalysis
+        schema, suitable for piping into jq or another script."""
+        import json as _json
+
+        self._patch_embed(monkeypatch)
+        result = runner.invoke(
+            app,
+            ["why", "python", "--expect", "/test/python_guide.md", "--json"],
+        )
+        assert result.exit_code in (0, 2)
+        # stdout should be parseable JSON with the MissAnalysis keys.
+        data = _json.loads(result.stdout)
+        assert data["query"] == "python"
+        assert data["expected_path"] == "/test/python_guide.md"
+        assert "stage_verdicts" in data
+        assert "actual_top_k" in data
+        assert "suggestions" in data
+
+
 class TestRelevanceTier:
     """Test the _relevance_tier helper."""
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -122,28 +122,35 @@ class TestAskErrorPaths:
 class TestWhyCommand:
     """Test 'vstash why' command (issue #157 / H-WHY)."""
 
-    def _patch_embed(self, monkeypatch) -> None:
-        """Stub embed_query so tests do not download a real model."""
+    def _patch_embed(self, monkeypatch, populated_store: VstashStore) -> None:
+        """Stub embed_query so tests do not download a real model.
+        Dim is derived from the populated_store fixture instead of
+        hardcoded, so the test remains stable if the default embedding
+        model changes dim."""
         import vstash.cli as cli_mod
 
+        dim = populated_store.embedding_dim
+
         def _fake(query: str, model: str) -> list[float]:
-            # Match populated_store's chunk dim; use a deterministic vector
-            # close to one of the ingested chunks so the trace has content.
-            return [0.3] * 384
+            return [0.3] * dim
 
         monkeypatch.setattr(cli_mod, "embed_query", _fake)
 
-    def test_why_requires_expect_or_expect_chunk_id(self, monkeypatch) -> None:
+    def test_why_requires_expect_or_expect_chunk_id(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
         """vstash why without --expect / --expect-chunk-id errors cleanly."""
-        self._patch_embed(monkeypatch)
+        self._patch_embed(monkeypatch, populated_store)
         result = runner.invoke(app, ["why", "python programming"])
         assert result.exit_code == 1
         assert "--expect" in result.stdout
 
-    def test_why_with_existing_path_prints_trace(self, monkeypatch) -> None:
+    def test_why_with_existing_path_prints_trace(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
         """vstash why <query> --expect <path> prints a pipeline trace
         table and exits with appearance-aware code."""
-        self._patch_embed(monkeypatch)
+        self._patch_embed(monkeypatch, populated_store)
         result = runner.invoke(
             app,
             [
@@ -171,10 +178,12 @@ class TestWhyCommand:
             )
         )
 
-    def test_why_with_unknown_path_errors_gracefully(self, monkeypatch) -> None:
+    def test_why_with_unknown_path_errors_gracefully(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
         """An unknown --expect path surfaces the ValueError from
         miss_analysis as a clean CLI error (not a traceback)."""
-        self._patch_embed(monkeypatch)
+        self._patch_embed(monkeypatch, populated_store)
         result = runner.invoke(
             app,
             ["why", "python", "--expect", "/does/not/exist.md"],
@@ -184,13 +193,15 @@ class TestWhyCommand:
         # it with a red 'x' marker.
         assert "No chunks found" in result.stdout or "not found" in result.stdout.lower()
 
-    def test_why_json_error_path_returns_json(self, monkeypatch) -> None:
+    def test_why_json_error_path_returns_json(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
         """Code-review W1: when --json is set, error outputs must still be
         valid JSON so piped consumers (jq / scripts) do not choke on Rich
         markup text. Mirrors the ``vstash search --miss --json`` contract."""
         import json as _json
 
-        self._patch_embed(monkeypatch)
+        self._patch_embed(monkeypatch, populated_store)
         # Trigger the "no --expect, no --expect-chunk-id" error path.
         result = runner.invoke(app, ["why", "q", "--json"])
         assert result.exit_code == 1
@@ -207,12 +218,14 @@ class TestWhyCommand:
         data = _json.loads(result.stdout)
         assert "error" in data
 
-    def test_why_json_output_is_parseable(self, monkeypatch) -> None:
+    def test_why_json_output_is_parseable(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
         """--json emits a single JSON document matching the MissAnalysis
         schema, suitable for piping into jq or another script."""
         import json as _json
 
-        self._patch_embed(monkeypatch)
+        self._patch_embed(monkeypatch, populated_store)
         result = runner.invoke(
             app,
             ["why", "python", "--expect", "/test/python_guide.md", "--json"],

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1366,6 +1366,185 @@ def serve(
 
 
 @app.command()
+def why(
+    ctx: typer.Context,
+    query: str = typer.Argument(..., help="The search query that missed."),
+    expect: str | None = typer.Option(
+        None,
+        "--expect",
+        "-e",
+        help="Path of the document you expected to see. Either this or "
+        "--expect-chunk-id must be given.",
+    ),
+    expect_chunk_id: int | None = typer.Option(
+        None,
+        "--expect-chunk-id",
+        help="Specific chunk id to track instead of resolving from a path. "
+        "Useful when you already have a chunk id from an earlier search.",
+    ),
+    top_k: int = typer.Option(5, "--top-k", "-k", help="Top-k window to check against"),
+    collection: str | None = typer.Option(
+        None, "--collection", "-c", help="Restrict to collection"
+    ),
+    project: str | None = typer.Option(None, "--project", "-p", help="Restrict to project"),
+    layer: str | None = typer.Option(None, "--layer", "-l", help="Restrict to layer"),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the raw MissAnalysis as JSON (for scripting / piping). "
+        "Default output is a rich table plus a suggestions panel.",
+    ),
+) -> None:
+    """Diagnose why an expected document did not appear in search results.
+
+    Runs ``VstashStore.miss_analysis()`` and prints a stage-by-stage trace
+    showing where the expected chunk was eliminated from the ranking, plus
+    rule-based suggestions for fixing the query.
+
+    Examples:
+
+        vstash why "rate limits" --expect notes/api-design.md
+
+        vstash why "renewable energy" --expect papers/2024/clean.pdf --top-k 10
+
+        vstash why "quota" --expect-chunk-id 4213 --json | jq .suggestions
+    """
+    import json as _json
+    import sqlite3 as _sqlite3
+
+    def _why_error(msg: str, exit_code: int = 1) -> typer.Exit:
+        """Emit an error consistently for both --json and pretty modes.
+        Mirrors the pattern in ``vstash search --miss`` so script
+        consumers piping ``vstash why --json`` always see JSON, even on
+        the error path."""
+        if json_out:
+            print(_json.dumps({"error": msg}))
+        else:
+            console.print(f"[red]x[/red] {msg}")
+        return typer.Exit(exit_code)
+
+    if expect is None and expect_chunk_id is None:
+        raise _why_error("Provide either --expect <path> or --expect-chunk-id <id>.")
+
+    # ``why`` is a diagnostic tool; don't eagerly warm the embedder.
+    # ``embed_query`` will load on demand if needed. Users running
+    # ``vstash why`` against a misconfigured model get the actual error
+    # instead of a cold-start failure that masks the diagnostic.
+    cfg, store = _get_store(warm=False, profile=_profile_from_ctx(ctx))
+
+    with store:
+        try:
+            q_embedding = embed_query(query, cfg.embeddings.model)
+            analysis = store.miss_analysis(
+                query_embedding=q_embedding,
+                query_text=query,
+                expected_path=expect,
+                expected_chunk_id=expect_chunk_id,
+                top_k=top_k,
+                collection=collection,
+                project=project,
+                layer=layer,
+            )
+        except ValueError as exc:
+            # ValueError covers the documented miss_analysis failures
+            # (unknown path / chunk id, no expected provided) plus
+            # LimitError which subclasses ValueError.
+            raise _why_error(str(exc)) from exc
+        except _sqlite3.Error as exc:
+            # Corrupt / locked DB surfaces here from the search() step
+            # inside miss_analysis. Keep the user on the --json contract.
+            raise _why_error(f"database error: {exc}") from exc
+        except (RuntimeError, OSError) as exc:
+            # embed_query failure modes: ONNX load failure, daemon
+            # socket error, model download failure, etc.
+            raise _why_error(f"embedder error: {exc}") from exc
+
+    if json_out:
+        print(_json.dumps(analysis.model_dump(), indent=2, default=str))
+        return
+
+    # Header.
+    if analysis.appeared_in_results:
+        console.print(
+            f"[green]✓[/green] [bold]Expected doc IS in the top-{analysis.top_k_requested}[/bold] "
+            f"(rank {analysis.final_rank})."
+        )
+    else:
+        console.print(
+            f"[red]✗[/red] [bold]Expected doc NOT in top-{analysis.top_k_requested}.[/bold]"
+        )
+        if analysis.dropped_at:
+            console.print(
+                f"  Dropped at stage: [yellow bold]{analysis.dropped_at}[/yellow bold]"
+            )
+
+    console.print()
+    console.print(f"  [dim]Query:[/dim]          {analysis.query!r}")
+    if analysis.expected_path:
+        console.print(f"  [dim]Expected path:[/dim]  {analysis.expected_path}")
+    if analysis.expected_chunk_id is not None:
+        console.print(
+            f"  [dim]Chunk id:[/dim]       {analysis.expected_chunk_id} "
+            f"([dim]{analysis.target_resolution}[/dim])"
+        )
+    if analysis.total_chunks_in_doc > 1:
+        console.print(
+            f"  [dim]Doc has[/dim]         {analysis.total_chunks_in_doc} chunks"
+        )
+
+    # Per-stage trace.
+    console.print()
+    console.print("[bold]Pipeline trace[/bold]")
+    trace_table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+    trace_table.add_column("Stage", style="cyan")
+    trace_table.add_column("Passed")
+    trace_table.add_column("Rank", justify="right")
+    trace_table.add_column("Score", justify="right")
+    trace_table.add_column("Detail", overflow="fold")
+    for v in analysis.stage_verdicts:
+        passed_cell = "[green]yes[/green]" if v.passed else "[red]no[/red]"
+        drop_style = "red bold" if v.stage == analysis.dropped_at else ""
+        stage_cell = f"[{drop_style}]{v.stage}[/{drop_style}]" if drop_style else v.stage
+        trace_table.add_row(
+            stage_cell,
+            passed_cell,
+            "-" if v.rank is None else str(v.rank),
+            "-" if v.score is None else f"{v.score:.4f}",
+            v.detail,
+        )
+    console.print(trace_table)
+
+    # Actual top-k for contrast.
+    if analysis.actual_top_k:
+        console.print()
+        console.print("[bold]Actual top-k[/bold]")
+        top_table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+        top_table.add_column("Rank", justify="right")
+        top_table.add_column("Path", overflow="fold")
+        top_table.add_column("Title", overflow="fold")
+        top_table.add_column("Score", justify="right")
+        for r in analysis.actual_top_k:
+            top_table.add_row(
+                str(r.rank), r.path, r.title or "-", f"{r.score:.4f}"
+            )
+        console.print(top_table)
+
+    # Suggestions panel last so it lands near the user's prompt.
+    if analysis.suggestions:
+        console.print()
+        console.print(
+            Panel.fit(
+                "\n".join(f"- {s}" for s in analysis.suggestions),
+                title="[bold]Suggestions[/bold]",
+                border_style="yellow",
+            )
+        )
+
+    if not analysis.appeared_in_results:
+        raise typer.Exit(code=2)
+
+
+@app.command()
 def remember(
     ctx: typer.Context,
     text: str | None = typer.Argument(None, help="Text to ingest (or pipe via stdin)"),

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1382,7 +1382,9 @@ def why(
         help="Specific chunk id to track instead of resolving from a path. "
         "Useful when you already have a chunk id from an earlier search.",
     ),
-    top_k: int = typer.Option(5, "--top-k", "-k", help="Top-k window to check against"),
+    top_k: int = typer.Option(
+        0, "--top-k", "-k", help="Top-k window to check against (0 = from config)"
+    ),
     collection: str | None = typer.Option(
         None, "--collection", "-c", help="Restrict to collection"
     ),
@@ -1416,11 +1418,12 @@ def why(
         """Emit an error consistently for both --json and pretty modes.
         Mirrors the pattern in ``vstash search --miss`` so script
         consumers piping ``vstash why --json`` always see JSON, even on
-        the error path."""
+        the error path. ``_safe_exc`` strips Rich markup so paths like
+        ``foo[bar].md`` do not get mangled by the markup parser."""
         if json_out:
             print(_json.dumps({"error": msg}))
         else:
-            console.print(f"[red]x[/red] {msg}")
+            console.print(f"[red]x[/red] {_safe_exc(msg)}")
         return typer.Exit(exit_code)
 
     if expect is None and expect_chunk_id is None:
@@ -1432,15 +1435,30 @@ def why(
     # instead of a cold-start failure that masks the diagnostic.
     cfg, store = _get_store(warm=False, profile=_profile_from_ctx(ctx))
 
+    # Normalize --expect the same way ``vstash search --miss`` and
+    # ``Memory.miss_analysis`` do: http(s)/text URIs pass through,
+    # everything else resolves to an absolute path. Without this,
+    # ``vstash why "q" --expect notes/doc.md`` would lookup the
+    # literal relative string against a DB that stores absolute paths
+    # and always report "No chunks found".
+    expected_path_arg: str | None = None
+    if expect is not None:
+        if expect.startswith(("http://", "https://", "text://")):
+            expected_path_arg = expect
+        else:
+            expected_path_arg = str(Path(expect).resolve(strict=False))
+
+    effective_top_k = top_k or cfg.chunking.top_k
+
     with store:
         try:
             q_embedding = embed_query(query, cfg.embeddings.model)
             analysis = store.miss_analysis(
                 query_embedding=q_embedding,
                 query_text=query,
-                expected_path=expect,
+                expected_path=expected_path_arg,
                 expected_chunk_id=expect_chunk_id,
-                top_k=top_k,
+                top_k=effective_top_k,
                 collection=collection,
                 project=project,
                 layer=layer,
@@ -1460,14 +1478,19 @@ def why(
             raise _why_error(f"embedder error: {exc}") from exc
 
     if json_out:
-        print(_json.dumps(analysis.model_dump(), indent=2, default=str))
-        return
+        # exclude_none strips empty-but-optional fields; indent=2 matches
+        # the search --miss JSON contract. Exit code mirrors pretty-mode
+        # (2 when dropped) so script consumers get reliable CI checks.
+        print(_json.dumps(analysis.model_dump(exclude_none=True), indent=2, default=str))
+        raise typer.Exit(0 if analysis.appeared_in_results else 2)
 
     # Header.
+    # Ranks are 0-indexed internally; display 1-indexed to match ``vstash search``.
     if analysis.appeared_in_results:
+        assert analysis.final_rank is not None
         console.print(
             f"[green]✓[/green] [bold]Expected doc IS in the top-{analysis.top_k_requested}[/bold] "
-            f"(rank {analysis.final_rank})."
+            f"(rank {analysis.final_rank + 1})."
         )
     else:
         console.print(
@@ -1508,7 +1531,7 @@ def why(
         trace_table.add_row(
             stage_cell,
             passed_cell,
-            "-" if v.rank is None else str(v.rank),
+            "-" if v.rank is None else str(v.rank + 1),
             "-" if v.score is None else f"{v.score:.4f}",
             v.detail,
         )
@@ -1525,7 +1548,7 @@ def why(
         top_table.add_column("Score", justify="right")
         for r in analysis.actual_top_k:
             top_table.add_row(
-                str(r.rank), r.path, r.title or "-", f"{r.score:.4f}"
+                str(r.rank + 1), r.path, r.title or "-", f"{r.score:.4f}"
             )
         console.print(top_table)
 


### PR DESCRIPTION
Ships part 1 of issue #157: elevate ``VstashStore.miss_analysis`` from a
Python-SDK-only API to a CLI command so users don't need to drop into
a REPL to diagnose "my doc is in the DB but not surfacing".

## Usage

    vstash why "rate limits" --expect notes/api-design.md
    vstash why "renewable energy" --expect papers/2024/clean.pdf --top-k 10
    vstash why "quota" --expect-chunk-id 4213 --json | jq .suggestions

Output: header (appeared vs dropped-at), pipeline trace with drop
stage highlighted, actual top-k for contrast, suggestions panel.
``--json`` emits the raw MissAnalysis for scripting.

Exit codes: 0 = appeared, 2 = dropped, 1 = caller error. Matches the
existing ``vstash search --miss`` + ``vstash retrain`` conventions.

## Tests

5 new tests in ``TestWhyCommand`` (``tests/test_cli_commands.py``):
- Missing --expect / --expect-chunk-id -> clean error + exit 1.
- Existing path -> pipeline trace rendered; exit 0 or 2 depending on appearance.
- Unknown path -> wrapped ValueError -> clean error, no traceback.
- ``--json`` error path -> valid JSON object with ``error`` key.
- ``--json`` success path -> parseable JSON matching the MissAnalysis schema.

All 15 CLI command tests pass. Full suite green + ruff clean.

## What's NOT in this PR (deferred follow-ups on #157)

- **Part 2: ``/debug/why`` web route** on ``vstash serve``. Requires Starlette route + HTML template work; scope keeps it out of this PR.
- **Part 3: Auto-log on empty / all-low results**. Requires schema migration on ``search_events`` + pipeline hook + config flag + recovery tooling. Non-trivial enough to warrant its own PR.

Both are documented in ``docs/observability.md`` as parked follow-ups.

## Pre-merge review

Code-reviewer subagent (per CLAUDE.md) flagged 3 ``worth fixing``:
- ``--json`` error path emitted Rich-styled text, breaking the pipe contract. Fixed by mirroring ``_miss_error`` pattern from ``vstash search --miss``.
- Exception surface was too narrow (only ``ValueError``). Widened to include ``sqlite3.Error`` + ``RuntimeError`` + ``OSError`` for embedder/DB failures.
- ``warm=True`` on a diagnostic command masked misconfig errors under cold-start noise. Changed to ``warm=False``.

Full summary in the commit message. All three applied in the same commit.

## Test plan

- [x] ``pytest tests/test_cli_commands.py -k Why`` (5 passed).
- [x] ``pytest tests/test_cli_commands.py`` (15 passed).
- [x] ``ruff check vstash/ tests/``.
- [ ] Smoke ``vstash why`` against a local corpus before merging.