### PR TITLE
feat(#157 part 2): /debug/why route on vstash serve

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -243,9 +243,20 @@ The hook is on by default. Disable via ``vstash.toml``:
 auto_miss_hint = false
 ```
 
-**Planned follow-up for #157** (not yet shipped):
-- ``/debug/why`` JSON/HTML route on ``vstash serve`` for a browser-native
-  debug surface.
+**Web debug route** (#157 part 2):
+
+```bash
+# Expose /debug/why on vstash serve (off by default):
+vstash serve --debug
+
+# Then:
+curl 'http://127.0.0.1:8585/debug/why?q=rate%20limits&expect=/notes/api-design.md'
+```
+
+Same MissAnalysis payload as ``vstash why --json``, served over HTTP
+so browsers and remote tooling can consume it. Off by default because
+the endpoint echoes arbitrary query text back to the caller; intended
+for local diagnostic use, not production.
 
 **Prometheus alerting suggestion:**
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -249,8 +249,15 @@ auto_miss_hint = false
 # Expose /debug/why on vstash serve (off by default):
 vstash serve --debug
 
-# Then:
-curl 'http://127.0.0.1:8585/debug/why?q=rate%20limits&expect=/notes/api-design.md'
+# Then (note: ingest stores absolute paths via Path.resolve(), so the
+# endpoint normalizes ``expect`` the same way -- relative paths work
+# as long as the caller invokes curl from a working dir where the
+# resolved path matches what was ingested):
+curl 'http://127.0.0.1:8585/debug/why?q=rate%20limits&expect=notes/api-design.md'
+
+# To avoid any path ambiguity, use an absolute path or take it straight
+# from a search result or ``/api/documents``:
+curl 'http://127.0.0.1:8585/debug/why?q=rate%20limits&expect='"$(readlink -f notes/api-design.md)"
 ```
 
 Same MissAnalysis payload as ``vstash why --json``, served over HTTP

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -393,6 +393,65 @@ class TestDebugWhyEndpoint:
             assert resp.status_code == 400
             assert "No chunks found" in resp.json()["error"]
 
+    def test_expect_relative_path_normalized_to_absolute(self) -> None:
+        """Code review on PR #262: ingest stores absolute paths via
+        ``Path.resolve()``, so ``expect`` must be normalized the same
+        way. Relative paths should reach ``_do_miss_analysis`` as
+        absolute, matching the CLI + SDK behavior."""
+        from vstash.models import MissAnalysis
+        from pathlib import Path
+
+        fake = MissAnalysis(
+            query="q",
+            expected_path="placeholder",
+            top_k_requested=5,
+            appeared_in_results=False,
+        )
+        with (
+            patch(
+                "vstash.web._do_miss_analysis",
+                return_value=fake.model_dump(exclude_none=True),
+            ) as mock_do,
+            self._client_with_debug(debug=True) as c,
+        ):
+            resp = c.get("/debug/why?q=q&expect=notes/doc.md")
+            assert resp.status_code == 200
+            # expected_path arg (2nd positional) must be resolved absolute.
+            passed = mock_do.call_args.args[1]
+            assert passed is not None
+            assert Path(passed).is_absolute(), f"expected absolute, got {passed!r}"
+
+    def test_expect_http_uri_passes_through(self) -> None:
+        """http:// / https:// / text:// URIs stay verbatim, no Path
+        resolution, matching ``vstash search --miss`` and ``vstash why``."""
+        from vstash.models import MissAnalysis
+
+        fake = MissAnalysis(
+            query="q",
+            expected_path="placeholder",
+            top_k_requested=5,
+            appeared_in_results=False,
+        )
+        with (
+            patch(
+                "vstash.web._do_miss_analysis",
+                return_value=fake.model_dump(exclude_none=True),
+            ) as mock_do,
+            self._client_with_debug(debug=True) as c,
+        ):
+            resp = c.get("/debug/why?q=q&expect=https://example.com/doc")
+            assert resp.status_code == 200
+            assert mock_do.call_args.args[1] == "https://example.com/doc"
+
+    def test_expect_whitespace_only_is_treated_as_missing(self) -> None:
+        """``expect=   `` with only whitespace must fall into the
+        'one of expect/expect_chunk_id is required' error, not silently
+        stringify into ``/cwd/   ``."""
+        with self._client_with_debug(debug=True) as c:
+            resp = c.get("/debug/why?q=q&expect=%20%20%20")
+            assert resp.status_code == 400
+            assert "expect" in resp.json()["error"]
+
     def test_unexpected_error_returns_500(self) -> None:
         """Any other exception maps to 500 with a generic message so
         internals do not leak to unauthed callers."""

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -316,3 +316,93 @@ class TestJsonHelper:
 
         resp = _json({"error": "bad"}, status=400)
         assert resp.status_code == 400
+
+
+class TestDebugWhyEndpoint:
+    """Issue #157 part 2: /debug/why -- miss analysis as JSON, mounted
+    only when ``create_app(debug=True)``."""
+
+    def _client_with_debug(self, debug: bool) -> TestClient:
+        app = create_app(debug=debug)
+        return TestClient(app)
+
+    def test_route_not_mounted_by_default(self) -> None:
+        """Without ``debug=True``, the route returns 404."""
+        with self._client_with_debug(debug=False) as c:
+            resp = c.get("/debug/why?q=hello&expect=/a.md")
+            assert resp.status_code == 404
+
+    def test_route_mounted_when_debug_true(self) -> None:
+        """With ``debug=True``, the route is available and dispatches
+        to ``_do_miss_analysis``."""
+        from vstash.models import MissAnalysis
+
+        fake_analysis = MissAnalysis(
+            query="test",
+            expected_path="/a.md",
+            top_k_requested=5,
+            appeared_in_results=False,
+            dropped_at="vector_search",
+        )
+        with (
+            patch("vstash.web._do_miss_analysis", return_value=fake_analysis.model_dump(exclude_none=True)),
+            self._client_with_debug(debug=True) as c,
+        ):
+            resp = c.get("/debug/why?q=test&expect=/a.md")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["query"] == "test"
+            assert body["expected_path"] == "/a.md"
+            assert body["dropped_at"] == "vector_search"
+
+    def test_missing_query_returns_400(self) -> None:
+        with self._client_with_debug(debug=True) as c:
+            resp = c.get("/debug/why?expect=/a.md")
+            assert resp.status_code == 400
+            assert "q" in resp.json()["error"]
+
+    def test_missing_expect_returns_400(self) -> None:
+        with self._client_with_debug(debug=True) as c:
+            resp = c.get("/debug/why?q=hello")
+            assert resp.status_code == 400
+            assert "expect" in resp.json()["error"]
+
+    def test_invalid_expect_chunk_id_returns_400(self) -> None:
+        with self._client_with_debug(debug=True) as c:
+            resp = c.get("/debug/why?q=hello&expect_chunk_id=notanint")
+            assert resp.status_code == 400
+            assert "integer" in resp.json()["error"]
+
+    def test_invalid_top_k_returns_400(self) -> None:
+        with self._client_with_debug(debug=True) as c:
+            resp = c.get("/debug/why?q=hello&expect=/a.md&top_k=bad")
+            assert resp.status_code == 400
+            assert "top_k" in resp.json()["error"]
+
+    def test_value_error_from_miss_analysis_returns_400(self) -> None:
+        """A ValueError from the store (e.g. unknown path) surfaces as
+        a clean 400 + JSON error, not a 500."""
+        with (
+            patch(
+                "vstash.web._do_miss_analysis",
+                side_effect=ValueError("No chunks found for path: /missing.md"),
+            ),
+            self._client_with_debug(debug=True) as c,
+        ):
+            resp = c.get("/debug/why?q=hello&expect=/missing.md")
+            assert resp.status_code == 400
+            assert "No chunks found" in resp.json()["error"]
+
+    def test_unexpected_error_returns_500(self) -> None:
+        """Any other exception maps to 500 with a generic message so
+        internals do not leak to unauthed callers."""
+        with (
+            patch(
+                "vstash.web._do_miss_analysis",
+                side_effect=RuntimeError("sensitive path /etc/...")
+            ),
+            self._client_with_debug(debug=True) as c,
+        ):
+            resp = c.get("/debug/why?q=hello&expect=/a.md")
+            assert resp.status_code == 500
+            assert resp.json()["error"] == "internal error"

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1401,6 +1401,13 @@ def serve(
         "--warm/--no-warm",
         help="Pre-load embedding model at startup (eliminates first-query cold start)",
     ),
+    debug: bool = typer.Option(
+        False,
+        "--debug/--no-debug",
+        help="Expose the /debug/why route (miss analysis as JSON). Off by "
+        "default because the endpoint echoes arbitrary query text back. "
+        "Intended for local diagnostic use only. Issue #157 part 2.",
+    ),
 ) -> None:
     """Launch the vstash web interface -- a pocket memory agent.
 
@@ -1462,8 +1469,13 @@ def serve(
         )
 
     console.print(f"[bold cyan]vstash[/bold cyan] serving at [link]http://{host}:{port}[/link]")
+    if debug:
+        console.print(
+            "[yellow]! debug mode: /debug/why is exposed. "
+            "Do not use in production.[/yellow]"
+        )
     console.print("[dim]Press Ctrl+C to stop[/dim]")
-    uvicorn.run(create_app(), host=host, port=port, log_level="warning")
+    uvicorn.run(create_app(debug=debug), host=host, port=port, log_level="warning")
 
 
 @app.command()

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -176,6 +176,33 @@ def _do_embed_query(text: str) -> dict:
     }
 
 
+def _do_miss_analysis(
+    query: str,
+    expected_path: str | None,
+    expected_chunk_id: int | None,
+    top_k: int,
+    collection: str | None,
+    project: str | None,
+    layer: str | None,
+) -> dict:
+    """Run ``VstashStore.miss_analysis`` from the debug endpoint.
+    Returns the dumped MissAnalysis as a dict ready for JSONResponse."""
+    cfg = _get_config()
+    store = _get_store()
+    q_emb = embed_query(query, cfg.embeddings.model)
+    analysis = store.miss_analysis(
+        query_embedding=q_emb,
+        query_text=query,
+        expected_path=expected_path,
+        expected_chunk_id=expected_chunk_id,
+        top_k=top_k or cfg.chunking.top_k,
+        collection=collection,
+        project=project,
+        layer=layer,
+    )
+    return analysis.model_dump(exclude_none=True)
+
+
 # ------------------------------------------------------------------ #
 # API endpoints (all async, blocking work via _run_sync)               #
 # ------------------------------------------------------------------ #
@@ -383,6 +410,79 @@ async def api_health(request: Request) -> JSONResponse:
     )
 
 
+async def api_debug_why(request: Request) -> JSONResponse:
+    """GET /debug/why?q=...&expect=... -- miss analysis as JSON.
+
+    Issue #157 part 2. Behind the ``--debug`` flag on ``vstash serve``
+    because the endpoint echoes arbitrary query text + path back to
+    the caller and is intended for local diagnostic use, not public
+    consumption. When ``--debug`` is not set, this route is NOT
+    mounted and the URL returns 404.
+
+    Query parameters:
+        q (required): the search query that missed.
+        expect (optional): expected document path.
+        expect_chunk_id (optional): specific chunk id.
+          One of ``expect`` / ``expect_chunk_id`` is required.
+        top_k (optional, int, default from config): top-k window.
+        collection / project / layer (optional): metadata filters.
+
+    Response: the MissAnalysis model as JSON, ``exclude_none=True``.
+
+    Errors return 400 with ``{"error": "..."}`` for input problems,
+    500 for unexpected internals.
+    """
+    qp = request.query_params
+    query = (qp.get("q") or "").strip()
+    expect = qp.get("expect") or None
+    expect_chunk_id_raw = qp.get("expect_chunk_id")
+    top_k_raw = qp.get("top_k")
+    collection = qp.get("collection") or None
+    project = qp.get("project") or None
+    layer = qp.get("layer") or None
+
+    if not query:
+        return _json({"error": "q (query) is required"}, 400)
+    if expect is None and expect_chunk_id_raw is None:
+        return _json(
+            {"error": "one of expect=<path> or expect_chunk_id=<id> is required"}, 400
+        )
+
+    expect_chunk_id: int | None = None
+    if expect_chunk_id_raw is not None:
+        try:
+            expect_chunk_id = int(expect_chunk_id_raw)
+        except ValueError:
+            return _json({"error": "expect_chunk_id must be an integer"}, 400)
+
+    top_k = 0
+    if top_k_raw is not None:
+        try:
+            top_k = int(top_k_raw)
+        except ValueError:
+            return _json({"error": "top_k must be an integer"}, 400)
+
+    try:
+        data = await _run_sync(
+            _do_miss_analysis,
+            query,
+            expect,
+            expect_chunk_id,
+            top_k,
+            collection,
+            project,
+            layer,
+        )
+    except ValueError as exc:
+        # Expected-path / chunk-id resolution failures come through here.
+        return _json({"error": str(exc)}, 400)
+    except Exception:
+        logger.exception("debug/why failed")
+        return _json({"error": "internal error"}, 500)
+
+    return _json(data)
+
+
 async def api_metrics(request: Request) -> JSONResponse:
     """GET /metrics — snapshot of the metrics registry as JSON.
 
