### PR TITLE
feat(#106): exact_match substring filter on search()

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,25 @@ The `recency_boost` parameter can also be set per-call in `store.search()`, `Mem
 mem.search("meeting notes", added_after="2024-06-01", added_before="2024-12-31")
 ```
 
+### Exact-match substring filter
+
+`exact_match` is a per-call substring post-filter that bypasses FTS5 tokenization. It's applied after the full hybrid pipeline, so candidate pool sizing ignores it — pass a larger `top_k` when the substring is selective.
+
+```python
+# Case-insensitive by default (casefold compare).
+mem.search("policy", exact_match="rate-limit")
+
+# Strict compare for code identifiers / casing-sensitive terms.
+mem.search("api", exact_match="RateLimit", exact_match_case_sensitive=True)
+```
+
+```bash
+vstash search "policy" --exact-match "rate-limit"
+vstash search "api" --exact-match "RateLimit" --exact-match-case-sensitive
+```
+
+Use this when FTS5 stemming / lowercasing would eat a term you care about (code identifiers, punctuation-heavy strings, specific casing). Part of issue #106.
+
 ---
 
 ## `[observability]`

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -817,18 +817,18 @@ class TestMemorySearchExactMatch:
             mem.add(tmp_path / "a.md")
             mem.add(tmp_path / "b.md")
 
-            # Without filter both docs likely surface via 'rate' / 'limit'.
-            baseline = mem.search("rate limits", top_k=10)
-            assert len(baseline) >= 1
-
-            # Case-sensitive "RateLimit" only matches doc A.
+            # Include the exact literal in the query so doc A is reliably
+            # retrieved by FTS / vector before the post-filter runs. Without
+            # this, the test could pass vacuously if the candidate pool
+            # happens to exclude doc A upstream.
             strict = mem.search(
-                "rate limits",
+                "RateLimit rate limits",
                 top_k=10,
                 exact_match="RateLimit",
                 exact_match_case_sensitive=True,
             )
+            assert strict, "passthrough test must surface at least one hit"
             for r in strict:
                 assert "RateLimit" in r.text
             paths = {r.path for r in strict}
-            assert all(str(tmp_path / "a.md") == p for p in paths) or not paths
+            assert paths == {str(tmp_path / "a.md")}

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -800,3 +800,35 @@ class TestDynamicChunkSize:
 
         # Smaller chunk_size should produce more chunks
         assert chunk_count_512 >= chunk_count_4096
+
+
+class TestMemorySearchExactMatch:
+    """#106 (2026-04-21): Memory.search passes exact_match through to
+    the store and respects the case-sensitivity toggle."""
+
+    def test_memory_search_forwards_exact_match(self, tmp_path: Path) -> None:
+        (tmp_path / "a.md").write_text(
+            "# Doc A\n\nThis paragraph mentions RateLimit as a specific identifier."
+        )
+        (tmp_path / "b.md").write_text(
+            "# Doc B\n\nThis paragraph mentions rate limits but nothing code-ish."
+        )
+        with Memory(db=tmp_path / "mem.db") as mem:
+            mem.add(tmp_path / "a.md")
+            mem.add(tmp_path / "b.md")
+
+            # Without filter both docs likely surface via 'rate' / 'limit'.
+            baseline = mem.search("rate limits", top_k=10)
+            assert len(baseline) >= 1
+
+            # Case-sensitive "RateLimit" only matches doc A.
+            strict = mem.search(
+                "rate limits",
+                top_k=10,
+                exact_match="RateLimit",
+                exact_match_case_sensitive=True,
+            )
+            for r in strict:
+                assert "RateLimit" in r.text
+            paths = {r.path for r in strict}
+            assert all(str(tmp_path / "a.md") == p for p in paths) or not paths

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1734,3 +1734,98 @@ class TestTemporalFilters:
         q = [0.15] * dim
         results = populated_store.search(q, "programming", top_k=10)
         assert len(results) >= 1
+
+
+class TestSearchExactMatch:
+    """#106 (2026-04-21): ``exact_match`` substring post-filter
+    bypasses FTS5 tokenization so literal identifiers / punctuation /
+    casing survive the pipeline without being stemmed away."""
+
+    def _seed(self, store) -> None:
+        dim = store.embedding_dim
+        store.add_document(
+            path="/docs/rate-limit.md",
+            title="Rate limit policy",
+            chunks=[
+                "Our API enforces a rate-limit of 100 req/s per token rate.",
+                "The rate-limit applies per-IP before per-token rate logic.",
+            ],
+            embeddings=[[0.5] * dim, [0.5] * dim],
+        )
+        store.add_document(
+            path="/docs/quota.md",
+            title="Quota policy",
+            chunks=["Quota caps are daily and reset at 00:00 UTC per rate."],
+            embeddings=[[0.5] * dim],
+        )
+
+    def test_exact_match_requires_literal_substring(self, sample_store) -> None:
+        """A chunk without the literal substring must be dropped, even
+        when it ranks high on vector/FTS signals."""
+        self._seed(sample_store)
+        dim = sample_store.embedding_dim
+        q = [0.5] * dim
+
+        # Without filter: rate-limit chunks surface on FTS via "rate".
+        # The quota chunk is vector-only (uniform 0.5 vectors) so it
+        # may or may not be in top-10 depending on pipeline tie-breaks.
+        unfiltered = sample_store.search(q, "rate", top_k=10)
+        assert unfiltered, "baseline search must surface at least one rate-limit chunk"
+
+        # With exact_match: only chunks whose text contains the
+        # hyphenated literal survive. The quota chunk has no "rate-limit"
+        # substring at all -> excluded.
+        filtered = sample_store.search(
+            q, "policy", top_k=10, exact_match="rate-limit"
+        )
+        assert filtered, "at least one rate-limit chunk must survive"
+        for r in filtered:
+            assert "rate-limit" in r.text.casefold()
+        assert not any(r.path == "/docs/quota.md" for r in filtered)
+
+    def test_exact_match_case_insensitive_by_default(self, sample_store) -> None:
+        """Default ``exact_match_case_sensitive=False`` casefolds both
+        sides so "RATE-LIMIT" matches "Rate-limit" matches "rate-limit"."""
+        self._seed(sample_store)
+        dim = sample_store.embedding_dim
+        q = [0.5] * dim
+
+        lower = sample_store.search(q, "rate", top_k=10, exact_match="rate-limit")
+        upper = sample_store.search(q, "rate", top_k=10, exact_match="RATE-LIMIT")
+        mixed = sample_store.search(q, "rate", top_k=10, exact_match="Rate-LIMIT")
+
+        def _paths(rs):
+            return {r.path for r in rs}
+
+        assert _paths(lower) == _paths(upper) == _paths(mixed)
+
+    def test_exact_match_case_sensitive_toggle(self, sample_store) -> None:
+        """With ``exact_match_case_sensitive=True`` the comparison is strict."""
+        self._seed(sample_store)
+        dim = sample_store.embedding_dim
+        q = [0.5] * dim
+
+        # Lowercase literal "rate-limit" is in both seeded chunks.
+        # Strict compare is "no casefold"; the test confirms the
+        # substring is present verbatim in every returned chunk.
+        strict_lower = sample_store.search(
+            q,
+            "rate",
+            top_k=10,
+            exact_match="rate-limit",
+            exact_match_case_sensitive=True,
+        )
+        for r in strict_lower:
+            assert "rate-limit" in r.text  # strict: no casefold
+
+    def test_exact_match_empty_filter_is_noop(self, populated_store) -> None:
+        """``exact_match=None`` and ``exact_match=""`` both leave the
+        ranking untouched (the empty string would match everything and
+        the None path skips the filter block)."""
+        dim = populated_store.embedding_dim
+        q = [0.15] * dim
+        base = populated_store.search(q, "python", top_k=5)
+        none_result = populated_store.search(q, "python", top_k=5, exact_match=None)
+        empty_result = populated_store.search(q, "python", top_k=5, exact_match="")
+        assert [r.path for r in base] == [r.path for r in none_result]
+        assert [r.path for r in base] == [r.path for r in empty_result]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1797,6 +1797,9 @@ class TestSearchExactMatch:
         def _paths(rs):
             return {r.path for r in rs}
 
+        # Guard against the pipeline silently returning zero candidates --
+        # an all-empty set would make the equality check pass vacuously.
+        assert lower, "baseline case-insensitive query must return hits"
         assert _paths(lower) == _paths(upper) == _paths(mixed)
 
     def test_exact_match_case_sensitive_toggle(self, sample_store) -> None:
@@ -1815,6 +1818,8 @@ class TestSearchExactMatch:
             exact_match="rate-limit",
             exact_match_case_sensitive=True,
         )
