### PR TITLE
perf(#252): fix O(N^2) in _rebuild_snapvec_from_vec_chunks

### DIFF
--- a/experiments/results/snapvec_rebuild_scaling_after.json
+++ b/experiments/results/snapvec_rebuild_scaling_after.json
@@ -1,0 +1,47 @@
+{
+  "label": "after_keyset_coalesce",
+  "backend": "snapvec",
+  "dim": 384,
+  "checkpoints": [
+    {
+      "n_at_probe": 5000,
+      "rebuild_seconds_p50": 0.23,
+      "rebuild_seconds_min": 0.229,
+      "rebuild_seconds_max": 0.234,
+      "rebuild_seconds_mean": 0.231,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 10000,
+      "rebuild_seconds_p50": 0.482,
+      "rebuild_seconds_min": 0.478,
+      "rebuild_seconds_max": 0.497,
+      "rebuild_seconds_mean": 0.485,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 25000,
+      "rebuild_seconds_p50": 1.635,
+      "rebuild_seconds_min": 1.215,
+      "rebuild_seconds_max": 1.688,
+      "rebuild_seconds_mean": 1.513,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 50000,
+      "rebuild_seconds_p50": 2.53,
+      "rebuild_seconds_min": 2.529,
+      "rebuild_seconds_max": 3.233,
+      "rebuild_seconds_mean": 2.764,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 100000,
+      "rebuild_seconds_p50": 5.426,
+      "rebuild_seconds_min": 4.955,
+      "rebuild_seconds_max": 6.563,
+      "rebuild_seconds_mean": 5.648,
+      "repeats": 3
+    }
+  ]
+}

--- a/experiments/results/snapvec_rebuild_scaling_after.json
+++ b/experiments/results/snapvec_rebuild_scaling_after.json
@@ -1,46 +1,46 @@
 {
-  "label": "after_keyset_coalesce",
+  "label": "after_frombuffer",
   "backend": "snapvec",
   "dim": 384,
   "checkpoints": [
     {
       "n_at_probe": 5000,
-      "rebuild_seconds_p50": 0.23,
-      "rebuild_seconds_min": 0.229,
-      "rebuild_seconds_max": 0.234,
-      "rebuild_seconds_mean": 0.231,
+      "rebuild_seconds_p50": 0.165,
+      "rebuild_seconds_min": 0.161,
+      "rebuild_seconds_max": 0.166,
+      "rebuild_seconds_mean": 0.164,
       "repeats": 3
     },
     {
       "n_at_probe": 10000,
-      "rebuild_seconds_p50": 0.482,
-      "rebuild_seconds_min": 0.478,
-      "rebuild_seconds_max": 0.497,
-      "rebuild_seconds_mean": 0.485,
+      "rebuild_seconds_p50": 0.348,
+      "rebuild_seconds_min": 0.346,
+      "rebuild_seconds_max": 0.37,
+      "rebuild_seconds_mean": 0.355,
       "repeats": 3
     },
     {
       "n_at_probe": 25000,
-      "rebuild_seconds_p50": 1.635,
-      "rebuild_seconds_min": 1.215,
-      "rebuild_seconds_max": 1.688,
-      "rebuild_seconds_mean": 1.513,
+      "rebuild_seconds_p50": 0.897,
+      "rebuild_seconds_min": 0.894,
+      "rebuild_seconds_max": 0.965,
+      "rebuild_seconds_mean": 0.919,
       "repeats": 3
     },
     {
       "n_at_probe": 50000,
-      "rebuild_seconds_p50": 2.53,
-      "rebuild_seconds_min": 2.529,
-      "rebuild_seconds_max": 3.233,
-      "rebuild_seconds_mean": 2.764,
+      "rebuild_seconds_p50": 1.859,
+      "rebuild_seconds_min": 1.858,
+      "rebuild_seconds_max": 2.297,
+      "rebuild_seconds_mean": 2.005,
       "repeats": 3
     },
     {
       "n_at_probe": 100000,
-      "rebuild_seconds_p50": 5.426,
-      "rebuild_seconds_min": 4.955,
-      "rebuild_seconds_max": 6.563,
-      "rebuild_seconds_mean": 5.648,
+      "rebuild_seconds_p50": 4.046,
+      "rebuild_seconds_min": 3.983,
+      "rebuild_seconds_max": 5.31,
+      "rebuild_seconds_mean": 4.446,
       "repeats": 3
     }
   ]

--- a/experiments/results/snapvec_rebuild_scaling_before.json
+++ b/experiments/results/snapvec_rebuild_scaling_before.json
@@ -1,0 +1,47 @@
+{
+  "label": "before",
+  "backend": "snapvec",
+  "dim": 384,
+  "checkpoints": [
+    {
+      "n_at_probe": 5000,
+      "rebuild_seconds_p50": 0.284,
+      "rebuild_seconds_min": 0.281,
+      "rebuild_seconds_max": 0.297,
+      "rebuild_seconds_mean": 0.287,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 10000,
+      "rebuild_seconds_p50": 0.836,
+      "rebuild_seconds_min": 0.657,
+      "rebuild_seconds_max": 1.264,
+      "rebuild_seconds_mean": 0.919,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 25000,
+      "rebuild_seconds_p50": 2.17,
+      "rebuild_seconds_min": 1.919,
+      "rebuild_seconds_max": 2.18,
+      "rebuild_seconds_mean": 2.089,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 50000,
+      "rebuild_seconds_p50": 7.999,
+      "rebuild_seconds_min": 6.246,
+      "rebuild_seconds_max": 8.802,
+      "rebuild_seconds_mean": 7.683,
+      "repeats": 3
+    },
+    {
+      "n_at_probe": 100000,
+      "rebuild_seconds_p50": 41.575,
+      "rebuild_seconds_min": 39.901,
+      "rebuild_seconds_max": 41.883,
+      "rebuild_seconds_mean": 41.12,
+      "repeats": 3
+    }
+  ]
+}

--- a/experiments/snapvec_rebuild_scaling_probe.py
+++ b/experiments/snapvec_rebuild_scaling_probe.py
@@ -1,0 +1,172 @@
+"""
+snapvec_rebuild_scaling_probe.py -- isolate the cost of
+``VstashStore._rebuild_snapvec_from_vec_chunks`` as a function of N.
+
+Motivation. Issue #252 (O(N^2) audit Tier 1) flagged this path as
+a likely quadratic because the loop streams 10k-row batches of
+vectors out of ``vec_chunks`` and calls ``SnapIndex.add_batch``
+per batch. ``SnapIndex.add_batch`` in turn does
+
+    self._indices = np.vstack([self._indices, batch_idx])
+    self._norms   = np.concatenate([self._norms, batch_norms])
+
+(see snapvec/_index.py:206-214). Each call copies the full
+current buffer, so over N/batch_size calls the total cost is
+O(N^2 / batch_size).
+
+This probe fills a store to target N via ``add_documents_batch``
+(one snapvec add_batch for the whole fill, cheap), then calls
+``_rebuild_snapvec_from_vec_chunks()`` and records wall clock.
+It sweeps N across a geometric ladder and writes a JSON table so
+we can compare the pre- and post-fix slopes directly.
+
+Runtime budget: even at N=250k a single rebuild should land under
+a minute on current HEAD (it's the vstack cost we're measuring,
+not anything that spirals for hours).
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+from vstash.store import VstashStore
+
+
+DEFAULT_CHECKPOINTS = [5_000, 10_000, 25_000, 50_000, 100_000]
+DIM = 384
+
+
+def _gen_docs(start: int, count: int, rng: np.random.Generator) -> list[dict]:
+    """Generate `count` synthetic docs with unit-norm random embeddings.
+
+    One chunk per doc keeps chunk_count == doc_count == N which makes
+    the post-rebuild assertions simple.
+    """
+    vecs = rng.standard_normal((count, DIM)).astype(np.float32)
+    vecs /= np.linalg.norm(vecs, axis=1, keepdims=True).clip(min=1e-12)
+    return [
+        {
+            "path": f"probe/doc_{start + i}",
+            "title": f"doc_{start + i}",
+            "chunks": [f"synthetic body {start + i} for rebuild scaling probe"],
+            "embeddings": [vecs[i].tolist()],
+            "source_type": "text",
+        }
+        for i in range(count)
+    ]
+
+
+def _measure_rebuild(store: VstashStore, repeats: int) -> list[float]:
+    """Run ``_rebuild_snapvec_from_vec_chunks`` `repeats` times and return
+    per-call wall clock in seconds."""
+    samples: list[float] = []
+    for _ in range(repeats):
+        gc.collect()
+        t0 = time.perf_counter()
+        store._rebuild_snapvec_from_vec_chunks()
+        samples.append(time.perf_counter() - t0)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoints",
+        type=int,
+        nargs="+",
+        default=DEFAULT_CHECKPOINTS,
+        help="Cumulative chunk counts at which to measure rebuild.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of rebuild calls per checkpoint (reports median).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/results/snapvec_rebuild_scaling_probe.json"),
+    )
+    parser.add_argument(
+        "--backend",
+        default="snapvec",
+        choices=("snapvec", "snapvec-ivfpq"),
+        help="Which snapvec variant to probe.",
+    )
+    parser.add_argument(
+        "--fill-batch",
+        type=int,
+        default=5_000,
+        help="Batch size for seeding the store (smaller = more progress ticks).",
+    )
+    parser.add_argument(
+        "--label",
+        default=None,
+        help="Optional label written to the result JSON (e.g. 'before', 'after').",
+    )
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(seed=0xC0FFEE)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / f"{args.backend}.db"
+        store = VstashStore(str(db_path), embedding_dim=DIM, vector_backend=args.backend)
+
+        measurements: list[dict] = []
+        last_n = 0
+        for target in args.checkpoints:
+            delta = target - last_n
+            # Seed in sub-batches so memory pressure stays sane at large N.
+            cursor = 0
+            while cursor < delta:
+                chunk = min(args.fill_batch, delta - cursor)
+                store.add_documents_batch(_gen_docs(last_n + cursor, chunk, rng))
+                cursor += chunk
+            last_n = target
+
+            n_at_probe = store.stats().chunks
+            samples = _measure_rebuild(store, args.repeats)
+
+            cell = {
+                "n_at_probe": n_at_probe,
+                "rebuild_seconds_p50": round(statistics.median(samples), 3),
+                "rebuild_seconds_min": round(min(samples), 3),
+                "rebuild_seconds_max": round(max(samples), 3),
+                "rebuild_seconds_mean": round(statistics.mean(samples), 3),
+                "repeats": args.repeats,
+            }
+            measurements.append(cell)
+
+            print(
+                f"N={n_at_probe:>7}  rebuild p50={cell['rebuild_seconds_p50']:>7.3f}s "
+                f"min={cell['rebuild_seconds_min']:>7.3f}s "
+                f"max={cell['rebuild_seconds_max']:>7.3f}s",
+                flush=True,
+            )
+
+        store.close()
+
+    result = {
+        "label": args.label,
+        "backend": args.backend,
+        "dim": DIM,
+        "checkpoints": measurements,
+    }
+    args.output.write_text(json.dumps(result, indent=2))
+    print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    main()

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -534,9 +534,7 @@ class VstashStore:
         # do not silently lose vectors from the last write burst.
         if loaded_clean and self._vector_backend == "snapvec" and self._snap is not None:
             try:
-                sqlite_n = int(
-                    self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0]
-                )
+                sqlite_n = int(self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0])
             except sqlite3.Error:
                 sqlite_n = 0
             snap_n = len(self._snap)
@@ -555,28 +553,59 @@ class VstashStore:
         Used for crash recovery when ``_init_snapvec`` detects staleness
         and as the ``fit_snapvec`` analogue to ``fit_ivfpq``. Returns the
         number of vectors indexed.
+
+        Two O(N^2) patterns are avoided here (issue #252):
+
+        1. ``LIMIT ? OFFSET ?`` pagination on ``vec_chunks`` rescans
+           ``offset`` rows on every call. With N/batch_size pages the
+           total scan cost is O(N^2/batch_size). Keyset pagination
+           (``WHERE rowid > last``) is O(N) total.
+        2. ``SnapIndex.add_batch`` does ``np.vstack([self._indices,
+           batch_idx])`` internally (snapvec/_index.py:206), so calling
+           it N/batch_size times copies a growing buffer on each call.
+           Coalescing all (rowids, vectors) into a single final call
+           keeps the total memcpy at O(N).
+
+        Measured on 2026-04-22: N=100k rebuild dropped from 41.5s to
+        5.4s (7.65x) after the fix; scaling went from super-linear
+        (148x wall clock for 20x N) to near-linear (23x for 20x N).
+        See experiments/results/snapvec_rebuild_scaling_{before,after}.json.
         """
         if self._snap is None:
             raise RuntimeError("snapvec backend not initialised")
         self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
 
-        offset = 0
-        total = 0
+        # rowid >= 1 because chunks.id is INTEGER PRIMARY KEY AUTOINCREMENT
+        # and vec_chunks.rowid is fed from chunks.id; starting at 0 matches
+        # all real rows on the first page.
+        last_rowid = 0
+        rowid_parts: list[list[int]] = []
+        vector_parts: list[np.ndarray] = []
         while True:
             rows = self._conn.execute(
-                "SELECT rowid, embedding FROM vec_chunks ORDER BY rowid "
-                "LIMIT ? OFFSET ?",
-                [batch_size, offset],
+                "SELECT rowid, embedding FROM vec_chunks WHERE rowid > ? ORDER BY rowid LIMIT ?",
+                [last_rowid, batch_size],
             ).fetchall()
             if not rows:
                 break
-            rowids = [int(r["rowid"]) for r in rows]
-            vectors = np.asarray(
-                [_deserialize(r["embedding"]) for r in rows], dtype=np.float32
+            rowid_parts.append([int(r["rowid"]) for r in rows])
+            vector_parts.append(
+                np.asarray([_deserialize(r["embedding"]) for r in rows], dtype=np.float32)
             )
-            self._snap.add_batch(rowids, vectors)
-            offset += batch_size
-            total += len(rows)
+            last_rowid = int(rows[-1]["rowid"])
+
+        total = sum(len(p) for p in rowid_parts)
+        if total:
+            all_rowids = [rid for part in rowid_parts for rid in part]
+            all_vectors = (
+                vector_parts[0] if len(vector_parts) == 1 else np.concatenate(vector_parts, axis=0)
+            )
+            # Drop the per-batch list once coalesced so the peak RSS is bounded
+            # by (concat buffer + SnapIndex internal copy) instead of 3x the
+            # final index size. Matters at N >> 500k (f32 x 384 dim ~= 1.5 GB
+            # per copy).
+            vector_parts.clear()
+            self._snap.add_batch(all_rowids, all_vectors)
 
         # Immediately persist the rebuilt index so subsequent opens do
         # not re-run the rebuild unnecessarily.
@@ -1259,9 +1288,7 @@ class VstashStore:
 
                     if self._snap is not None:
                         pending_snap_rowids.extend(rowids)
-                        pending_snap_vecs.append(
-                            np.asarray(embeddings, dtype=np.float32)
-                        )
+                        pending_snap_vecs.append(np.asarray(embeddings, dtype=np.float32))
 
                 # ONE coalesced add_batch for the whole transaction's
                 # worth of vectors instead of one per document. Avoids
@@ -1867,12 +1894,7 @@ class VstashStore:
         # filter is rare enough that the simpler skip is preferable.
         _cache_key: int | None = None
         _cache_max = self._cache_config.query_cache_size
-        if (
-            _cache_max > 0
-            and _tracer is None
-            and not explain
-            and not exact_match
-        ):
+        if _cache_max > 0 and _tracer is None and not explain and not exact_match:
             _cache_key = self._compute_search_cache_key(
                 query_embedding=query_embedding,
                 query_text=query_text,

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -567,9 +567,10 @@ class VstashStore:
            keeps the total memcpy at O(N).
 
         Measured on 2026-04-22: N=100k rebuild dropped from 41.5s to
-        5.4s (7.65x) after the fix; scaling went from super-linear
-        (148x wall clock for 20x N) to near-linear (23x for 20x N).
-        See experiments/results/snapvec_rebuild_scaling_{before,after}.json.
+        4.0s (10.3x) after the fix (keyset + coalesce + frombuffer).
+        Scaling went from super-linear (148x wall clock for 20x N) to
+        near-linear (24x for 20x N). See experiments/results/
+        snapvec_rebuild_scaling_{before,after}.json.
         """
         if self._snap is None:
             raise RuntimeError("snapvec backend not initialised")
@@ -589,8 +590,13 @@ class VstashStore:
             if not rows:
                 break
             rowid_parts.append([int(r["rowid"]) for r in rows])
+            # np.frombuffer avoids the Python-list intermediate that
+            # struct.unpack + list() pays inside ``_deserialize``. At
+            # N=100k with dim=384 the fill path allocates ~15M Python
+            # floats otherwise; reading the blob straight into a float32
+            # array drops that to a single memcpy per row.
             vector_parts.append(
-                np.asarray([_deserialize(r["embedding"]) for r in rows], dtype=np.float32)
+                np.stack([np.frombuffer(r["embedding"], dtype=np.float32) for r in rows])
             )
             last_rowid = int(rows[-1]["rowid"])
 
@@ -600,11 +606,13 @@ class VstashStore:
             all_vectors = (
                 vector_parts[0] if len(vector_parts) == 1 else np.concatenate(vector_parts, axis=0)
             )
-            # Drop the per-batch list once coalesced so the peak RSS is bounded
-            # by (concat buffer + SnapIndex internal copy) instead of 3x the
-            # final index size. Matters at N >> 500k (f32 x 384 dim ~= 1.5 GB
-            # per copy).
+            # Drop the per-batch lists once coalesced so the peak RSS is
+            # bounded by (concat buffer + SnapIndex internal copy) instead
+            # of 3x the final index size. Matters at N >> 500k (f32 x 384
+            # dim ~= 1.5 GB per copy). rowid_parts is tiny relative to
+            # vectors, cleared for consistency.
             vector_parts.clear()
+            rowid_parts.clear()
             self._snap.add_batch(all_rowids, all_vectors)
 
         # Immediately persist the rebuilt index so subsequent opens do


### PR DESCRIPTION
## Summary

First Tier-1 item from issue #252 (O(N^2) audit) landed.

Two compounding quadratics in `VstashStore._rebuild_snapvec_from_vec_chunks` (called on crash recovery and by the public `fit_snapvec` helper):

1. **OFFSET pagination** on `vec_chunks`. SQLite rescans `offset` rows per page, so N/batch_size pages cost O(N^2/batch_size) total. Replaced with keyset pagination (`WHERE rowid > last`).
2. **Per-page `SnapIndex.add_batch`**. `snapvec/_index.py:206` does `np.vstack([self._indices, batch_idx])` on every call, copying the growing buffer. Replaced with a single coalesced `add_batch` at the end of the loop (same pattern as #251 used inside `add_documents_batch`).

The hypothesis in #252 only flagged the vstack. When the vstack fix alone failed to move the needle, the bench surfaced the OFFSET pagination as the second quadratic. Both fixed here.

## Numbers

From `experiments/snapvec_rebuild_scaling_probe.py` (new in this PR, following the #252 process):

| N       | before    | after    | speedup |
|---------|-----------|----------|---------|
| 5k      |   0.28s   |  0.23s   |   1.2x  |
| 10k     |   0.84s   |  0.48s   |   1.7x  |
| 25k     |   2.17s   |  1.64s   |   1.3x  |
| 50k     |   8.00s   |  2.53s   |   3.2x  |
| 100k    |  41.58s   |  5.43s   |   7.7x  |

Shape goes from super-linear (148x wall clock for 20x N) to nearly linear (24x for 20x N). Raw JSON in `experiments/results/snapvec_rebuild_scaling_{before,after}.json`.

## Audit output

See the Tier-1 audit table below for the other three candidates still open:

| Candidate | Verdict | Next action |
|---|---|---|
| `ingest.ingest_directory` | CLEAN (already routes through `add_documents_batch`) | none |
| `store.reindex` | O(N^2) confirmed on inspection | separate PR; same coalescing pattern applies |
| `watch.py` | O(N^2) confirmed (burst events = per-doc path) | separate PR; needs queue redesign to coalesce |
| `store._rebuild_snapvec_from_vec_chunks` | **fixed here** | closed for this track |

## Code review

Ran `code-reviewer` subagent against the diff per `~/.claude/CLAUDE.md` rule. Verdict: OK to merge. Flagged `vector_parts.clear()` as a nice-to-have to bound peak RSS at N >> 500k -- applied in the same commit. Keyset pagination `rowid > 0` is safe because `chunks.id` is `INTEGER PRIMARY KEY AUTOINCREMENT` (starts at 1). Full review in the commit trail.

## Test plan

- [x] `pytest tests/test_snapvec_backend.py tests/test_store.py` passes (115 tests)
- [x] `ruff check` + `ruff format --check` clean
- [x] Bench rerun confirms the claimed speedup
- [x] Code review pass per global CLAUDE.md rule

Refs #252 Tier 1.