### PR TITLE
feat: #157 part 3 -- auto-log miss_hint on empty/low search

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,15 @@ mem.search("meeting notes", added_after="2024-06-01", added_before="2024-12-31")
 
 ---
 
+## `[observability]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `slow_query_ms` | float | `100.0` | Search queries slower than this threshold log to stderr with their query, latency, and result count. Set to 0 to log every query (debug). |
+| `auto_miss_hint` | bool | `true` | When a search returns empty or an all-low-tier result set, persist a lightweight `miss_hint` JSON on the `search_events` row. Consumed by `vstash why --recent` for post-hoc diagnosis. Issue #157 part 3 (2026-04-21). |
+
+---
+
 ## `[scoring]` (deprecated)
 
 The `[scoring]` section from v0.5–v0.17 is still parsed for backward compatibility — existing `vstash.toml` files won't error. However, all scoring parameters are ignored. The frequency+decay scoring pipeline was removed in v0.18.0 and replaced by the simpler `[recency]` boost in v0.19.0.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ mem.search("meeting notes", added_after="2024-06-01", added_before="2024-12-31")
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `slow_query_ms` | float | `100.0` | Search queries slower than this threshold log to stderr with their query, latency, and result count. Set to 0 to log every query (debug). |
-| `auto_miss_hint` | bool | `true` | When a search returns empty or an all-low-tier result set, persist a lightweight `miss_hint` JSON on the `search_events` row. Consumed by `vstash why --recent` for post-hoc diagnosis. Issue #157 part 3 (2026-04-21). |
+| `auto_miss_hint` | bool | `true` | When a search returns empty or an all-low-tier result set, persist a lightweight `miss_hint` JSON on the `search_events` row. Consumed by `vstash why --recent` for post-hoc diagnosis. Added in issue #157 part 3. |
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -222,13 +222,14 @@ vstash why "my query" --expect path/to/doc.md --json | jq .suggestions
 # programmatic use.
 ```
 
-**Auto-logged miss hints** (#157 part 3, 2026-04-21):
+**Auto-logged miss hints** (#157 part 3):
 
 ```bash
 # List the most recent auto-logged miss hints (empty / all-low search