+        # Guarantee at least one hit so the loop actually exercises the filter.
+        assert strict_lower, "case-sensitive filter for 'rate-limit' must match the seeded chunks"
         for r in strict_lower:
             assert "rate-limit" in r.text  # strict: no casefold
 

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -638,6 +638,21 @@ def search(
                 )
                 chunks = [r for _, r in tagged]
                 _search_tagged = tagged
+                # Post-filter federated results the same way VstashStore.search
+                # does so --exact-match works across profiles too. #106.
+                if exact_match:
+                    if exact_match_case_sensitive:
+                        _search_tagged = [
+                            (name, r) for (name, r) in _search_tagged if exact_match in r.text
+                        ]
+                    else:
+                        _needle = exact_match.casefold()
+                        _search_tagged = [
+                            (name, r)
+                            for (name, r) in _search_tagged
+                            if _needle in r.text.casefold()
+                        ]
+                    chunks = [r for _, r in _search_tagged]
             else:
                 chunks = store.search(
                     q_embedding,

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -504,6 +504,19 @@ def search(
         "--miss-chunk",
         help="Diagnose why this expected chunk id did not appear in results",
     ),
+    exact_match: str | None = typer.Option(
+        None,
+        "--exact-match",
+        help="Post-filter: each returned chunk's text must contain this "
+        "literal substring. Bypasses FTS5 tokenization so punctuation / "
+        "identifiers / code survive verbatim. Case-insensitive by default "
+        "-- pair with --exact-match-case-sensitive for a strict compare.",
+    ),
+    exact_match_case_sensitive: bool = typer.Option(
+        False,
+        "--exact-match-case-sensitive/--no-exact-match-case-sensitive",
+        help="Toggle case sensitivity of --exact-match.",
+    ),
 ) -> None:
     """Semantic search without LLM (free, local)."""
     cfg, store = _get_store(warm=True, profile=_profile_from_ctx(ctx))