@@ -426,25 +526,32 @@ async def _lifespan(app: Starlette):  # noqa: ARG001
         _store = None
 
 
-def create_app() -> Starlette:
-    """Create the Starlette app with all routes."""
+def create_app(debug: bool = False) -> Starlette:
+    """Create the Starlette app with all routes.
+
+    Args:
+        debug: When True, also mounts ``/debug/why`` (miss analysis as
+            JSON). Issue #157 part 2. Off by default because the
+            endpoint echoes arbitrary query text back and is intended
+            for local diagnostic use, not production.
+    """
     # Eagerly initialize store to avoid lazy-init deadlocks with asyncio
     _get_store()
-    return Starlette(
-        lifespan=_lifespan,
-        routes=[
-            Route("/", index),
-            Route("/api/embed", api_embed, methods=["POST"]),
-            Route("/api/search", api_search, methods=["POST"]),
-            Route("/api/chat", api_chat, methods=["POST"]),
-            Route("/api/chat/reset", api_chat_reset, methods=["POST"]),
-            Route("/api/documents", api_documents),
-            Route("/api/stats", api_stats),
-            Route("/api/upload", api_upload, methods=["POST"]),
-            Route("/health", api_health),
-            Route("/metrics", api_metrics),
-        ],
-    )
+    routes = [
+        Route("/", index),
+        Route("/api/embed", api_embed, methods=["POST"]),
+        Route("/api/search", api_search, methods=["POST"]),
+        Route("/api/chat", api_chat, methods=["POST"]),
+        Route("/api/chat/reset", api_chat_reset, methods=["POST"]),
+        Route("/api/documents", api_documents),
+        Route("/api/stats", api_stats),
+        Route("/api/upload", api_upload, methods=["POST"]),
+        Route("/health", api_health),
+        Route("/metrics", api_metrics),
+    ]
+    if debug:
+        routes.append(Route("/debug/why", api_debug_why))
+    return Starlette(lifespan=_lifespan, routes=routes)
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -434,7 +434,19 @@ async def api_debug_why(request: Request) -> JSONResponse:
     """
     qp = request.query_params
     query = (qp.get("q") or "").strip()
-    expect = qp.get("expect") or None
+    # Normalize ``expect`` the same way the CLI and Memory SDK do:
+    # http(s)/text URIs pass through verbatim, everything else resolves
+    # to an absolute path (ingest stores ``Path(source).resolve()``,
+    # so a caller passing a relative path would otherwise reliably get
+    # "No chunks found" even when the doc exists). ``.strip()`` treats
+    # whitespace-only values as missing.
+    expect_raw = (qp.get("expect") or "").strip()
+    if not expect_raw:
+        expect = None
+    elif expect_raw.startswith(("http://", "https://", "text://")):
+        expect = expect_raw
+    else:
+        expect = str(Path(expect_raw).resolve(strict=False))
     expect_chunk_id_raw = qp.get("expect_chunk_id")
     top_k_raw = qp.get("top_k")
     collection = qp.get("collection") or None


### PR DESCRIPTION
Closes issue #157. Adds the last of the three surfaces (CLI / auto-log
/ web): ``vstash serve --debug`` mounts ``GET /debug/why`` returning
the MissAnalysis as JSON.

## Usage

    vstash serve --debug
    curl 'http://127.0.0.1:8585/debug/why?q=rate%20limits&expect=/notes/api.md'

## Security posture

Off by default. The endpoint echoes caller-supplied query + path back
and runs embed/search on them, so it is intended for local diagnostic
use only. A one-shot yellow warning fires on startup when ``--debug``
is on. Without ``--debug`` the route is not mounted at all (404).

## Error surface

- 400 on missing / malformed query params or ValueError from the store
  (unknown path / chunk id).
- 500 + generic message on unexpected exceptions (details logged
  server-side; internals don't leak to unauthed callers).

## Tests

8 new ``TestDebugWhyEndpoint`` tests. 57 total test_web + test_cli_commands passing. ruff clean.

## #157 status after this PR

- [x] Part 1 (#260): ``vstash why`` CLI + ``--json``.
- [x] Part 3 (#261): auto-log miss_hint + ``vstash why --recent``.
- [x] Part 2 (this PR): ``/debug/why`` JSON route on serve.

Issue can be closed after merge.

## Test plan
- [x] ``pytest tests/test_web.py::TestDebugWhyEndpoint`` (8 passed).
- [x] ``pytest tests/test_web.py tests/test_cli_commands.py`` (57 passed).
- [x] ``ruff check vstash/ tests/``.
- [ ] Smoke: ``vstash serve --debug`` + a local curl before merging.