-# results) captured since the store was opened. Each row is a query
-# that returned nothing or only low-relevance chunks; drill into any
-# of them with `vstash why "<query>" --expect <path>` for full trace.
+# results) persisted in the DB. ``search_events`` keeps the last 1000
+# rows across runs. Each row is a query that returned nothing or only
+# low-relevance chunks; drill into any of them with
+# `vstash why "<query>" --expect <path>` for the full trace.
 vstash why --recent 10
 
 # JSON for scripting / dashboards:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -222,11 +222,28 @@ vstash why "my query" --expect path/to/doc.md --json | jq .suggestions
 # programmatic use.
 ```
 
-**Planned follow-ups for #157** (not yet shipped):
-- Auto-log a lightweight `miss_analysis_hint` into `search_events` when
-  a search returns empty or entirely low-tier results, so `vstash why`
-  can be invoked post-hoc without the caller having re-run the query.
-- `/debug/why` JSON/HTML route on `vstash serve` for a browser-native
+**Auto-logged miss hints** (#157 part 3, 2026-04-21):
+
+```bash
+# List the most recent auto-logged miss hints (empty / all-low search
+# results) captured since the store was opened. Each row is a query
+# that returned nothing or only low-relevance chunks; drill into any
+# of them with `vstash why "<query>" --expect <path>` for full trace.
+vstash why --recent 10
+
+# JSON for scripting / dashboards:
+vstash why --recent 10 --json | jq '.recent_miss_hints[] | .query'
+```
+
+The hook is on by default. Disable via ``vstash.toml``:
+
+```toml
+[observability]
+auto_miss_hint = false
+```
+
+**Planned follow-up for #157** (not yet shipped):
+- ``/debug/why`` JSON/HTML route on ``vstash serve`` for a browser-native
   debug surface.
 
 **Prometheus alerting suggestion:**

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -321,6 +321,26 @@ class TestWhyCommand:
         data = _json.loads(result.stdout)
         assert "error" in data
 
+    def test_why_recent_rejects_negative(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
+        """Code-review: ``--recent`` must validate the int. Negative
+        values previously would slip through (and SQLite's ``LIMIT -1``
+        would silently return all rows). Now raises a clean error."""
+        self._patch_embed(monkeypatch, populated_store)
+        result = runner.invoke(app, ["why", "--recent", "-3"])
+        assert result.exit_code == 1
+        assert "--recent" in result.stdout
+
+    def test_recent_miss_hints_rejects_negative_limit(
+        self, populated_store: VstashStore
+    ) -> None:
+        """``VstashStore.recent_miss_hints`` clamps against ``LIMIT -1``."""
+        with pytest.raises(ValueError, match="limit must be"):
+            populated_store.recent_miss_hints(limit=-1)
+        with pytest.raises(ValueError, match="limit must be"):
+            populated_store.recent_miss_hints(limit=0)
+
     def test_why_recent_lists_logged_hints(
         self, monkeypatch, populated_store: VstashStore
     ) -> None:
@@ -380,28 +400,23 @@ class TestWhyCommand:
         self, monkeypatch, tmp_path, sample_config
     ) -> None:
         """With no hints recorded, --recent prints a friendly message,
-        not an error."""
-        # Use a fresh store so the prior tests' seeded rows don't leak.
+        not an error. Uses the pytest ``monkeypatch`` fixture directly
+        so the teardown runs automatically."""
+        from vstash.config import load_config as _lc
         from vstash.embed import get_embedding_dim as _gdim
+        import vstash.cli as cli_mod
 
         dim = _gdim(sample_config.embeddings.model)
         fresh = VstashStore(str(tmp_path / "fresh.db"), embedding_dim=dim)
         try:
-            import vstash.cli as cli_mod
-            from vstash.config import load_config as _lc
-
-            monkeypatch = pytest.MonkeyPatch()
             monkeypatch.setattr(
                 cli_mod,
                 "_get_store",
                 lambda cfg=None, warm=False, profile=None: (_lc(), fresh),
             )
-            try:
-                result = runner.invoke(app, ["why", "--recent", "5"])
-                assert result.exit_code == 0
-                assert "No recent miss_hints" in result.stdout
-            finally:
-                monkeypatch.undo()
+            result = runner.invoke(app, ["why", "--recent", "5"])
+            assert result.exit_code == 0
+            assert "No recent miss_hints" in result.stdout
         finally:
             fresh.close()
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -119,6 +119,109 @@ class TestAskErrorPaths:
         empty_store.close()
 
 
+class TestAutoMissHintHook:
+    """#157 part 3 (2026-04-21): ``vstash ask`` and ``vstash search``
+    auto-log a miss_hint to search_events when result_count=0 or tier=low
+    and ``[observability] auto_miss_hint`` is enabled (default)."""
+
+    def _patch_embed(self, monkeypatch, dim: int) -> None:
+        import vstash.cli as cli_mod
+
+        def _fake(query: str, model: str) -> list[float]:
+            # A vector that does NOT match any populated_store chunk so
+            # the search returns empty / low-tier.
+            return [0.99] * dim
+
+        monkeypatch.setattr(cli_mod, "embed_query", _fake)
+
+    def test_record_search_event_persists_hint(
+        self, populated_store: VstashStore
+    ) -> None:
+        """Unit-level check: record_search_event + recent_miss_hints
+        roundtrip a dict through the miss_hint column without data loss."""
+        populated_store.record_search_event(
+            query="unmatchable_xyz",
+            best_distance=1.0,
+            relevance_tier="low",
+            result_count=0,
+            miss_hint={"reason": "empty", "tier": "low",
+                       "best_distance": 1.0, "result_count": 0,
+                       "top_k_requested": 5},
+        )
+        hints = populated_store.recent_miss_hints(limit=5)
+        assert any(h["query"] == "unmatchable_xyz" for h in hints)
+        match = next(h for h in hints if h["query"] == "unmatchable_xyz")
+        assert match["miss_hint"]["reason"] == "empty"
+        assert match["miss_hint"]["tier"] == "low"
+
+    def test_record_search_event_none_hint_stays_null(
+        self, populated_store: VstashStore
+    ) -> None:
+        """When the caller passes miss_hint=None (e.g., auto_miss_hint
+        is disabled) the row is written but recent_miss_hints skips it."""
+        start_ids = {h["id"] for h in populated_store.recent_miss_hints(limit=50)}
+        populated_store.record_search_event(
+            query="no_hint_query",
+            best_distance=0.5,
+            relevance_tier="high",
+            result_count=3,
+            miss_hint=None,
+        )
+        end_hints = populated_store.recent_miss_hints(limit=50)
+        new = [h for h in end_hints if h["id"] not in start_ids]
+        assert new == [], "recent_miss_hints should skip rows with NULL miss_hint"
+
+    def test_build_miss_hint_helper(self) -> None:
+        """``_build_miss_hint`` returns None when auto_hint is off OR
+        when tier is high with results; returns a structured dict for
+        empty / all-low cases."""
+        from vstash.cli import _build_miss_hint
+
+        # Disabled -> None
+        assert (
+            _build_miss_hint(
+                cfg_auto_hint=False,
+                result_count=0,
+                tier="low",
+                best_distance=1.0,
+                top_k_requested=5,
+            )
+            is None
+        )
+        # High tier with results -> None
+        assert (
+            _build_miss_hint(
+                cfg_auto_hint=True,
+                result_count=3,
+                tier="high",
+                best_distance=0.2,
+                top_k_requested=5,
+            )
+            is None
+        )
+        # Empty -> populated
+        hint = _build_miss_hint(
+            cfg_auto_hint=True,
+            result_count=0,
+            tier="low",
+            best_distance=1.0,
+            top_k_requested=5,
+        )
+        assert hint is not None
+        assert hint["reason"] == "empty"
+        assert hint["top_k_requested"] == 5
+        # All-low -> populated
+        hint2 = _build_miss_hint(
+            cfg_auto_hint=True,
+            result_count=3,
+            tier="low",
+            best_distance=0.99,
+            top_k_requested=5,
+        )
+        assert hint2 is not None
+        assert hint2["reason"] == "all_low"
+
+
 class TestWhyCommand:
     """Test 'vstash why' command (issue #157 / H-WHY)."""
 
@@ -217,6 +320,90 @@ class TestWhyCommand:
         assert result.exit_code == 1
         data = _json.loads(result.stdout)
         assert "error" in data
+
+    def test_why_recent_lists_logged_hints(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
+        """#157 part 3 (2026-04-21): ``vstash why --recent N`` lists
+        the N most recent search_events whose auto-logged miss_hint is
+        populated. Seed one synthetic event and assert it surfaces."""
+        # Seed a miss_hint row directly via the store API so the test
+        # does not depend on the search pipeline firing auto-log.
+        populated_store.record_search_event(
+            query="unicorn discovery",
+            best_distance=0.99,
+            relevance_tier="low",
+            result_count=0,
+            miss_hint={
+                "reason": "empty",
+                "tier": "low",
+                "best_distance": 0.99,
+                "result_count": 0,
+                "top_k_requested": 5,
+            },
+        )
+
+        result = runner.invoke(app, ["why", "--recent", "5"])
+        assert result.exit_code == 0
+        assert "unicorn discovery" in result.stdout
+        # Should surface the reason and tier.
+        assert "empty" in result.stdout
+        assert "low" in result.stdout
+
+    def test_why_recent_json_output(
+        self, monkeypatch, populated_store: VstashStore
+    ) -> None:
+        """``vstash why --recent N --json`` emits a parseable JSON object."""
+        import json as _json
+
+        populated_store.record_search_event(
+            query="another miss",
+            best_distance=0.995,
+            relevance_tier="low",
+            result_count=0,
+            miss_hint={"reason": "empty", "tier": "low", "best_distance": 0.995,
+                       "result_count": 0, "top_k_requested": 5},
+        )
+
+        result = runner.invoke(app, ["why", "--recent", "3", "--json"])
+        assert result.exit_code == 0
+        data = _json.loads(result.stdout)
+        assert "recent_miss_hints" in data
+        hints = data["recent_miss_hints"]
+        assert any(h["query"] == "another miss" for h in hints)
+        # Each hint row has the structured blob we expect.
+        for h in hints:
+            assert "miss_hint" in h
+            assert "reason" in h["miss_hint"]
+
+    def test_why_recent_empty_is_friendly(
+        self, monkeypatch, tmp_path, sample_config
+    ) -> None:
+        """With no hints recorded, --recent prints a friendly message,
+        not an error."""
+        # Use a fresh store so the prior tests' seeded rows don't leak.
+        from vstash.embed import get_embedding_dim as _gdim
+
+        dim = _gdim(sample_config.embeddings.model)
+        fresh = VstashStore(str(tmp_path / "fresh.db"), embedding_dim=dim)
+        try:
+            import vstash.cli as cli_mod
+            from vstash.config import load_config as _lc
+
+            monkeypatch = pytest.MonkeyPatch()
+            monkeypatch.setattr(
+                cli_mod,
+                "_get_store",
+                lambda cfg=None, warm=False, profile=None: (_lc(), fresh),
+            )
+            try:
+                result = runner.invoke(app, ["why", "--recent", "5"])
+                assert result.exit_code == 0
+                assert "No recent miss_hints" in result.stdout
+            finally:
+                monkeypatch.undo()
+        finally:
+            fresh.close()
 
     def test_why_json_output_is_parseable(
         self, monkeypatch, populated_store: VstashStore

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -83,6 +83,43 @@ def _safe_exc(exc: object) -> str:
     return _escape(str(exc))
 
 
+def _build_miss_hint(
+    *,
+    cfg_auto_hint: bool,
+    result_count: int,
+    tier: str,
+    best_distance: float,
+    top_k_requested: int,
+) -> dict | None:
+    """Return a lightweight miss_hint dict when a search returns empty
+    results or an all-low relevance tier, or ``None`` otherwise.
+
+    Issue #157 part 3 (2026-04-21): the hint is persisted on the
+    search_events row by ``record_search_event`` and consumed by
+    ``vstash why --recent`` so a user can drill into recent misses
+    post-hoc without re-running the query from memory.
+
+    The hint is intentionally cheap to compute (no extra SQL, no
+    re-embedding) -- full ``miss_analysis`` is deferred to the explicit
+    ``vstash why <query> --expect <path>`` call.
+    """
+    if not cfg_auto_hint:
+        return None
+    if result_count == 0:
+        reason = "empty"
+    elif tier == "low":
+        reason = "all_low"
+    else:
+        return None
+    return {
+        "reason": reason,
+        "tier": tier,
+        "best_distance": round(float(best_distance), 4),
+        "result_count": int(result_count),
+        "top_k_requested": int(top_k_requested),
+    }
+
+
 @app.callback()
 def _app_callback(
     ctx: typer.Context,
@@ -318,6 +355,26 @@ def ask(
                 )
 
         if not chunks:
+            if not all_profiles:
+                # Log the empty-result event with a miss_hint so
+                # ``vstash why --recent`` can surface it later. Use
+                # best_distance=1.0 (max) as the sentinel for "no
+                # vector ever matched" -- federated mode has no single
+                # best_distance and is skipped.
+                hint = _build_miss_hint(
+                    cfg_auto_hint=cfg.observability.auto_miss_hint,
+                    result_count=0,
+                    tier="low",
+                    best_distance=1.0,
+                    top_k_requested=k,
+                )
+                store.record_search_event(
+                    query=query,
+                    best_distance=1.0,
+                    relevance_tier="low",
+                    result_count=0,
+                    miss_hint=hint,
+                )
             console.print(
                 "[yellow]No relevant documents found. "
                 "Try adding some with [bold]vstash add[/bold].[/yellow]"
@@ -327,11 +384,19 @@ def ask(
         # Tiered relevance signal (skip for federated — no single best_distance)
         if not all_profiles:
             tier = relevance_tier(store.last_best_distance)
+            hint = _build_miss_hint(
+                cfg_auto_hint=cfg.observability.auto_miss_hint,
+                result_count=len(chunks),
+                tier=tier,
+                best_distance=store.last_best_distance,
+                top_k_requested=k,
+            )
             store.record_search_event(
                 query=query,
                 best_distance=store.last_best_distance,
                 relevance_tier=tier,
                 result_count=len(chunks),
+                miss_hint=hint,
             )
             if tier == "low":
                 console.print(
@@ -550,6 +615,21 @@ def search(
                 )
 
         if not chunks:
+            if not all_profiles:
+                hint = _build_miss_hint(
+                    cfg_auto_hint=cfg.observability.auto_miss_hint,
+                    result_count=0,
+                    tier="low",
+                    best_distance=1.0,
+                    top_k_requested=k,
+                )
+                store.record_search_event(
+                    query=query,
+                    best_distance=1.0,
+                    relevance_tier="low",
+                    result_count=0,
+                    miss_hint=hint,
+                )
             if json_output:
                 print("[]")
                 raise typer.Exit()
@@ -565,12 +645,21 @@ def search(
             best_distance = store.last_best_distance
             tier = relevance_tier(best_distance)
 
-            # Telemetry: record search event for discard rate analysis
+            # Telemetry: record search event for discard rate analysis,
+            # attaching a miss_hint when the tier is "low" (issue #157 part 3).
+            hint = _build_miss_hint(
+                cfg_auto_hint=cfg.observability.auto_miss_hint,
+                result_count=len(chunks),
+                tier=tier,
+                best_distance=best_distance,
+                top_k_requested=k,
+            )
             _event_id = store.record_search_event(
                 query=query,
                 best_distance=best_distance,
                 relevance_tier=tier,
                 result_count=len(chunks),
+                miss_hint=hint,
             )
 
         if json_output:
@@ -1368,7 +1457,18 @@ def serve(
 @app.command()
 def why(
     ctx: typer.Context,
-    query: str = typer.Argument(..., help="The search query that missed."),
+    query: str | None = typer.Argument(
+        None,
+        help="The search query that missed. Omit when using --recent.",
+    ),
+    recent: int = typer.Option(
+        0,
+        "--recent",
+        "-r",
+        help="Instead of running a new miss analysis, list the N most "
+        "recent search events that carry an auto-logged miss_hint "
+        "(empty / all-low results). 0 = disabled. Issue #157 part 3.",
+    ),
     expect: str | None = typer.Option(
         None,
         "--expect",
@@ -1425,6 +1525,55 @@ def why(
         else:
             console.print(f"[red]x[/red] {_safe_exc(msg)}")
         return typer.Exit(exit_code)
+
+    # --recent mode: dump the N most recent miss_hint rows and exit.
+    # Issue #157 part 3 (2026-04-21): surfaces what the auto-log hook
+    # has captured since the store was opened, so users can see which
+    # queries recently missed without having to remember them.
+    if recent > 0:
+        _, store = _get_store(warm=False, profile=_profile_from_ctx(ctx))
+        with store:
+            hints = store.recent_miss_hints(limit=recent)
+        if json_out:
+            print(_json.dumps({"recent_miss_hints": hints}, indent=2, default=str))
+            raise typer.Exit(0)
+        if not hints:
+            console.print(
+                "[dim]No recent miss_hints recorded. "
+                "Run a search that returns empty / all-low results, "
+                "or verify [observability] auto_miss_hint is enabled.[/dim]"
+            )
+            raise typer.Exit(0)
+        console.print(f"[bold]{len(hints)} recent miss hint(s)[/bold]")
+        table = Table(show_header=True, header_style="bold", box=None, pad_edge=False)
+        table.add_column("When", style="dim")
+        table.add_column("Query", overflow="fold")
+        table.add_column("Reason")
+        table.add_column("Tier")
+        table.add_column("Best dist", justify="right")
+        table.add_column("Results", justify="right")
+        for h in hints:
+            reason = h["miss_hint"].get("reason", "-")
+            table.add_row(
+                h["created_at"][:19],  # truncate to seconds
+                h["query"][:80],
+                reason,
+                h["relevance_tier"],
+                f"{h['best_distance']:.4f}",
+                str(h["result_count"]),
+            )
+        console.print(table)
+        console.print()
+        console.print(
+            "[dim]Drill into any of these with:[/dim] "
+            "[bold]vstash why \"<query>\" --expect <path>[/bold]"
+        )
+        raise typer.Exit(0)
+
+    if query is None:
+        raise _why_error(
+            "Missing argument QUERY. Pass a query or use --recent N."
+        )
 
     if expect is None and expect_chunk_id is None:
         raise _why_error("Provide either --expect <path> or --expect-chunk-id <id>.")

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -94,10 +94,16 @@ def _build_miss_hint(
     """Return a lightweight miss_hint dict when a search returns empty
     results or an all-low relevance tier, or ``None`` otherwise.
 
-    Issue #157 part 3 (2026-04-21): the hint is persisted on the
-    search_events row by ``record_search_event`` and consumed by
-    ``vstash why --recent`` so a user can drill into recent misses
-    post-hoc without re-running the query from memory.
+    Issue #157 part 3: the hint is persisted on the search_events row
+    by ``record_search_event`` and consumed by ``vstash why --recent``
+    so a user can drill into recent misses post-hoc without re-running
+    the query from memory.
+
+    The hint carries ONLY information that is not already a column on
+    ``search_events`` (``tier``, ``best_distance``, ``result_count``
+    are all stored separately). Keeping the hint dict minimal keeps
+    the JSON blob small and avoids two-sources-of-truth drift when
+    the columns evolve.
 
     The hint is intentionally cheap to compute (no extra SQL, no
     re-embedding) -- full ``miss_analysis`` is deferred to the explicit
@@ -113,11 +119,37 @@ def _build_miss_hint(
         return None
     return {
         "reason": reason,
-        "tier": tier,
-        "best_distance": round(float(best_distance), 4),
-        "result_count": int(result_count),
         "top_k_requested": int(top_k_requested),
     }
+
+
+def _record_miss_event(
+    *,
+    store,
+    cfg,
+    query: str,
+    best_distance: float,
+    tier: str,
+    result_count: int,
+    top_k_requested: int,
+) -> None:
+    """Build + persist a miss_hint search event in one place. Shared
+    between ``vstash ask`` and ``vstash search`` to kill the
+    copy-paste this PR introduced."""
+    hint = _build_miss_hint(
+        cfg_auto_hint=cfg.observability.auto_miss_hint,
+        result_count=result_count,
+        tier=tier,
+        best_distance=best_distance,
+        top_k_requested=top_k_requested,
+    )
+    store.record_search_event(
+        query=query,
+        best_distance=best_distance,
+        relevance_tier=tier,
+        result_count=result_count,
+        miss_hint=hint,
+    )
 
 
 @app.callback()
@@ -361,19 +393,14 @@ def ask(
                 # best_distance=1.0 (max) as the sentinel for "no
                 # vector ever matched" -- federated mode has no single
                 # best_distance and is skipped.
-                hint = _build_miss_hint(
-                    cfg_auto_hint=cfg.observability.auto_miss_hint,
-                    result_count=0,
-                    tier="low",
-                    best_distance=1.0,
-                    top_k_requested=k,
-                )
-                store.record_search_event(
+                _record_miss_event(
+                    store=store,
+                    cfg=cfg,
                     query=query,
                     best_distance=1.0,
-                    relevance_tier="low",
+                    tier="low",
                     result_count=0,
-                    miss_hint=hint,
+                    top_k_requested=k,
                 )
             console.print(
                 "[yellow]No relevant documents found. "
@@ -384,19 +411,14 @@ def ask(
         # Tiered relevance signal (skip for federated — no single best_distance)
         if not all_profiles:
             tier = relevance_tier(store.last_best_distance)
-            hint = _build_miss_hint(
-                cfg_auto_hint=cfg.observability.auto_miss_hint,
-                result_count=len(chunks),
-                tier=tier,
-                best_distance=store.last_best_distance,
-                top_k_requested=k,
-            )
-            store.record_search_event(
+            _record_miss_event(
+                store=store,
+                cfg=cfg,
                 query=query,
                 best_distance=store.last_best_distance,
-                relevance_tier=tier,
+                tier=tier,
                 result_count=len(chunks),
-                miss_hint=hint,
+                top_k_requested=k,
             )
             if tier == "low":
                 console.print(
@@ -616,19 +638,14 @@ def search(
 
         if not chunks:
             if not all_profiles:
-                hint = _build_miss_hint(
-                    cfg_auto_hint=cfg.observability.auto_miss_hint,
-                    result_count=0,
-                    tier="low",
-                    best_distance=1.0,
-                    top_k_requested=k,
-                )
-                store.record_search_event(
+                _record_miss_event(
+                    store=store,
+                    cfg=cfg,
                     query=query,
                     best_distance=1.0,
-                    relevance_tier="low",
+                    tier="low",
                     result_count=0,
-                    miss_hint=hint,
+                    top_k_requested=k,
                 )
             if json_output:
                 print("[]")
@@ -647,19 +664,14 @@ def search(
 
             # Telemetry: record search event for discard rate analysis,
             # attaching a miss_hint when the tier is "low" (issue #157 part 3).
-            hint = _build_miss_hint(
-                cfg_auto_hint=cfg.observability.auto_miss_hint,
-                result_count=len(chunks),
-                tier=tier,
-                best_distance=best_distance,
-                top_k_requested=k,
-            )
-            _event_id = store.record_search_event(
+            _record_miss_event(
+                store=store,
+                cfg=cfg,
                 query=query,
                 best_distance=best_distance,
-                relevance_tier=tier,
+                tier=tier,
                 result_count=len(chunks),
-                miss_hint=hint,
+                top_k_requested=k,
             )
 
         if json_output:
@@ -1527,9 +1539,14 @@ def why(
         return typer.Exit(exit_code)
 
     # --recent mode: dump the N most recent miss_hint rows and exit.
-    # Issue #157 part 3 (2026-04-21): surfaces what the auto-log hook
-    # has captured since the store was opened, so users can see which
-    # queries recently missed without having to remember them.
+    # Issue #157 part 3: surfaces recent miss hints stored in the DB
+    # for this profile (the ``search_events`` table keeps the last
+    # 1000 rows, including prior runs). Users see which queries
+    # recently missed without having to remember them.
+    if recent < 0:
+        raise _why_error(
+            f"--recent must be >= 0 (0 = disabled), got {recent}."
+        )
     if recent > 0:
         _, store = _get_store(warm=False, profile=_profile_from_ctx(ctx))
         with store:

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -302,9 +302,9 @@ class ObservabilityConfig(BaseModel):
             "Record a lightweight ``miss_hint`` JSON on search_events "
             "rows when a query returns zero results or a result set "
             "entirely in the 'low' relevance tier (distance > 0.98). "
-            "Issue #157 part 3 (2026-04-21). Set to false to skip the "
-            "extra JSON column write per miss. The hint is consumed by "
-            "``vstash why --recent``."
+            "Set to false to skip the extra JSON column write per miss. "
+            "The hint is consumed by ``vstash why --recent``. Added in "
+            "issue #157 part 3."
         ),
     )
 

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -296,6 +296,17 @@ class ObservabilityConfig(BaseModel):
             "to effectively disable."
         ),
     )
+    auto_miss_hint: bool = Field(
+        default=True,
+        description=(
+            "Record a lightweight ``miss_hint`` JSON on search_events "
+            "rows when a query returns zero results or a result set "
+            "entirely in the 'low' relevance tier (distance > 0.98). "
+            "Issue #157 part 3 (2026-04-21). Set to false to skip the "
+            "extra JSON column write per miss. The hint is consumed by "
+            "``vstash why --recent``."
+        ),
+    )
 
 
 class LimitsConfig(BaseModel):

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -4015,13 +4015,20 @@ class VstashStore:
 
     def recent_miss_hints(self, limit: int = 10) -> list[dict]:
         """Return the N most recent search_events that carry a miss_hint,
-        newest first. Used by ``vstash why --recent``."""
+        newest first. Used by ``vstash why --recent``.
+
+        Raises ``ValueError`` when ``limit < 1`` so a negative value
+        does not accidentally turn into SQLite's "unlimited" sentinel
+        (``LIMIT -1``)."""
+        limit = int(limit)
+        if limit < 1:
+            raise ValueError(f"limit must be >= 1, got {limit}")
         rows = self._conn.execute(
             "SELECT id, query, best_distance, relevance_tier, result_count, "
             "miss_hint, created_at FROM search_events "
             "WHERE miss_hint IS NOT NULL "
             "ORDER BY id DESC LIMIT ?",
-            [int(limit)],
+            [limit],
         ).fetchall()
         out: list[dict] = []
         for r in rows:

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -11,6 +11,7 @@ Single .db file. WAL mode for safe concurrent reads.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import math
 import operator
@@ -758,7 +759,11 @@ class VstashStore:
                 created_at TEXT NOT NULL
             );
 
-            -- Search event telemetry for validating relevance signal
+            -- Search event telemetry for validating relevance signal.
+            -- ``miss_hint`` (issue #157 part 3, 2026-04-21) is a small
+            -- JSON blob populated by ``record_search_event`` when a
+            -- query returned empty / all-low results; consumed by
+            -- ``vstash why --recent`` for post-hoc diagnosis.
             CREATE TABLE IF NOT EXISTS search_events (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
                 query           TEXT NOT NULL,
@@ -766,7 +771,8 @@ class VstashStore:
                 relevance_tier  TEXT NOT NULL,
                 result_count    INTEGER NOT NULL,
                 dismissed       INTEGER NOT NULL DEFAULT 0,
-                created_at      TEXT NOT NULL
+                created_at      TEXT NOT NULL,
+                miss_hint       TEXT
             );
 
             -- Store metadata: key-value table for tracking what the
@@ -870,6 +876,13 @@ class VstashStore:
             migrations.append("ALTER TABLE documents ADD COLUMN layer TEXT")
         if "tags" not in doc_columns:
             migrations.append("ALTER TABLE documents ADD COLUMN tags TEXT")
+
+        # miss_hint column on search_events (issue #157 part 3, 2026-04-21)
+        event_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(search_events)").fetchall()
+        }
+        if event_columns and "miss_hint" not in event_columns:
+            migrations.append("ALTER TABLE search_events ADD COLUMN miss_hint TEXT")
 
         # Frequency + decay scoring columns on chunks
         chunk_columns = {row[1] for row in conn.execute("PRAGMA table_info(chunks)").fetchall()}
@@ -3965,17 +3978,32 @@ class VstashStore:
         best_distance: float,
         relevance_tier: str,
         result_count: int,
+        miss_hint: dict | None = None,
     ) -> int:
         """Record a search event for discard telemetry.
+
+        Args:
+            query: Raw query text.
+            best_distance: Distance of the top result (smaller = more relevant).
+            relevance_tier: ``"high"`` | ``"medium"`` | ``"low"`` bucket.
+            result_count: Number of rows the caller surfaced to the user.
+            miss_hint: Optional lightweight diagnostic blob, persisted as
+                JSON in the ``miss_hint`` column. Issue #157 part 3
+                (2026-04-21). Typical shape:
+                ``{"reason": "empty" | "all_low", "best_distance": ...,
+                "tier": ..., "result_count": ..., "top_k_requested": ...}``.
+                Consumed by ``vstash why --recent``.
 
         Returns the event ID so it can be marked as dismissed later.
         """
         now_iso = datetime.now(timezone.utc).isoformat()
+        hint_json = json.dumps(miss_hint) if miss_hint is not None else None
         with self._write_lock:
             cursor = self._conn.execute(
                 "INSERT INTO search_events (query, best_distance, relevance_tier, "
-                "result_count, dismissed, created_at) VALUES (?, ?, ?, ?, 0, ?)",
-                [query, best_distance, relevance_tier, result_count, now_iso],
+                "result_count, dismissed, created_at, miss_hint) "
+                "VALUES (?, ?, ?, ?, 0, ?, ?)",
+                [query, best_distance, relevance_tier, result_count, now_iso, hint_json],
             )
             # Prune to keep only the last 1000 entries
             self._conn.execute(
@@ -3984,6 +4012,35 @@ class VstashStore:
             )
             self._conn.commit()
             return cursor.lastrowid  # type: ignore[return-value]
+
+    def recent_miss_hints(self, limit: int = 10) -> list[dict]:
+        """Return the N most recent search_events that carry a miss_hint,
+        newest first. Used by ``vstash why --recent``."""
+        rows = self._conn.execute(
+            "SELECT id, query, best_distance, relevance_tier, result_count, "
+            "miss_hint, created_at FROM search_events "
+            "WHERE miss_hint IS NOT NULL "
+            "ORDER BY id DESC LIMIT ?",
+            [int(limit)],
+        ).fetchall()
+        out: list[dict] = []
+        for r in rows:
+            try:
+                hint = json.loads(r["miss_hint"]) if r["miss_hint"] else {}
+            except (TypeError, ValueError):
+                hint = {}
+            out.append(
+                {
+                    "id": int(r["id"]),
+                    "query": str(r["query"]),
+                    "best_distance": float(r["best_distance"]),
+                    "relevance_tier": str(r["relevance_tier"]),
+                    "result_count": int(r["result_count"]),
+                    "created_at": str(r["created_at"]),
+                    "miss_hint": hint,
+                }
+            )
+        return out
 
     def mark_search_dismissed(self, event_id: int) -> None:
         """Mark a search event as dismissed (user didn't engage with results)."""


### PR DESCRIPTION
Part 3 of issue #157. Makes the miss-analysis loop **proactive**: the
CLI now auto-logs a lightweight ``miss_hint`` on every search that
returns empty or an all-low-tier result set, and ``vstash why --recent``
lists them back so the user can drill into failures they didn't think
to capture at the moment.

## What changed

- **Schema**: ``search_events.miss_hint TEXT`` (nullable). Migration
  added for existing DBs.
- **Config**: ``[observability] auto_miss_hint = true`` (default).
- **API**: ``record_search_event(..., miss_hint=None)`` +
  ``recent_miss_hints(limit=10)``.
- **CLI**: ``_build_miss_hint`` helper plus hooks in ``vstash ask``
  and ``vstash search`` (both the normal and empty-result branches).
  New ``vstash why --recent N`` subcommand (Rich table + ``--json``).
- **Docs**: ``docs/observability.md`` section + ``docs/configuration.md``
  ``[observability]`` table.

## Why this matters

Before: if a user's query returned zero results, we showed "No relevant
documents found" and exited. The miss was invisible afterwards -- the
user had to remember the query and re-run ``vstash why`` from scratch.

After: the miss is persisted automatically. ``vstash why --recent 10``
shows the last 10 queries that missed, with reason (``empty`` vs
``all_low``), tier, best_distance, and result count. Drill into any
one of them with ``vstash why "<query>" --expect <path>``.

## Tests

- 3 new ``TestAutoMissHintHook`` tests (record/read roundtrip, NULL
  skipping, ``_build_miss_hint`` matrix).
- 3 new ``TestWhyCommand`` tests (--recent success, --recent --json,
  --recent empty-DB friendly message).
- Full suite: **998 passed**, ruff clean.

## Remaining work on #157

- Part 2: ``/debug/why`` JSON/HTML route on ``vstash serve``. Small
  standalone PR once an HTML presentation is settled.

## Test plan
- [x] ``pytest tests/test_cli_commands.py`` (22 passed).
- [x] ``pytest tests/`` full (998 passed).
- [x] ``ruff check vstash/ tests/``.
- [ ] Smoke: run ``vstash search nonsense_query_xyz`` then ``vstash why --recent 5`` against a local DB.