@@ -634,6 +647,8 @@ def search(
                     project=project,
                     layer=layer,
                     explain=explain,
+                    exact_match=exact_match,
+                    exact_match_case_sensitive=exact_match_case_sensitive,
                 )
 
         if not chunks:

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -282,6 +282,8 @@ class Memory:
         vec_weight: float | None = None,
         fts_weight: float | None = None,
         fts_only: bool = False,
+        exact_match: str | None = None,
+        exact_match_case_sensitive: bool = False,
     ) -> list[SearchResult]:
         """Semantic search without LLM inference.
 
@@ -308,6 +310,12 @@ class Memory:
                 other to ``1.0 - provided`` so the pair sums to 1.0.
             fts_weight: Pin the RRF FTS weight for this single call.
                 Same semantics and range as ``vec_weight``.
+            exact_match: Optional literal substring the returned chunk's
+                ``text`` must contain. Bypasses FTS5 tokenization
+                (stemming, lowercasing) so identifiers and punctuation
+                survive. #106, 2026-04-21.
+            exact_match_case_sensitive: Whether ``exact_match`` is
+                case-sensitive. Default False (casefold compare).
             fts_only: If True, run FTS5 keyword search only and skip the
                 vector ANN scan, distance cutoff, and adaptive RRF
                 entirely. Useful for debugging ranking, for queries
@@ -354,6 +362,8 @@ class Memory:
             added_after=added_after,
             added_before=added_before,
             mmr_lambda=mmr_lambda,
+            exact_match=exact_match,
+            exact_match_case_sensitive=exact_match_case_sensitive,
         )
 
     def miss_analysis(

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1860,17 +1860,18 @@ class VstashStore:
         )
 
         # --- Query cache key ---
-        # Skip the cache when an exact_match filter is active; mixing an
-        # arbitrary substring into the cache key would bloat the cache
-        # and produce stale-match hits across similar-but-different
-        # filter strings. Cheap fallthrough for the rare filter use.
+        # Skip the cache when an exact_match filter is ACTIVE (non-empty).
+        # An empty string and None are no-ops against the post-filter and
+        # stay cacheable. Including the substring in the cache key would
+        # be correct but blow up key cardinality and reduce reuse; the
+        # filter is rare enough that the simpler skip is preferable.
         _cache_key: int | None = None
         _cache_max = self._cache_config.query_cache_size
         if (
             _cache_max > 0
             and _tracer is None
             and not explain
-            and exact_match is None
+            and not exact_match
         ):
             _cache_key = self._compute_search_cache_key(
                 query_embedding=query_embedding,
@@ -2405,13 +2406,11 @@ class VstashStore:
             # guaranteed top_k under a selective substring should pass a
             # larger ``top_k`` (e.g. 3x) or accept a smaller result set.
             if exact_match:
-                needle = exact_match if exact_match_case_sensitive else exact_match.casefold()
-                filtered: list[SearchResult] = []
-                for r in results:
-                    hay = r.text if exact_match_case_sensitive else r.text.casefold()
-                    if needle in hay:
-                        filtered.append(r)
-                results = filtered
+                if exact_match_case_sensitive:
+                    results = [r for r in results if exact_match in r.text]
+                else:
+                    needle = exact_match.casefold()
+                    results = [r for r in results if needle in r.text.casefold()]
 
             # Stash values the finally block needs to log slow queries
             # with accurate data.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1791,6 +1791,8 @@ class VstashStore:
         added_before: str | None = None,
         mmr_lambda: float = 0.5,
         fts_only: bool = False,
+        exact_match: str | None = None,
+        exact_match_case_sensitive: bool = False,
         _tracer: _PipelineTracer | None = None,
     ) -> list[SearchResult]:
         """Hybrid search: vector (semantic) + FTS5 (keyword) combined with RRF.
