### PR TITLE
perf(#266): batch-drain watch worker (4-5x burst speedup)

### DIFF
--- a/experiments/perf_watch_burst.py
+++ b/experiments/perf_watch_burst.py
@@ -1,0 +1,145 @@
+"""Probe: watch.py burst ingestion shape (issue #266).
+
+Goal: before fixing, confirm that the per-file ``ingest()`` path used by
+the watch worker scales super-linearly on the snapvec flat backend.
+The serialized queue in ``watch.py`` calls ``ingest(file)`` once per
+dropped file; each ``add_document`` pays ``SnapIndex.add_batch`` which
+internally vstacks against the growing buffer. For a burst of N files
+that is O(N^2) memcpy.
+
+Prints a per-N timing table for two shapes:
+- ``serialized``: N x ``store.add_document`` (matches current watch).
+- ``batched``:   one ``store.batch_mode() + add_documents_batch``
+                  (matches the fix route via ingest_batch).
+
+If the probe shows quadratic growth on serialized and near-linear on
+batched, the fix in watch.py is justified. If the shapes match, the
+hypothesis in #266 is incomplete -- stop, re-probe, do not write the
+fix (probe-first discipline from the 2026-04-22 audit lessons).
+
+Run: python -m experiments.perf_watch_burst [--backend snapvec|sqlite-vec]
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import tempfile
+import time
+
+from vstash.embed import embed_texts, get_embedding_dim
+from vstash.store import VstashStore
+
+MODEL = "BAAI/bge-small-en-v1.5"
+
+
+def _seed_embeddings(k: int = 16) -> list[list[float]]:
+    seed_texts = [f"seed embedding {i} for watch-burst probe" for i in range(k)]
+    return embed_texts(seed_texts, model_name=MODEL)
+
+
+def _make_docs(n: int, embeddings: list[list[float]]) -> list[dict]:
+    return [
+        {
+            "path": f"/probe/burst_doc_{i}.md",
+            "title": f"Burst Document {i}",
+            "chunks": [f"content of burst document {i} mentioning topic {i % 8}."],
+            "embeddings": [embeddings[i % len(embeddings)]],
+            "source_type": "markdown",
+        }
+        for i in range(n)
+    ]
+
+
+def _bench_serialized(docs: list[dict], dim: int, backend: str, rounds: int) -> float:
+    """Emulate the current watch worker: one add_document per file."""
+    latencies = []
+    for _ in range(rounds):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = VstashStore(
+                f"{tmp}/burst.db",
+                embedding_dim=dim,
+                vector_backend=backend,
+                snapvec_bits=4,
+            )
+            t0 = time.perf_counter()
+            for doc in docs:
+                store.add_document(
+                    path=doc["path"],
+                    title=doc["title"],
+                    chunks=doc["chunks"],
+                    embeddings=doc["embeddings"],
+                )
+            store.close()
+            latencies.append((time.perf_counter() - t0) * 1000)
+    return statistics.median(latencies)
+
+
+def _bench_batched(docs: list[dict], dim: int, backend: str, rounds: int) -> float:
+    """Emulate the fix: one add_documents_batch for the burst."""
+    latencies = []
+    for _ in range(rounds):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = VstashStore(
+                f"{tmp}/burst.db",
+                embedding_dim=dim,
+                vector_backend=backend,
+                snapvec_bits=4,
+            )
+            t0 = time.perf_counter()
+            with store.batch_mode(defer_fts=True):
+                store.add_documents_batch(docs)
+            store.close()
+            latencies.append((time.perf_counter() - t0) * 1000)
+    return statistics.median(latencies)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        choices=["sqlite-vec", "snapvec", "snapvec-ivfpq"],
+        default="snapvec",
+        help="Vector backend to probe (default: snapvec, the worst case).",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=[100, 300, 1000, 3000],
+        help="Burst sizes to sweep.",
+    )
+    parser.add_argument("--rounds", type=int, default=3, help="Runs per size (median).")
+    args = parser.parse_args()
+
+    dim = get_embedding_dim(MODEL)
+    embeddings = _seed_embeddings()
+
+    print(f"backend={args.backend}  model={MODEL}  dim={dim}  rounds={args.rounds}")
+    print(f"{'N':>6}  {'serialized (ms)':>16}  {'batched (ms)':>14}  {'speedup':>8}")
+    prev_ser = None
+    prev_n = None
+    for n in args.sizes:
+        docs = _make_docs(n, embeddings)
+        ser = _bench_serialized(docs, dim, args.backend, args.rounds)
+        bat = _bench_batched(docs, dim, args.backend, args.rounds)
+        speedup = ser / bat if bat > 0 else float("inf")
+        if prev_ser is not None and prev_n is not None:
+            ratio_n = n / prev_n
+            ratio_t = ser / prev_ser if prev_ser > 0 else float("inf")
+            shape = f"  (N x {ratio_n:.1f}, t x {ratio_t:.2f})"
+        else:
+            shape = ""
+        print(f"{n:>6}  {ser:>16.1f}  {bat:>14.1f}  {speedup:>7.1f}x{shape}")
+        prev_ser, prev_n = ser, n
+
+    print()
+    print("Reading the output:")
+    print("  - If serialized t grows quadratically with N (t ratio ~ N^2), the O(N^2)")
+    print("    hypothesis holds and the watcher fix is justified.")
+    print("  - If both shapes grow linearly, the hypothesis is incomplete -- stop and")
+    print("    re-probe (probe-first discipline from the 2026-04-22 audit).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ingest_batch.py
+++ b/tests/test_ingest_batch.py
@@ -1,0 +1,147 @@
+"""Tests for the ingest_batch helper (issue #266).
+
+The helper is the coalescing route shared by ``ingest_directory`` and
+the ``watch.py`` worker. Contracts under test:
+
+- N sources are routed through a single ``add_documents_batch`` call
+  inside one ``batch_mode(defer_fts=True)`` context (transaction +
+  deferred FTS + single snapvec vstack).
+- Per-file error isolation: one bad source does not kill the rest,
+  the bad one shows up as ``status="error"`` in its slot of the
+  output list and the remaining sources are ingested successfully.
+- Empty input is a no-op and returns an empty list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from tests.conftest import requires_sqlite_vec
+from vstash.config import VstashConfig
+from vstash.ingest import ingest_batch
+from vstash.store import VstashStore
+
+
+pytestmark = requires_sqlite_vec
+
+
+_PADDING = (
+    "This document has enough prose to survive the minimum-chunk "
+    "filter after markdown stripping and whitespace normalisation. "
+    "Without this padding the chunker reports an empty document and "
+    "the batch test sees status='empty' for every file, which masks "
+    "the coalescing contract we actually want to exercise."
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> str:
+    p = tmp_path / name
+    p.write_text(f"{body}\n\n{_PADDING}\n")
+    return str(p)
+
+
+class TestIngestBatchCoalescing:
+    """Phase 2 must hit one batch call inside one batch_mode context."""
+
+    def test_single_batch_call_for_many_files(
+        self,
+        tmp_path: Path,
+        sample_store: VstashStore,
+        sample_config: VstashConfig,
+        monkeypatch,
+    ) -> None:
+        sources = [
+            _write(tmp_path, f"doc_{i}.md", f"# Doc {i}\n\nContent for document {i}.")
+            for i in range(5)
+        ]
+
+        batch_calls: list[int] = []
+        batch_mode_calls: list[bool] = []
+        real_add_batch = sample_store.add_documents_batch
+        real_batch_mode = sample_store.batch_mode
+
+        def spy_add_batch(docs):
+            batch_calls.append(len(docs))
+            return real_add_batch(docs)
+
+        def spy_batch_mode(*, defer_fts: bool = False):
+            batch_mode_calls.append(defer_fts)
+            return real_batch_mode(defer_fts=defer_fts)
+
+        monkeypatch.setattr(sample_store, "add_documents_batch", spy_add_batch)
+        monkeypatch.setattr(sample_store, "batch_mode", spy_batch_mode)
+
+        results = ingest_batch(sources, sample_config, sample_store)
+
+        assert len(results) == 5
+        assert all(r.status == "ok" for r in results)
+        assert batch_calls == [5], (
+            f"expected one add_documents_batch([5 docs]) call, got {batch_calls}"
+        )
+        assert batch_mode_calls == [True], (
+            f"expected one batch_mode(defer_fts=True), got {batch_mode_calls}"
+        )
+
+
+class TestIngestBatchErrorIsolation:
+    """A bad file must not kill the batch."""
+
+    def test_bad_file_isolated_from_rest(
+        self,
+        tmp_path: Path,
+        sample_store: VstashStore,
+        sample_config: VstashConfig,
+    ) -> None:
+        good_a = _write(tmp_path, "good_a.md", "# A\n\nAlpha content here.")
+        bad = str(tmp_path / "does_not_exist.md")  # path that is not on disk
+        good_b = _write(tmp_path, "good_b.md", "# B\n\nBravo content here.")
+
+        results = ingest_batch([good_a, bad, good_b], sample_config, sample_store)
+
+        assert len(results) == 3
+        statuses = [r.status for r in results]
+        # The two good files land as status="ok" (order preserved among
+        # successful docs in phase 2). The bad file lands as the error
+        # from phase 1.
+        assert "error" in statuses, f"expected at least one error result, got {statuses}"
+        assert statuses.count("ok") == 2, f"expected 2 ok results, got {statuses}"
+
+
+class TestIngestBatchEmpty:
+    def test_empty_list_returns_empty_noop(
+        self,
+        sample_store: VstashStore,
+        sample_config: VstashConfig,
+        monkeypatch,
+    ) -> None:
+        called: list[str] = []
+        monkeypatch.setattr(
+            sample_store,
+            "add_documents_batch",
+            lambda docs: called.append("add_documents_batch") or [],
+        )
+        results = ingest_batch([], sample_config, sample_store)
+        assert results == []
+        assert called == [], "empty input must not call add_documents_batch"
+
+
+class TestIngestDirectoryStillWorks:
+    """Regression: ingest_directory routes through ingest_batch and must
+    keep its existing behaviour (progress bar on, limits enforced)."""
+
+    def test_directory_returns_one_result_per_file(
+        self,
+        tmp_path: Path,
+        sample_store: VstashStore,
+        sample_config: VstashConfig,
+    ) -> None:
+        from vstash.ingest import ingest_directory
+
+        for i in range(3):
+            _write(tmp_path, f"dir_doc_{i}.md", f"# Dir Doc {i}\n\nBody {i}.")
+
+        results = ingest_directory(str(tmp_path), sample_config, sample_store)
+
+        assert len(results) == 3
+        assert all(r.status == "ok" for r in results)

--- a/tests/test_watch_burst.py
+++ b/tests/test_watch_burst.py
@@ -1,0 +1,114 @@
+"""Unit tests for the watch.py burst-drain logic (issue #266).
+
+The drain helper takes a queue-head path plus the queue itself and
+returns an ordered batch of up to ``max_batch`` paths, capped by a
+``max_window_s`` deadline. The watcher worker then feeds that batch to
+``ingest_batch`` so the whole burst shares one transaction, one FTS5
+flush, and one snapvec vstack.
+
+These tests exercise the drain contract in isolation from watchdog
+and SQLite so we can assert semantics (ordering, poison-pill
+re-enqueue, batch cap, window cap) deterministically.
+"""
+
+from __future__ import annotations
+
+import queue
+
+
+from vstash.watch import DRAIN_MAX_BATCH, _drain_burst
+
+
+class TestDrainBurstOrdering:
+    def test_returns_first_then_drained_in_fifo_order(self) -> None:
+        q: queue.Queue[str | None] = queue.Queue()
+        for p in ["b", "c", "d"]:
+            q.put(p)
+
+        batch = _drain_burst(q, "a")
+
+        assert batch == ["a", "b", "c", "d"]
+        assert q.empty()
+
+
+class TestDrainBurstCaps:
+    def test_max_batch_caps_drain(self) -> None:
+        q: queue.Queue[str | None] = queue.Queue()
+        # Queue holds way more than max_batch so we can see the cap fire.
+        for i in range(200):
+            q.put(f"p{i}")
+
+        batch = _drain_burst(q, "first", max_batch=4)
+
+        assert len(batch) == 4
+        assert batch[0] == "first"
+        assert batch[1:] == ["p0", "p1", "p2"]
+        # Remaining items must still be on the queue for the next drain.
+        remaining = []
+        while not q.empty():
+            remaining.append(q.get_nowait())
+        assert remaining[0] == "p3"
+        assert len(remaining) == 200 - 3
+
+    def test_window_cap_stops_drain_when_empty(self) -> None:
+        """Empty queue + zero window must not hang."""
+        q: queue.Queue[str | None] = queue.Queue()
+
+        # Frozen clock: time never advances, so the very first check of
+        # "remaining = deadline - now()" returns exactly 0 after the
+        # deadline is computed (deadline = t0 + 0 = t0). The drain must
+        # return the single head path without blocking.
+        frozen = [0.0]
+
+        def _now() -> float:
+            return frozen[0]
+
+        batch = _drain_burst(q, "only", max_window_s=0.0, now=_now)
+        assert batch == ["only"]
+
+
+class TestDrainBurstPoisonPill:
+    def test_poison_pill_mid_burst_is_requeued(self) -> None:
+        """If None arrives mid-burst, the drain stops and re-enqueues it
+        so the main worker loop still sees the shutdown signal.
+
+        The re-queued poison pill lands at the tail, not back at the
+        head, so the main loop will drain any already-queued paths
+        ahead of it (one more burst window) before shutting down. That
+        is the intended behaviour: shutdown is cooperative, not pre-
+        emptive, and the cost of one extra burst is bounded by
+        ``max_window_s``.
+        """
+        q: queue.Queue[str | None] = queue.Queue()
+        q.put("b")
+        q.put(None)
+        q.put("c")
+
+        batch = _drain_burst(q, "a", max_batch=10)
+
+        # "a" is the head arg, "b" was taken from the queue before the
+        # poison pill stopped the drain.
+        assert batch == ["a", "b"]
+        # Remaining queue: items after the None in the original stream
+        # plus the re-queued None at the tail.
+        remaining = []
+        while not q.empty():
+            remaining.append(q.get_nowait())
+        assert None in remaining, (
+            "poison pill must be re-enqueued so the main loop sees the shutdown signal"
+        )
+        assert "c" in remaining, "untouched items after the poison pill must survive"
+
+
+class TestDrainBurstDefaults:
+    def test_default_cap_matches_module_constant(self) -> None:
+        """Cheap regression: the public DRAIN_MAX_BATCH is the one wired
+        into the default keyword so changing one requires changing the
+        other."""
+        q: queue.Queue[str | None] = queue.Queue()
+        # Fill the queue with max-1 items. Together with the head path
+        # that totals DRAIN_MAX_BATCH and must not overflow.
+        for i in range(DRAIN_MAX_BATCH + 10):
+            q.put(f"p{i}")
+        batch = _drain_burst(q, "head")
+        assert len(batch) == DRAIN_MAX_BATCH

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -896,43 +896,110 @@ def ingest_directory(
         f"[dim]Found {len(files)} files ({total_bytes / 1024:.0f} KB) in {directory}[/dim]"
     )
 
+    return ingest_batch(
+        [str(f) for f in files],
+        cfg,
+        store,
+        force=force,
+        collection=collection,
+        project=project,
+        layer=layer,
+        tags=tags,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+        quiet=False,
+    )
+
+
+def ingest_batch(
+    sources: list[str],
+    cfg: VstashConfig,
+    store: VstashStore,
+    *,
+    force: bool = False,
+    collection: str = "default",
+    project: str | None = None,
+    layer: str | None = None,
+    tags: str | None = None,
+    chunk_size: int | None = None,
+    chunk_overlap: int | None = None,
+    quiet: bool = True,
+) -> list[IngestResult]:
+    """Ingest many files in two phases with per-file error isolation.
+
+    Phase 1 runs ``_prepare_document`` per source so a bad file yields
+    a per-file error ``IngestResult`` without killing the rest. Phase
+    2 routes every successfully prepared doc through
+    ``store.batch_mode(defer_fts=True) + add_documents_batch`` so the
+    whole batch shares one SQLite transaction, one snapvec vstack, and
+    one FTS5 flush.
+
+    Used by both ``ingest_directory`` (progress bar on) and the
+    ``watch.py`` worker draining its queue (progress bar off).
+
+    Args:
+        sources: File paths or URLs to ingest.
+        cfg: vstash configuration.
+        store: Vector store instance.
+        force: If False, skip documents already in the store.
+        collection: Named collection to group ingested documents.
+        project: Project tag to apply (overrides frontmatter).
+        layer: Layer tag to apply (overrides frontmatter).
+        tags: Comma-separated tags to apply (overrides frontmatter).
+        chunk_size: Optional chunk-size override.
+        chunk_overlap: Optional chunk-overlap override.
+        quiet: If False, show a preparation progress bar.
+
+    Returns:
+        One ``IngestResult`` per input source, order preserved.
+    """
+    if not sources:
+        return []
+
     results: list[IngestResult] = []
     pending: list[_PreparedDoc] = []
 
-    # Phase 1: parse + chunk + embed (per-file, progress bar)
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[bold]Preparing[/bold]"),
-        BarColumn(),
-        MofNCompleteColumn(),
-        TimeElapsedColumn(),
-        console=console,
-    ) as progress:
-        task = progress.add_task("", total=len(files))
-        for f in files:
-            progress.update(task, description=f.name)
-            prepared = _prepare_document(
-                str(f),
-                cfg,
-                store,
-                force=force,
-                collection=collection,
-                project=project,
-                layer=layer,
-                tags=tags,
-                chunk_size=chunk_size,
-                chunk_overlap=chunk_overlap,
-                quiet=True,
-            )
-            if isinstance(prepared, IngestResult):
-                if prepared.status == "error":
-                    console.print(f"[red]  x {f.name}: {prepared.error}[/red]")
-                results.append(prepared)
-            else:
-                pending.append(prepared)
-            progress.advance(task)
+    def _prepare_one(src: str) -> None:
+        prepared = _prepare_document(
+            src,
+            cfg,
+            store,
+            force=force,
+            collection=collection,
+            project=project,
+            layer=layer,
+            tags=tags,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            quiet=True,
+        )
+        if isinstance(prepared, IngestResult):
+            if prepared.status == "error" and not quiet:
+                console.print(f"[red]  x {Path(src).name}: {prepared.error}[/red]")
+            results.append(prepared)
+        else:
+            pending.append(prepared)
 
-    # Phase 2: store all prepared docs in one batched transaction
+    # Phase 1: parse + chunk + embed (per-file, error-isolated).
+    if quiet:
+        for src in sources:
+            _prepare_one(src)
+    else:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[bold]Preparing[/bold]"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeElapsedColumn(),
+            console=console,
+        ) as progress:
+            task = progress.add_task("", total=len(sources))
+            for src in sources:
+                progress.update(task, description=Path(src).name)
+                _prepare_one(src)
+                progress.advance(task)
+
+    # Phase 2: store all prepared docs in one batched transaction.
     if pending:
         batch_docs = [
             {

--- a/vstash/watch.py
+++ b/vstash/watch.py
@@ -95,6 +95,53 @@ def _should_process(path: str, extensions: frozenset[str]) -> bool:
     return p.suffix.lower() in extensions
 
 
+# Burst-drain tuning. The watcher blocks for one queued file, then
+# tries to accumulate a small burst before flushing through the batch
+# ingest route. Both bounds are defensive:
+#   - DRAIN_MAX_BATCH caps peak memory: a burst of 100k files would
+#     otherwise hold every path + embedding in Python land before the
+#     single batch transaction commits.
+#   - DRAIN_MAX_WINDOW_S caps the tail latency a user sees: even if
+#     more files keep arriving, we flush what we have so the first
+#     dropped file does not wait indefinitely.
+DRAIN_MAX_BATCH = 64
+DRAIN_MAX_WINDOW_S = 0.25
+
+
+def _drain_burst(
+    q: queue.Queue[str | None],
+    first: str,
+    *,
+    max_batch: int = DRAIN_MAX_BATCH,
+    max_window_s: float = DRAIN_MAX_WINDOW_S,
+    now: Callable[[], float] = time.monotonic,
+) -> list[str]:
+    """Collect ``first`` plus any extra queued paths up to the window.
+
+    Returns an ordered list of paths ready to feed to ``ingest_batch``.
+    If a poison-pill (``None``) is drained mid-burst, it is re-enqueued
+    so the main loop still sees it and exits cleanly.
+
+    Exposed top-level so the drain semantics are unit-testable without
+    spinning up watchdog or a real ``start_watch``.
+    """
+    batch: list[str] = [first]
+    deadline = now() + max_window_s
+    while len(batch) < max_batch:
+        remaining = deadline - now()
+        if remaining <= 0:
+            break
+        try:
+            extra = q.get(timeout=remaining)
+        except queue.Empty:
+            break
+        if extra is None:
+            q.put(None)
+            break
+        batch.append(extra)
+    return batch
+
+
 def start_watch(
     paths: list[str],
     cfg: VstashConfig,
@@ -128,7 +175,7 @@ def start_watch(
             "watchdog is required for watch mode. Install it with: pip install vstash[watch]"
         ) from exc
 
-    from .ingest import ingest
+    from .ingest import ingest_batch
 
     exts = extensions or SUPPORTED_EXTENSIONS
 
@@ -136,40 +183,48 @@ def start_watch(
     ingest_queue: queue.Queue[str | None] = queue.Queue()
     stop_event = threading.Event()
 
+    def _process_batch(paths: list[str]) -> None:
+        """Route a drained burst through ingest_batch and report."""
+        existing = [p for p in paths if Path(p).exists()]
+        if not existing:
+            return
+        try:
+            results = ingest_batch(
+                existing,
+                cfg,
+                store,
+                force=True,
+                collection=collection,
+                quiet=True,
+            )
+        except Exception as exc:
+            console.print(f"[red]✗ Watch ingest error: {_rich_escape(str(exc))}[/red]")
+            return
+        ts = time.strftime("%H:%M:%S")
+        for result in results:
+            src_name = Path(result.source).name
+            if result.status == "ok":
+                console.print(
+                    f"[dim]{ts}[/dim] [green]✓[/green] "
+                    f"[bold]{result.title}[/bold] — "
+                    f"{result.chunks} chunks → [cyan]{collection}[/cyan]"
+                )
+            elif result.status == "empty":
+                console.print(f"[dim]{ts}[/dim] [yellow]⚠[/yellow] No content: {src_name}")
+            elif result.status == "error":
+                console.print(f"[dim]{ts}[/dim] [red]✗[/red] Error: {result.error}")
+
     def _worker() -> None:
-        """Process files from the queue one at a time."""
+        """Block for the first file, then drain the burst window and flush."""
         while not stop_event.is_set():
             try:
-                file_path = ingest_queue.get(timeout=1)
+                first = ingest_queue.get(timeout=1)
             except queue.Empty:
                 continue
-            if file_path is None:  # Poison pill → exit
+            if first is None:  # Poison pill → exit
                 break
-            if not Path(file_path).exists():
-                continue
-            try:
-                result = ingest(
-                    file_path,
-                    cfg,
-                    store,
-                    force=True,
-                    collection=collection,
-                )
-                ts = time.strftime("%H:%M:%S")
-                if result.status == "ok":
-                    console.print(
-                        f"[dim]{ts}[/dim] [green]✓[/green] "
-                        f"[bold]{result.title}[/bold] — "
-                        f"{result.chunks} chunks → [cyan]{collection}[/cyan]"
-                    )
-                elif result.status == "empty":
-                    console.print(
-                        f"[dim]{ts}[/dim] [yellow]⚠[/yellow] No content: {Path(file_path).name}"
-                    )
-                elif result.status == "error":
-                    console.print(f"[dim]{ts}[/dim] [red]✗[/red] Error: {result.error}")
-            except Exception as exc:
-                console.print(f"[red]✗ Watch ingest error: {_rich_escape(str(exc))}[/red]")
+            batch = _drain_burst(ingest_queue, first)
+            _process_batch(batch)
 
     worker_thread = threading.Thread(target=_worker, daemon=True)
     worker_thread.start()

--- a/vstash/watch.py
+++ b/vstash/watch.py
@@ -185,10 +185,14 @@ def start_watch(
 
     def _process_batch(paths: list[str]) -> None:
         """Route a drained burst through ingest_batch and report."""
-        existing = [p for p in paths if Path(p).exists()]
-        if not existing:
-            return
         try:
+            # Path.exists() can raise OSError (permission denied,
+            # stale NFS mount, dead symlink target on some FSes).
+            # Keep the check inside the try so a transient FS error on
+            # one path does not kill the long-running worker thread.
+            existing = [p for p in paths if Path(p).exists()]
+            if not existing:
+                return
             results = ingest_batch(
                 existing,
                 cfg,


### PR DESCRIPTION
## Summary

Issue #266 originally framed the watch.py burst path as **O(N^2)**. A pre-fix probe proved that framing was obsolete: \`_save_snapvec\` was deferred in the #250/#251 cycle so the disk-write quadratic is already gone, and the remaining per-call vstack is dominated by SQLite + embedding work. Both \`serialized\` and \`batched\` paths scale **linearly** across N=100..3000 (see the findings comment on #266).

Shipping the batching anyway because the **4-5x constant factor** on a user-visible path (e.g. \`git pull\` drops 1000 files: 200 ms -> 45 ms on snapvec flat) is worth the small helper. Re-scoped the PR title away from \"O(N^2) fix\" to reflect what this actually is.

## Changes

1. **Extract \`ingest_batch\`** (\`vstash/ingest.py\`) from \`ingest_directory\`. Phase 1 isolates per-file errors; Phase 2 routes successful preps through one \`store.batch_mode(defer_fts=True) + add_documents_batch\` call. \`ingest_directory\` now wraps \`ingest_batch\` (no behaviour change).
2. **Rewrite the watch worker** (\`vstash/watch.py\`). Blocks for first queued path, drains up to \`DRAIN_MAX_BATCH=64\` more within \`DRAIN_MAX_WINDOW_S=0.25\`, flushes through \`ingest_batch\`. Drain logic extracted to top-level \`_drain_burst\` so it's unit-testable without watchdog.
3. **Probe script** (\`experiments/perf_watch_burst.py\`) as a regression witness. Run it pre and post-fix to validate the constant-factor claim.

## Probe numbers

Backend: snapvec flat (bits=4), bge-small 384d, Apple M4 Pro 24 GB.

\`\`\`
     N   serialized (ms)   batched (ms)  speedup
   100              30.1            9.6    3.1x
   500             101.0           25.6    3.9x
  1000             201.1           46.0    4.4x
  3000             783.1          160.1    4.9x
\`\`\`

## Test plan

- [x] \`tests/test_ingest_batch.py\` (4 new) - helper coalescing contract, error isolation, empty input, \`ingest_directory\` regression.
- [x] \`tests/test_watch_burst.py\` (5 new) - \`_drain_burst\` ordering, batch cap, window cap, poison-pill re-enqueue, default sanity.
- [x] \`tests/test_watch_e2e.py\` (9 existing) - all green after refactor.
- [x] \`ruff check . && ruff format --check .\` clean.
- [x] Full suite: 422 passed (only pre-existing failure is #271 test_memory hermeticity, unrelated).

## Out of scope

- The probe script ships under \`experiments/\`. Not wired into the benchmark regression marker because it is a shape probe, not a correctness gate.
- #271 hermeticity and #272 L2-vs-cosine still open, unrelated to this PR.

Fixes #266 as a constant-factor perf win (the original O(N^2) premise is stale, as documented in the probe-first comment on the issue).