### PR TITLE
perf(#265): fix O(N^2) in store.reindex

### DIFF
--- a/experiments/results/snapvec_reindex_scaling_after.json
+++ b/experiments/results/snapvec_reindex_scaling_after.json
@@ -1,0 +1,55 @@
+{
+  "label": "after",
+  "backend": "snapvec",
+  "dim": 384,
+  "checkpoints": [
+    {
+      "n_at_probe": 5000,
+      "reindex_seconds_p50": 0.201,
+      "reindex_seconds_min": 0.2,
+      "reindex_seconds_max": 0.206,
+      "reindex_seconds_mean": 0.202,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 10000,
+      "reindex_seconds_p50": 0.428,
+      "reindex_seconds_min": 0.426,
+      "reindex_seconds_max": 0.439,
+      "reindex_seconds_mean": 0.43,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 25000,
+      "reindex_seconds_p50": 1.104,
+      "reindex_seconds_min": 1.076,
+      "reindex_seconds_max": 1.121,
+      "reindex_seconds_mean": 1.101,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 50000,
+      "reindex_seconds_p50": 2.274,
+      "reindex_seconds_min": 2.263,
+      "reindex_seconds_max": 2.304,
+      "reindex_seconds_mean": 2.278,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 100000,
+      "reindex_seconds_p50": 4.685,
+      "reindex_seconds_min": 4.627,
+      "reindex_seconds_max": 4.766,
+      "reindex_seconds_mean": 4.694,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 200000,
+      "reindex_seconds_p50": 10.694,
+      "reindex_seconds_min": 10.542,
+      "reindex_seconds_max": 11.115,
+      "reindex_seconds_mean": 10.794,
+      "repeats": 5
+    }
+  ]
+}

--- a/experiments/results/snapvec_reindex_scaling_before.json
+++ b/experiments/results/snapvec_reindex_scaling_before.json
@@ -1,0 +1,55 @@
+{
+  "label": "before",
+  "backend": "snapvec",
+  "dim": 384,
+  "checkpoints": [
+    {
+      "n_at_probe": 5000,
+      "reindex_seconds_p50": 0.216,
+      "reindex_seconds_min": 0.214,
+      "reindex_seconds_max": 0.226,
+      "reindex_seconds_mean": 0.218,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 10000,
+      "reindex_seconds_p50": 0.432,
+      "reindex_seconds_min": 0.428,
+      "reindex_seconds_max": 0.437,
+      "reindex_seconds_mean": 0.432,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 25000,
+      "reindex_seconds_p50": 1.108,
+      "reindex_seconds_min": 1.089,
+      "reindex_seconds_max": 1.116,
+      "reindex_seconds_mean": 1.103,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 50000,
+      "reindex_seconds_p50": 2.304,
+      "reindex_seconds_min": 2.278,
+      "reindex_seconds_max": 2.311,
+      "reindex_seconds_mean": 2.299,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 100000,
+      "reindex_seconds_p50": 5.235,
+      "reindex_seconds_min": 5.199,
+      "reindex_seconds_max": 5.282,
+      "reindex_seconds_mean": 5.24,
+      "repeats": 5
+    },
+    {
+      "n_at_probe": 200000,
+      "reindex_seconds_p50": 15.962,
+      "reindex_seconds_min": 12.63,
+      "reindex_seconds_max": 16.183,
+      "reindex_seconds_mean": 14.723,
+      "repeats": 5
+    }
+  ]
+}

--- a/experiments/snapvec_reindex_scaling_probe.py
+++ b/experiments/snapvec_reindex_scaling_probe.py
@@ -1,0 +1,186 @@
+"""
+snapvec_reindex_scaling_probe.py -- isolate the cost of
+``VstashStore.reindex`` as a function of N on the snapvec backend.
+
+Motivation. Issue #265 (spun off from #252 Tier 1) flags ``reindex``
+as likely quadratic for the same two reasons #264 just fixed in
+``_rebuild_snapvec_from_vec_chunks``:
+
+1. ``LIMIT ? OFFSET ?`` pagination on ``chunks`` (store.py:4293).
+   SQLite rescans ``offset`` rows per page so N/batch_size pages
+   cost O(N^2/batch_size) reads.
+2. ``self._snap.add_batch(ids, embeddings)`` called per page
+   (store.py:4313). ``SnapIndex.add_batch`` does np.vstack on the
+   growing index internally (snapvec/_index.py:206), so N/batch_size
+   calls copy a growing buffer.
+
+Fill the store with N random-vector docs via ``add_documents_batch``
+(one snapvec add_batch for the whole fill, cheap), then call
+``store.reindex(identity_embed_fn, new_dim=DIM)`` and record wall
+clock. Sweep N across a geometric ladder.
+
+The embed_fn is an identity that returns the same DIM-dimensional
+vectors so we measure the store-side work (SQL + snapvec rebuild),
+not embedding latency. new_dim stays equal to the current dim so
+the test exercises the re-embed loop without changing vec_chunks'
+schema dimensionality.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import os
+import statistics
+import tempfile
+import time
+from pathlib import Path
+
+import numpy as np
+
+from vstash.store import VstashStore
+
+
+DEFAULT_CHECKPOINTS = [5_000, 10_000, 25_000, 50_000, 100_000]
+DIM = 384
+
+
+def _gen_docs(start: int, count: int, rng: np.random.Generator) -> list[dict]:
+    """Generate `count` synthetic docs with unit-norm random embeddings."""
+    vecs = rng.standard_normal((count, DIM)).astype(np.float32)
+    vecs /= np.linalg.norm(vecs, axis=1, keepdims=True).clip(min=1e-12)
+    return [
+        {
+            "path": f"probe/doc_{start + i}",
+            "title": f"doc_{start + i}",
+            "chunks": [f"synthetic body {start + i} for reindex scaling probe"],
+            "embeddings": [vecs[i].tolist()],
+            "source_type": "text",
+        }
+        for i in range(count)
+    ]
+
+
+def _make_identity_embed_fn(rng: np.random.Generator):
+    """Return an embed_fn that yields deterministic random vectors.
+
+    ``store.reindex`` calls ``embed_fn(texts)`` per SQL batch. For
+    the probe we do NOT want to measure real embedding latency, so
+    we emit deterministic random vectors keyed off the probe RNG.
+    The content of the vectors doesn't matter -- only the store
+    write path is being measured.
+    """
+
+    def embed_fn(texts: list[str]) -> list[list[float]]:
+        arr = rng.standard_normal((len(texts), DIM)).astype(np.float32)
+        arr /= np.linalg.norm(arr, axis=1, keepdims=True).clip(min=1e-12)
+        return arr.tolist()
+
+    return embed_fn
+
+
+def _measure_reindex(store: VstashStore, rng: np.random.Generator, repeats: int) -> list[float]:
+    """Run ``store.reindex`` `repeats` times and return per-call wall clock."""
+    samples: list[float] = []
+    for _ in range(repeats):
+        embed_fn = _make_identity_embed_fn(rng)
+        gc.collect()
+        t0 = time.perf_counter()
+        store.reindex(embed_fn, new_dim=DIM)
+        samples.append(time.perf_counter() - t0)
+    return samples
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checkpoints",
+        type=int,
+        nargs="+",
+        default=DEFAULT_CHECKPOINTS,
+        help="Cumulative chunk counts at which to measure reindex.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=3,
+        help="Number of reindex calls per checkpoint (reports median).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/results/snapvec_reindex_scaling_probe.json"),
+    )
+    parser.add_argument(
+        "--backend",
+        default="snapvec",
+        choices=("sqlite-vec", "snapvec", "snapvec-ivfpq"),
+        help="Which backend to probe.",
+    )
+    parser.add_argument(
+        "--fill-batch",
+        type=int,
+        default=5_000,
+        help="Batch size for seeding the store (smaller = more progress ticks).",
+    )
+    parser.add_argument(
+        "--label",
+        default=None,
+        help="Optional label written to the result JSON (e.g. 'before', 'after').",
+    )
+    args = parser.parse_args()
+
+    rng = np.random.default_rng(seed=0xCAFE)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / f"{args.backend}.db"
+        store = VstashStore(str(db_path), embedding_dim=DIM, vector_backend=args.backend)
+
+        measurements: list[dict] = []
+        last_n = 0
+        for target in args.checkpoints:
+            delta = target - last_n
+            cursor = 0
+            while cursor < delta:
+                chunk = min(args.fill_batch, delta - cursor)
+                store.add_documents_batch(_gen_docs(last_n + cursor, chunk, rng))
+                cursor += chunk
+            last_n = target
+
+            n_at_probe = store.stats().chunks
+            samples = _measure_reindex(store, rng, args.repeats)
+
+            cell = {
+                "n_at_probe": n_at_probe,
+                "reindex_seconds_p50": round(statistics.median(samples), 3),
+                "reindex_seconds_min": round(min(samples), 3),
+                "reindex_seconds_max": round(max(samples), 3),
+                "reindex_seconds_mean": round(statistics.mean(samples), 3),
+                "repeats": args.repeats,
+            }
+            measurements.append(cell)
+
+            print(
+                f"N={n_at_probe:>7}  reindex p50={cell['reindex_seconds_p50']:>7.3f}s "
+                f"min={cell['reindex_seconds_min']:>7.3f}s "
+                f"max={cell['reindex_seconds_max']:>7.3f}s",
+                flush=True,
+            )
+
+        store.close()
+
+    result = {
+        "label": args.label,
+        "backend": args.backend,
+        "dim": DIM,
+        "checkpoints": measurements,
+    }
+    args.output.write_text(json.dumps(result, indent=2))
+    print(f"\nwrote {args.output}")
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+    main()

--- a/experiments/snapvec_reindex_scaling_probe.py
+++ b/experiments/snapvec_reindex_scaling_probe.py
@@ -19,10 +19,12 @@ Fill the store with N random-vector docs via ``add_documents_batch``
 ``store.reindex(identity_embed_fn, new_dim=DIM)`` and record wall
 clock. Sweep N across a geometric ladder.
 
-The embed_fn is an identity that returns the same DIM-dimensional
-vectors so we measure the store-side work (SQL + snapvec rebuild),
-not embedding latency. new_dim stays equal to the current dim so
-the test exercises the re-embed loop without changing vec_chunks'
+The embed_fn returns deterministic random unit vectors per batch
+(seeded from the probe RNG). It is NOT a true identity -- real
+embedding latency is skipped on purpose, but a small per-call
+RNG + normalization cost is paid so that the allocation pattern
+is realistic. ``new_dim`` stays equal to the current dim so the
+test exercises the re-embed loop without changing vec_chunks'
 schema dimensionality.
 """
 

--- a/tests/test_snapvec_backend.py
+++ b/tests/test_snapvec_backend.py
@@ -153,6 +153,40 @@ class TestSnapvecReindex:
         assert count == 5
         assert len(populated_snap_store._snap) == 5
 
+    def test_reindex_handles_more_than_one_batch(self, tmp_path):
+        """Reindex must paginate correctly past a single batch.
+
+        Regression guard for issue #265: the keyset pagination fix
+        replaced ``LIMIT ? OFFSET ?`` with ``WHERE id > ? ORDER BY id
+        LIMIT ?`` and coalesced per-batch ``snap.add_batch`` into one
+        final call. This test ensures both loops advance past batch 1
+        and that the final snap index ends with exactly N vectors.
+        """
+        db = str(tmp_path / "multibatch.db")
+        store = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+
+        # Use a batch_size of 10 and seed >> 10 chunks so the reindex
+        # loop must issue multiple pages.
+        n_chunks = 53
+        rng = np.random.default_rng(0xBEEF)
+        for i in range(n_chunks):
+            store.add_document(
+                path=f"/test/doc_{i}.md",
+                title=f"doc {i}",
+                chunks=[f"chunk body {i}"],
+                embeddings=[rng.standard_normal(DIM).tolist()],
+            )
+        assert len(store._snap) == n_chunks
+
+        def fake_embed(texts):
+            inner = np.random.default_rng(0xCAFE)
+            return [inner.standard_normal(DIM).tolist() for _ in texts]
+
+        count = store.reindex(fake_embed, new_dim=DIM, batch_size=10)
+        assert count == n_chunks
+        assert len(store._snap) == n_chunks
+        store.close()
+
 
 class TestSnapvecDimMismatch:
     def test_dim_mismatch_rebuilds(self, tmp_path):

--- a/tests/test_snapvec_backend.py
+++ b/tests/test_snapvec_backend.py
@@ -154,38 +154,138 @@ class TestSnapvecReindex:
         assert len(populated_snap_store._snap) == 5
 
     def test_reindex_handles_more_than_one_batch(self, tmp_path):
-        """Reindex must paginate correctly past a single batch.
+        """Reindex must paginate past a single batch AND avoid the two
+        O(N^2) patterns fixed in issue #265.
 
-        Regression guard for issue #265: the keyset pagination fix
-        replaced ``LIMIT ? OFFSET ?`` with ``WHERE id > ? ORDER BY id
-        LIMIT ?`` and coalesced per-batch ``snap.add_batch`` into one
-        final call. This test ensures both loops advance past batch 1
-        and that the final snap index ends with exactly N vectors.
+        Counting chunks alone would not catch a regression to the old
+        OFFSET + per-page behaviour because the final state is the same.
+        We observe the SQL stream to assert keyset pagination and wrap
+        ``snap.add_batch`` to assert coalescing.
         """
         db = str(tmp_path / "multibatch.db")
-        store = VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+        with VstashStore(db, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4) as store:
+            n_chunks = 53
+            rng = np.random.default_rng(0xBEEF)
+            for i in range(n_chunks):
+                store.add_document(
+                    path=f"/test/doc_{i}.md",
+                    title=f"doc {i}",
+                    chunks=[f"chunk body {i}"],
+                    embeddings=[rng.standard_normal(DIM).tolist()],
+                )
+            assert len(store._snap) == n_chunks
 
-        # Use a batch_size of 10 and seed >> 10 chunks so the reindex
-        # loop must issue multiple pages.
-        n_chunks = 53
-        rng = np.random.default_rng(0xBEEF)
-        for i in range(n_chunks):
-            store.add_document(
-                path=f"/test/doc_{i}.md",
-                title=f"doc {i}",
-                chunks=[f"chunk body {i}"],
-                embeddings=[rng.standard_normal(DIM).tolist()],
+            def fake_embed(texts):
+                inner = np.random.default_rng(0xCAFE)
+                return [inner.standard_normal(DIM).tolist() for _ in texts]
+
+            statements: list[str] = []
+            store._conn.set_trace_callback(statements.append)
+
+            # reindex re-creates ``self._snap`` with a fresh SnapIndex on
+            # entry (store.py around line 4276), so a monkey-patch on the
+            # pre-reindex instance would be discarded. Patch the class
+            # method for the duration of the call instead.
+            from snapvec import SnapIndex
+
+            original_add_batch = SnapIndex.add_batch
+            add_batch_calls: list[int] = []
+
+            def counting_add_batch(self, ids, vectors):
+                add_batch_calls.append(len(ids))
+                return original_add_batch(self, ids, vectors)
+
+            SnapIndex.add_batch = counting_add_batch  # type: ignore[method-assign]
+
+            try:
+                count = store.reindex(fake_embed, new_dim=DIM, batch_size=10)
+            finally:
+                SnapIndex.add_batch = original_add_batch  # type: ignore[method-assign]
+                store._conn.set_trace_callback(None)
+
+            assert count == n_chunks
+            assert len(store._snap) == n_chunks
+
+            import re
+
+            # ``chunk_offset`` is a column in sqlite-vec's internal
+            # vec_chunks_rowids table and would false-positive a plain
+            # substring match. Look for OFFSET as a SQL keyword instead.
+            offset_kw = re.compile(r"\bOFFSET\b", re.IGNORECASE)
+            chunks_selects = [
+                s for s in statements if re.search(r"FROM\s+chunks\b", s, re.IGNORECASE)
+            ]
+            assert not any(offset_kw.search(s) for s in chunks_selects), (
+                "reindex must use keyset pagination, not LIMIT ? OFFSET ?"
             )
-        assert len(store._snap) == n_chunks
+            assert any("WHERE id >" in s for s in chunks_selects), (
+                "expected keyset pagination with `WHERE id > ?`"
+            )
 
-        def fake_embed(texts):
-            inner = np.random.default_rng(0xCAFE)
-            return [inner.standard_normal(DIM).tolist() for _ in texts]
+            assert len(add_batch_calls) == 1, (
+                f"snap.add_batch should be coalesced into one call, got {len(add_batch_calls)}"
+            )
+            assert add_batch_calls[0] == n_chunks
 
-        count = store.reindex(fake_embed, new_dim=DIM, batch_size=10)
-        assert count == n_chunks
-        assert len(store._snap) == n_chunks
-        store.close()
+    def test_reindex_rejects_nonpositive_batch_size(self, tmp_path):
+        """``batch_size <= 0`` must raise BEFORE dropping vec_chunks.
+
+        Regression guard: the keyset loop terminates immediately on
+        ``batch_size=0``, and if we had already dropped vec_chunks the
+        store would be silently wiped. The validation lives at the top
+        of reindex() precisely to prevent that class of data loss.
+        """
+        with VstashStore(
+            str(tmp_path / "bad_batch.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec",
+            snapvec_bits=4,
+        ) as store:
+            store.add_document(
+                path="/x.md",
+                title="x",
+                chunks=["x"],
+                embeddings=[np.random.default_rng(0).standard_normal(DIM).tolist()],
+            )
+
+            def embed_fn(texts):
+                return [[0.0] * DIM for _ in texts]
+
+            with pytest.raises(ValueError, match="batch_size must be >= 1"):
+                store.reindex(embed_fn, new_dim=DIM, batch_size=0)
+
+            # vec_chunks must still contain the original row.
+            assert len(store._snap) == 1
+
+    def test_reindex_rejects_embed_fn_length_mismatch(self, tmp_path):
+        """``embed_fn`` that returns wrong count must fail fast.
+
+        Without the length check, ``executemany`` would silently truncate
+        against the shorter zip; the store would end up with a partial
+        vector index while ``reindex`` reports success. The validation
+        inside the per-batch loop raises instead.
+        """
+        with VstashStore(
+            str(tmp_path / "bad_embed.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec",
+            snapvec_bits=4,
+        ) as store:
+            for i in range(3):
+                store.add_document(
+                    path=f"/doc_{i}.md",
+                    title=f"doc {i}",
+                    chunks=[f"text {i}"],
+                    embeddings=[np.random.default_rng(i).standard_normal(DIM).tolist()],
+                )
+
+            def short_embed(texts):
+                # Drop one: simulate a buggy embed_fn that silently
+                # loses an item.
+                return [[0.0] * DIM for _ in texts[:-1]]
+
+            with pytest.raises(ValueError, match="embed_fn returned"):
+                store.reindex(short_embed, new_dim=DIM, batch_size=256)
 
 
 class TestSnapvecDimMismatch:

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -4299,7 +4299,16 @@ class VstashStore:
 
         Returns:
             Number of chunks re-embedded.
+
+        Raises:
+            ValueError: If ``batch_size`` is not a positive integer.
         """
+        # Fail before we DROP vec_chunks. A non-positive batch_size would
+        # make the keyset loop below terminate immediately after dropping
+        # the table, silently wiping the vector index.
+        if batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+
         with self._write_lock:
             # Count total chunks
             total = self._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
@@ -4346,6 +4355,16 @@ class VstashStore:
                     ids = [row["id"] for row in rows]
                     embeddings = embed_fn(texts)
 
+                    # Fail fast if embed_fn returns the wrong count. Without
+                    # this guard, executemany would silently truncate to the
+                    # shorter zip and leave the store with a partial vec
+                    # index while ``processed`` still counts all rows.
+                    if len(embeddings) != len(ids):
+                        raise ValueError(
+                            f"embed_fn returned {len(embeddings)} embeddings "
+                            f"for {len(ids)} texts; must match 1:1"
+                        )
+
                     self._conn.executemany(
                         "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
                         [(cid, _serialize(emb)) for cid, emb in zip(ids, embeddings)],
@@ -4361,15 +4380,20 @@ class VstashStore:
                         progress_cb(processed, total)
 
                 if self._snap is not None and snap_rowid_parts:
-                    all_rowids = [rid for part in snap_rowid_parts for rid in part]
+                    all_rowids = (
+                        snap_rowid_parts[0]
+                        if len(snap_rowid_parts) == 1
+                        else [rid for part in snap_rowid_parts for rid in part]
+                    )
                     all_vectors = (
                         snap_vector_parts[0]
                         if len(snap_vector_parts) == 1
                         else np.concatenate(snap_vector_parts, axis=0)
                     )
-                    # Drop per-batch list once coalesced so peak RSS is
+                    # Drop per-batch lists once coalesced so peak RSS is
                     # bounded during the final add_batch allocation.
                     snap_vector_parts.clear()
+                    snap_rowid_parts.clear()
                     self._snap.add_batch(all_rowids, all_vectors)
 
                 self._conn.commit()

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -4317,13 +4317,27 @@ class VstashStore:
                 if self._snap is not None:
                     self._snap = SnapIndex(dim=new_dim, bits=self._snapvec_bits, seed=0)
 
-                # Re-embed in batches
+                # Re-embed in batches. Two O(N^2) traps avoided here
+                # (issue #265, sibling to #264):
+                #
+                # 1. Keyset pagination (WHERE id > last_id) instead of
+                #    LIMIT ? OFFSET ?. SQLite rescans `offset` rows per
+                #    page, so N/batch_size pages cost O(N^2/batch_size).
+                # 2. Snapvec add_batch is coalesced into a single call
+                #    after the loop. SnapIndex.add_batch does np.vstack
+                #    on the growing buffer internally (snapvec/_index.py
+                #    :206), so per-page calls copy O(current) each time.
+                #
+                # chunks.id is INTEGER PRIMARY KEY AUTOINCREMENT (>=1),
+                # so seeding last_id=0 matches all rows on the first page.
                 processed = 0
-                offset = 0
-                while offset < total:
+                last_id = 0
+                snap_rowid_parts: list[list[int]] = []
+                snap_vector_parts: list[np.ndarray] = []
+                while True:
                     rows = self._conn.execute(
-                        "SELECT id, text FROM chunks ORDER BY id LIMIT ? OFFSET ?",
-                        [batch_size, offset],
+                        "SELECT id, text FROM chunks WHERE id > ? ORDER BY id LIMIT ?",
+                        [last_id, batch_size],
                     ).fetchall()
                     if not rows:
                         break
@@ -4332,20 +4346,31 @@ class VstashStore:
                     ids = [row["id"] for row in rows]
                     embeddings = embed_fn(texts)
 
-                    for chunk_id, embedding in zip(ids, embeddings):
-                        self._conn.execute(
-                            "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
-                            [chunk_id, _serialize(embedding)],
-                        )
+                    self._conn.executemany(
+                        "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
+                        [(cid, _serialize(emb)) for cid, emb in zip(ids, embeddings)],
+                    )
 
-                    # Add batch to snapvec index
                     if self._snap is not None:
-                        self._snap.add_batch(ids, np.array(embeddings, dtype=np.float32))
+                        snap_rowid_parts.append(ids)
+                        snap_vector_parts.append(np.asarray(embeddings, dtype=np.float32))
 
                     processed += len(rows)
-                    offset += batch_size
+                    last_id = ids[-1]
                     if progress_cb:
                         progress_cb(processed, total)
+
+                if self._snap is not None and snap_rowid_parts:
+                    all_rowids = [rid for part in snap_rowid_parts for rid in part]
+                    all_vectors = (
+                        snap_vector_parts[0]
+                        if len(snap_vector_parts) == 1
+                        else np.concatenate(snap_vector_parts, axis=0)
+                    )
+                    # Drop per-batch list once coalesced so peak RSS is
+                    # bounded during the final add_batch allocation.
+                    snap_vector_parts.clear()
+                    self._snap.add_batch(all_rowids, all_vectors)
 
                 self._conn.commit()
                 self._invalidate_idf_cache()


### PR DESCRIPTION
## Summary

Second Tier-1 item from #252 landed. Sibling to #264 which fixed the same two-headed quadratic in `_rebuild_snapvec_from_vec_chunks`.

Two compounding O(N^2) patterns in `VstashStore.reindex`:

1. **OFFSET pagination** on `chunks`. Replaced with keyset (`WHERE id > ? ORDER BY id LIMIT ?`).
2. **Per-page `SnapIndex.add_batch`**. Coalesced into one final call with all (ids, embeddings).

Drive-by cleanup: per-row `INSERT INTO vec_chunks` -> `executemany`.

## Numbers

5 repeats median, fresh tempdir per run, `experiments/snapvec_reindex_scaling_probe.py`:

| N       | before    | after    |
|---------|-----------|----------|
| 5k      |  0.22s    |  0.20s   |
| 10k     |  0.43s    |  0.43s   |
| 25k     |  1.11s    |  1.10s   |
| 50k     |  2.30s    |  2.27s   |
| 100k    |  5.24s    |  4.69s   |
| 200k    | 15.96s    | 10.69s   |

Shape 100k -> 200k: **before 3.05x, after 2.28x**. Near-linear tail restored. At N <= 50k the fix is not visible because embed_fn + SQLite inserts dominate the budget. This is a scale fix, not a micro-optimisation.

Raw JSON: `experiments/results/snapvec_reindex_scaling_{before,after}.json`.

## Regression guard

New test `tests/test_snapvec_backend.py::test_reindex_handles_more_than_one_batch`: 53 chunks through reindex with `batch_size=10` forces multi-page iteration so nobody swaps keyset back to OFFSET unnoticed.

## Code review

Ran `code-reviewer` subagent per global CLAUDE.md rule. Verdict: OK to merge. Verified:

- Keyset `WHERE id > 0` safe: `chunks.id` is `INTEGER PRIMARY KEY AUTOINCREMENT`, values start at 1.
- Rollback semantics preserved: `self._snap` is created fresh before the loop, so `rollback() + _reload_snapvec()` restores on failure. `_save_snapvec()` still only runs after `commit()`.
- `executemany` works on sqlite-vec's `vec0` virtual table (same pattern as `_rebuild_snapvec_from_vec_chunks` post-#264).
- Memory peak at N=1M is ~3x index size briefly during `np.concatenate` + internal vstack. Acceptable for a user-initiated cold path.

Suggested follow-up (not blocking): rollback-mid-embed test. Left as future work.

## Test plan

- [x] `pytest tests/test_snapvec_backend.py` (17 tests, +1 new regression)
- [x] `pytest tests/test_store.py tests/test_store_helpers.py` (112 tests)
- [x] `ruff check` + `ruff format --check` clean
- [x] Bench rerun confirms claimed shape

Refs #252 Tier 1. Closes #265.