@@ -1813,6 +1815,19 @@ class VstashStore:
             collection: If set, restrict search to documents in this collection.
             project: If set, restrict search to documents with this project tag.
             layer: If set, restrict search to documents with this layer tag.
+            exact_match: Optional substring that each returned chunk's
+                ``text`` must contain. Applied as a post-filter after
+                the full pipeline so the upstream candidate pool does
+                NOT know about this constraint -- callers who need a
+                guaranteed top_k under a selective substring should
+                request a larger ``top_k`` and accept that fewer
+                results may come back. Bypasses FTS5 tokenization, so
+                literal strings with punctuation / casing / code
+                identifiers survive (unlike the FTS5 keyword path
+                which stems and lowercases). #106, 2026-04-21.
+            exact_match_case_sensitive: Toggle for the above. Default
+                ``False`` does a casefold comparison which matches
+                typical retrieval-filter UX expectations.
             fts_only: If True, short-circuit the pipeline to FTS5 only (#152):
                 no vector ANN scan, no distance cutoff, no adaptive
                 RRF weight computation. FTS5 hits are still fed
@@ -1845,9 +1860,18 @@ class VstashStore:
         )
 
         # --- Query cache key ---
+        # Skip the cache when an exact_match filter is active; mixing an
+        # arbitrary substring into the cache key would bloat the cache
+        # and produce stale-match hits across similar-but-different
+        # filter strings. Cheap fallthrough for the rare filter use.
         _cache_key: int | None = None
         _cache_max = self._cache_config.query_cache_size
-        if _cache_max > 0 and _tracer is None and not explain:
+        if (
+            _cache_max > 0
+            and _tracer is None
+            and not explain
+            and exact_match is None
+        ):
             _cache_key = self._compute_search_cache_key(
                 query_embedding=query_embedding,
                 query_text=query_text,
@@ -2363,6 +2387,31 @@ class VstashStore:
                 vec_weight=vec_weight,
                 fts_weight=fts_weight,
             )
+
+            # Exact-match text filter (#106). Applied post-pipeline on
+            # the final ranked list: a chunk that otherwise would have
+            # made the top-k is dropped unless its ``text`` contains
+            # ``exact_match`` as a substring. Bypasses FTS5 tokenization
+            # so identifiers / phrases that stem or tokenize differently
+            # than the user typed survive -- e.g. ``exact_match="rate-
+            # limit"`` requires the literal string, not ``rate limit``.
+            #
+            # Case-sensitive opt-in via ``exact_match_case_sensitive``.
+            # Default is case-insensitive which is the usual UX
+            # expectation for retrieval filters.
+            #
+            # Post-filter means the candidate pool upstream was sized
+            # without knowing about this filter, so callers who need a
+            # guaranteed top_k under a selective substring should pass a
+            # larger ``top_k`` (e.g. 3x) or accept a smaller result set.
+            if exact_match:
+                needle = exact_match if exact_match_case_sensitive else exact_match.casefold()
+                filtered: list[SearchResult] = []
+                for r in results:
+                    hay = r.text if exact_match_case_sensitive else r.text.casefold()
+                    if needle in hay:
+                        filtered.append(r)
+                results = filtered
 
             # Stash values the finally block needs to log slow queries
             # with accurate data.


### PR DESCRIPTION
Ships the exact-match piece of issue #106. Boolean AND/OR operators
and faceting stay as separate follow-ups (they need API-shape
decisions).

## Behavior

- ``exact_match`` post-filters search results: each returned chunk's
  ``text`` must contain the literal substring.
- Applied AFTER the full hybrid pipeline (vector + FTS + RRF + MMR),
  so the candidate pool does NOT know about the constraint.
- Bypasses FTS5 tokenization (stemming, lowercasing) so code
  identifiers, punctuation-heavy strings, and casing-sensitive
  terms survive verbatim.
- ``exact_match_case_sensitive=False`` (default) uses casefold.

## Surfaces

- ``VstashStore.search(exact_match=..., exact_match_case_sensitive=...)``
- ``Memory.search(exact_match=..., exact_match_case_sensitive=...)``
- ``vstash search --exact-match <str> [--exact-match-case-sensitive]``

## Tests

- ``TestSearchExactMatch`` (4 tests): literal substring, case
  handling, None/empty no-op.
- ``TestMemorySearchExactMatch`` (1 test): SDK passthrough.
- Full suite: **1015 passed**, ruff clean.

## Deferred

- Boolean AND/OR operators between existing filters (collection /
  project / layer).
- Faceting support for narrowing results.

Issue #106 will remain open until the bool-ops piece lands.

## Test plan
- [x] ``pytest tests/test_store.py -k ExactMatch`` (4 passed).
- [x] ``pytest tests/test_memory.py -k ExactMatch`` (1 passed).
- [x] ``pytest tests/`` full (1015 passed).
- [x] ``ruff check vstash/ tests/``.
- [ ] Smoke: ``vstash search 'query' --exact-match 'rate-limit'`` on a local corpus.