### PR TITLE
feat(#275): add retrieval_mode enum with vec_only branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to vstash are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`retrieval_mode` enum on search** (#275). New `retrieval_mode` parameter on `VstashStore.search`, `Memory.search`, `Memory.ask`, the MCP `vstash_search` / `vstash_ask` tools, and `VstashRetriever`. Three values:
+  - `"hybrid"` (default): unchanged -- vector ANN + FTS5 + adaptive RRF.
+  - `"vec_only"`: skip the FTS5 branch; force `(vec_weight, fts_weight) = (1.0, 0.0)`. Useful when the corpus has no meaningful keyword signal (tabular, code, cross-lingual).
+  - `"fts_only"`: existing #152 short-circuit, now named consistently.
+
+### Deprecated
+
+- **`fts_only=True` bool on `search` / `ask`** is deprecated in favour of `retrieval_mode="fts_only"` (#275). Still works for one release with a `DeprecationWarning`; combining `fts_only=True` with a contradictory `retrieval_mode` now raises `ValueError` rather than silently ignoring one of them.
+
 ## [0.32.0] - 2026-04-16
 
 ### Added

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -235,7 +235,10 @@ class TestVstashSearch:
         _, kwargs = mock_store.return_value.search.call_args
         assert kwargs["vec_weight"] == 0.9
         assert kwargs["fts_weight"] == 0.1
-        assert kwargs["fts_only"] is False
+        # #275: MCP forwards the resolved retrieval_mode enum to the
+        # store now. fts_only=False resolves to "hybrid".
+        assert kwargs["retrieval_mode"] == "hybrid"
+        assert "fts_only" not in kwargs
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -260,7 +263,8 @@ class TestVstashSearch:
         _, kwargs = mock_store.return_value.search.call_args
         assert kwargs["vec_weight"] is None
         assert kwargs["fts_weight"] is None
-        assert kwargs["fts_only"] is False
+        assert kwargs["retrieval_mode"] == "hybrid"
+        assert "fts_only" not in kwargs
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -292,7 +296,7 @@ class TestVstashSearch:
         mock_store.return_value.record_search_event.return_value = 1
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
-        # Weights as strings, fts_only omitted (default False).
+        # Weights as strings, fts_only omitted (default False -> hybrid).
         vstash_search(
             "test",
             vec_weight="0.8",  # type: ignore[arg-type]
@@ -301,13 +305,17 @@ class TestVstashSearch:
         _, kwargs = mock_store.return_value.search.call_args
         assert kwargs["vec_weight"] == 0.8
         assert kwargs["fts_weight"] == 0.2
-        assert kwargs["fts_only"] is False
+        assert kwargs["retrieval_mode"] == "hybrid"
 
-        # fts_only as a string, weights omitted.
+        # fts_only as a string coerces + resolves to retrieval_mode='fts_only'.
         mock_store.return_value.search.reset_mock()
-        vstash_search("test", fts_only="true")  # type: ignore[arg-type]
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            vstash_search("test", fts_only="true")  # type: ignore[arg-type]
         _, kwargs = mock_store.return_value.search.call_args
-        assert kwargs["fts_only"] is True
+        assert kwargs["retrieval_mode"] == "fts_only"
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -331,6 +339,13 @@ class TestVstashSearch:
         result2 = json.loads(vstash_search("test", fts_only="maybe"))  # type: ignore[arg-type]
         assert "error" in result2
         assert "fts_only" in result2["error"]
+
+        # Unknown retrieval_mode string surfaces as structured error too.
+        result3 = json.loads(
+            vstash_search("test", retrieval_mode="semantic")  # type: ignore[arg-type]
+        )
+        assert "error" in result3
+        assert "retrieval_mode" in result3["error"]
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -386,29 +401,34 @@ class TestVstashSearch:
         mock_config.return_value.embeddings.model = "BAAI/bge-small-en-v1.5"
 
         # Every one of these combinations would fail coercion on its
-        # own but must succeed when paired with fts_only=true.
+        # own but must succeed when paired with fts_only=true (deprecated)
+        # or retrieval_mode="fts_only".
+        import warnings
+
         for bad_vec, bad_fts in [
             ("not_a_number", None),
             ("nan", None),
             (None, "-inf"),
-            ("10.0", "5.0"),  # out of [0, 1] — but never reaches validator
+            ("10.0", "5.0"),  # out of [0, 1] -- but never reaches validator
         ]:
             mock_store.return_value.search.reset_mock()
-            result = json.loads(
-                vstash_search(
-                    "test",
-                    fts_only=True,
-                    vec_weight=bad_vec,  # type: ignore[arg-type]
-                    fts_weight=bad_fts,  # type: ignore[arg-type]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                result = json.loads(
+                    vstash_search(
+                        "test",
+                        fts_only=True,
+                        vec_weight=bad_vec,  # type: ignore[arg-type]
+                        fts_weight=bad_fts,  # type: ignore[arg-type]
+                    )
                 )
-            )
             assert "error" not in result, (
                 f"fts_only=True should have dropped invalid weights "
                 f"vec_weight={bad_vec!r}, fts_weight={bad_fts!r}, "
                 f"but got {result}"
             )
             _, kwargs = mock_store.return_value.search.call_args
-            assert kwargs["fts_only"] is True
+            assert kwargs["retrieval_mode"] == "fts_only"
             assert kwargs["vec_weight"] is None
             assert kwargs["fts_weight"] is None
 
@@ -544,7 +564,9 @@ class TestVstashAsk:
         _, kwargs = store_inst.search.call_args
         assert kwargs["vec_weight"] == 0.3
         assert kwargs["fts_weight"] == 0.7
-        assert kwargs["fts_only"] is False
+        # #275: retrieval_mode replaces fts_only at the store boundary.
+        assert kwargs["retrieval_mode"] == "hybrid"
+        assert "fts_only" not in kwargs
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -578,14 +600,18 @@ class TestVstashAsk:
         _, kwargs = store_inst.search.call_args
         assert kwargs["vec_weight"] == 0.1
         assert kwargs["fts_weight"] == 0.9
-        assert kwargs["fts_only"] is False
+        assert kwargs["retrieval_mode"] == "hybrid"
 
-        # fts_only as a string, weights omitted.
+        # fts_only as a string coerces + resolves to retrieval_mode='fts_only'.
         store_inst.search.reset_mock()
+        import warnings
+
         with patch("vstash.chat.ask", return_value="answer"):
-            vstash_ask("query", fts_only="TRUE")  # type: ignore[arg-type]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                vstash_ask("query", fts_only="TRUE")  # type: ignore[arg-type]
         _, kwargs = store_inst.search.call_args
-        assert kwargs["fts_only"] is True
+        assert kwargs["retrieval_mode"] == "fts_only"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -320,8 +320,16 @@ class TestMemorySearch:
             )
 
     @requires_sqlite_vec
-    def test_search_fts_only_forwards_kwarg_to_store(self, tmp_path: Path) -> None:
-        """Memory.search must forward fts_only to VstashStore.search (#152)."""
+    def test_search_forwards_retrieval_mode_to_store(self, tmp_path: Path) -> None:
+        """Memory.search resolves fts_only/retrieval_mode and forwards the
+        enum value to VstashStore.search (#152, #275).
+
+        The legacy ``fts_only=True`` path is expected to emit a
+        DeprecationWarning, which we filter here -- we only care that
+        the resolved enum lands on the store side.
+        """
+        import warnings
+
         (tmp_path / "doc.md").write_text("Spy test content.")
         with Memory(db=tmp_path / "test.db") as mem:
             mem.add(tmp_path / "doc.md")
@@ -335,14 +343,21 @@ class TestMemorySearch:
 
             mem._store.search = spy_search  # type: ignore[method-assign]
 
-            mem.search("content", fts_only=True)
-            mem.search("content", fts_only=False)
-            mem.search("content")  # default must be False
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                mem.search("content", fts_only=True)
+                mem.search("content", retrieval_mode="vec_only")
+                mem.search("content")  # default -> hybrid
 
             assert len(captured) == 3
-            assert captured[0]["fts_only"] is True
-            assert captured[1]["fts_only"] is False
-            assert captured[2]["fts_only"] is False
+            assert captured[0]["retrieval_mode"] == "fts_only"
+            assert captured[1]["retrieval_mode"] == "vec_only"
+            assert captured[2]["retrieval_mode"] == "hybrid"
+            # fts_only bool must NOT be forwarded to the store any more:
+            # the mode enum is the single source of truth at the store
+            # boundary.
+            for call in captured:
+                assert "fts_only" not in call
 
     @requires_sqlite_vec
     def test_search_fts_only_skips_distance_signal(self, tmp_path: Path) -> None:

--- a/tests/test_retrieval_mode.py
+++ b/tests/test_retrieval_mode.py
@@ -1,0 +1,186 @@
+"""Tests for the retrieval_mode enum (issue #275).
+
+The three modes (``hybrid``, ``vec_only``, ``fts_only``) are mutually
+exclusive switches on ``VstashStore.search``. Contracts under test:
+
+- Default behaviour (mode unset / ``"hybrid"``) is unchanged -- both
+  branches run, adaptive RRF is enabled.
+- ``"vec_only"`` skips the FTS5 SQL entirely and forces
+  ``(vec_weight, fts_weight) = (1.0, 0.0)``.
+- ``"fts_only"`` keeps its historical short-circuit semantics (#152).
+- The legacy ``fts_only=True`` bool emits ``DeprecationWarning`` but
+  still resolves to ``retrieval_mode="fts_only"``.
+- A contradictory combination (``fts_only=True`` + ``retrieval_mode``
+  other than ``"fts_only"``) raises ``ValueError``.
+- An unknown string for ``retrieval_mode`` raises ``ValueError``.
+- The query cache distinguishes between modes (same query text in
+  different modes must not collide).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from tests.conftest import requires_sqlite_vec
+from vstash.store import VstashStore
+
+
+pytestmark = requires_sqlite_vec
+
+
+DIM = 16
+
+
+def _seed_store(tmp_path, dim: int = DIM) -> VstashStore:
+    """Small store with two docs sharing a keyword but distinct embeddings."""
+    store = VstashStore(str(tmp_path / "rm.db"), embedding_dim=dim)
+    store.add_document(
+        path="/rm/alpha.md",
+        title="Alpha",
+        chunks=["alpha mentions rust in passing"],
+        embeddings=[[1.0] + [0.0] * (dim - 1)],
+    )
+    store.add_document(
+        path="/rm/beta.md",
+        title="Beta",
+        chunks=["beta also mentions rust briefly"],
+        embeddings=[[0.0, 1.0] + [0.0] * (dim - 2)],
+    )
+    return store
+
+
+class TestResolver:
+    """_resolve_retrieval_mode is the single source of truth for mode."""
+
+    def test_default_is_hybrid(self) -> None:
+        assert VstashStore._resolve_retrieval_mode(None, False) == "hybrid"
+
+    def test_retrieval_mode_wins(self) -> None:
+        assert VstashStore._resolve_retrieval_mode("vec_only", False) == "vec_only"
+        assert VstashStore._resolve_retrieval_mode("fts_only", False) == "fts_only"
+
+    def test_legacy_fts_only_emits_deprecation(self) -> None:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mode = VstashStore._resolve_retrieval_mode(None, True)
+        assert mode == "fts_only"
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+        assert any("retrieval_mode='fts_only'" in str(w.message) for w in caught)
+
+    def test_conflicting_inputs_raise(self) -> None:
+        with pytest.raises(ValueError, match="conflicts with fts_only=True"):
+            VstashStore._resolve_retrieval_mode("vec_only", True)
+        with pytest.raises(ValueError, match="conflicts with fts_only=True"):
+            VstashStore._resolve_retrieval_mode("hybrid", True)
+
+    def test_fts_only_plus_fts_only_mode_is_ok(self) -> None:
+        # Not a conflict: redundant but consistent. Drop to "fts_only"
+        # silently (no deprecation since retrieval_mode was provided).
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            mode = VstashStore._resolve_retrieval_mode("fts_only", True)
+        assert mode == "fts_only"
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            "explicit retrieval_mode wins; no deprecation warning expected"
+        )
+
+    def test_unknown_mode_string_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be one of"):
+            VstashStore._resolve_retrieval_mode("semantic", False)
+
+
+class TestVecOnlyBranch:
+    """retrieval_mode='vec_only' must skip the FTS5 path.
+
+    The observable contract: ``_fuse_rrf_scores`` receives ``fts_rows=[]``
+    and ``fts_weight=0.0`` when the caller asks for ``"vec_only"``. We
+    spy on the private helper rather than ``sqlite3.Connection.execute``
+    (which is read-only in CPython and cannot be monkeypatched).
+    """
+
+    def test_vec_only_passes_empty_fts_rows_to_rrf(self, tmp_path, monkeypatch) -> None:
+        store = _seed_store(tmp_path)
+        try:
+            original_fuse = store._fuse_rrf_scores
+            captured: dict = {}
+
+            def _spy_fuse(**kwargs):
+                captured.update(kwargs)
+                return original_fuse(**kwargs)
+
+            monkeypatch.setattr(store, "_fuse_rrf_scores", _spy_fuse)
+
+            store.search(
+                query_embedding=[1.0] + [0.0] * (DIM - 1),
+                query_text="rust",
+                top_k=3,
+                retrieval_mode="vec_only",
+            )
+            assert captured.get("fts_rows") == [], (
+                f"vec_only must feed empty FTS rows to RRF; got {captured.get('fts_rows')}"
+            )
+            assert captured.get("fts_weight") == 0.0, (
+                f"vec_only must force fts_weight=0.0; got {captured.get('fts_weight')}"
+            )
+            assert captured.get("vec_weight") == 1.0, (
+                f"vec_only must force vec_weight=1.0; got {captured.get('vec_weight')}"
+            )
+        finally:
+            store.close()
+
+    def test_hybrid_feeds_nonempty_fts_rows_when_text_matches(self, tmp_path, monkeypatch) -> None:
+        """Default hybrid must still populate fts_rows (non-regression)."""
+        store = _seed_store(tmp_path)
+        try:
+            original_fuse = store._fuse_rrf_scores
+            captured: dict = {}
+
+            def _spy_fuse(**kwargs):
+                captured.update(kwargs)
+                return original_fuse(**kwargs)
+
+            monkeypatch.setattr(store, "_fuse_rrf_scores", _spy_fuse)
+
+            store.search(
+                query_embedding=[1.0] + [0.0] * (DIM - 1),
+                query_text="rust",
+                top_k=3,
+            )
+            fts_rows = captured.get("fts_rows", [])
+            assert len(fts_rows) >= 1, (
+                "hybrid default must pass non-empty FTS rows when the corpus matches"
+            )
+        finally:
+            store.close()
+
+
+class TestCacheKeySeparation:
+    """The query cache key must include retrieval_mode so different modes
+    for the same query text do not collide."""
+
+    def test_mode_separates_cache_key(self) -> None:
+        kwargs = dict(
+            query_embedding=[0.1] * DIM,
+            query_text="rust",
+            top_k=3,
+            vec_weight=None,
+            fts_weight=None,
+            distance_cutoff=1.15,
+            collection=None,
+            project=None,
+            layer=None,
+            adaptive_rrf=True,
+            recency_boost=0.0,
+            added_after=None,
+            added_before=None,
+            mmr_lambda=0.5,
+            cache_epoch=0,
+        )
+        h_hybrid = VstashStore._compute_search_cache_key(retrieval_mode="hybrid", **kwargs)
+        h_vec = VstashStore._compute_search_cache_key(retrieval_mode="vec_only", **kwargs)
+        h_fts = VstashStore._compute_search_cache_key(retrieval_mode="fts_only", **kwargs)
+        assert h_hybrid != h_vec, "hybrid and vec_only keys must not collide"
+        assert h_hybrid != h_fts, "hybrid and fts_only keys must not collide"
+        assert h_vec != h_fts, "vec_only and fts_only keys must not collide"

--- a/vstash/langchain.py
+++ b/vstash/langchain.py
@@ -16,7 +16,7 @@ all BaseRetriever subclasses automatically.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 try:
     from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
@@ -45,6 +45,9 @@ class VstashRetriever(BaseRetriever):
         project: Override the Memory's default project filter.
         collection: Override the Memory's default collection filter.
         layer: Filter by layer tag.
+        retrieval_mode: Which search branches to run. One of ``"hybrid"``
+            (default), ``"vec_only"``, or ``"fts_only"``. See
+            :meth:`vstash.Memory.search` for full semantics.
 
     Example::
 
@@ -71,6 +74,7 @@ class VstashRetriever(BaseRetriever):
     project: str | None = None
     collection: str | None = None
     layer: str | None = None
+    retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None
 
     def _get_relevant_documents(
         self,
@@ -92,7 +96,8 @@ class VstashRetriever(BaseRetriever):
         # will correctly override a Memory scoped to a project.
         search_kwargs: dict[str, Any] = {"top_k": self.top_k}
         retriever_filters = self.model_dump(
-            include={"project", "collection", "layer"}, exclude_unset=True
+            include={"project", "collection", "layer", "retrieval_mode"},
+            exclude_unset=True,
         )
         search_kwargs.update(retriever_filters)
 

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -219,6 +219,25 @@ def _coerce_optional_float(value: Any, field: str) -> float | None:
     return parsed
 
 
+def _coerce_retrieval_mode(value: Any, field: str = "retrieval_mode") -> str | None:
+    """Coerce an MCP-supplied value to a ``retrieval_mode`` enum string.
+
+    Accepts ``None`` (leave unset), ``"hybrid"``, ``"vec_only"``,
+    ``"fts_only"``. Any other string raises ``ValueError`` with the
+    valid set listed so the MCP client sees an actionable error instead
+    of a silent downgrade to hybrid.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == "":
+            return None
+        if lowered in ("hybrid", "vec_only", "fts_only"):
+            return lowered
+    raise ValueError(f"{field}: expected one of 'hybrid', 'vec_only', 'fts_only'; got {value!r}")
+
+
 def _coerce_bool(value: Any, field: str) -> bool:
     """Coerce an MCP-supplied value to ``bool``.
 
@@ -518,6 +537,7 @@ def vstash_ask(
     vec_weight: float | None = None,
     fts_weight: float | None = None,
     fts_only: bool = False,
+    retrieval_mode: str | None = None,
 ) -> str:
     """Query vstash memory and get an LLM-generated answer with sources.
 
@@ -537,8 +557,10 @@ def vstash_ask(
             adaptive per-query RRF.
         fts_weight: Pin the RRF FTS weight on the retrieval step. See
             ``vstash_search``.
-        fts_only: If true, retrieve context using FTS5 only. See
-            ``vstash_search``.
+        fts_only: DEPRECATED, use ``retrieval_mode="fts_only"`` instead.
+        retrieval_mode: Which search branches to run on the retrieval
+            step. One of ``"hybrid"`` (default), ``"vec_only"``,
+            ``"fts_only"``. See ``vstash_search`` for full semantics.
 
     Returns:
         JSON string with answer text and source documents.
@@ -551,11 +573,13 @@ def vstash_ask(
         store = _get_store()
 
         # Defensive type coercion (MCP clients may send strings where
-        # floats/bools are expected). Resolve fts_only first so that
-        # fts_only=True short-circuits weight coercion — see
+        # floats/bools/enums are expected). Resolve retrieval_mode first
+        # so a non-hybrid mode short-circuits the weight coercion -- see
         # vstash_search for the same precedence rule.
+        mode_coerced = _coerce_retrieval_mode(retrieval_mode, "retrieval_mode")
         fts_only_coerced = _coerce_bool(fts_only, "fts_only")
-        if fts_only_coerced:
+        resolved_mode = VstashStore._resolve_retrieval_mode(mode_coerced, fts_only_coerced)
+        if resolved_mode != "hybrid":
             vec_weight_coerced = None
             fts_weight_coerced = None
         else:
@@ -575,7 +599,7 @@ def vstash_ask(
             added_before=added_before,
             vec_weight=vec_weight_coerced,
             fts_weight=fts_weight_coerced,
-            fts_only=fts_only_coerced,
+            retrieval_mode=resolved_mode,
         )
 
         if not chunks:
@@ -643,6 +667,7 @@ def vstash_search(
     vec_weight: float | None = None,
     fts_weight: float | None = None,
     fts_only: bool = False,
+    retrieval_mode: str | None = None,
 ) -> str:
     """Search vstash memory without LLM — returns raw chunks with scores.
 
@@ -671,11 +696,19 @@ def vstash_search(
             embedding is known to be diffuse).
         fts_weight: Pin the RRF FTS weight. Same semantics and range as
             vec_weight.
-        fts_only: If true, run FTS5 keyword search only — skip the vector ANN
-            scan, the distance cutoff, and adaptive RRF entirely. Useful for
-            debugging whether a retrieval miss is a vector problem or an FTS
-            problem, and for queries where the vector signal is known to be
-            unreliable. When true, vec_weight/fts_weight are ignored.
+        fts_only: DEPRECATED, use ``retrieval_mode="fts_only"`` instead.
+        retrieval_mode: Which search branches to run. One of ``"hybrid"``
+            (default), ``"vec_only"``, ``"fts_only"``.
+            - ``"hybrid"``: vector ANN + FTS5 + adaptive RRF. The
+              benchmark default.
+            - ``"vec_only"``: skip FTS5 entirely; force vec_weight=1.0,
+              fts_weight=0.0. Useful when the corpus has no meaningful
+              keyword signal (tabular, code where identifiers are
+              noise) or for benchmarking / ranking debug.
+            - ``"fts_only"``: skip vector ANN. Useful when the vector
+              signal is known to be unreliable.
+            When a non-hybrid mode is set, vec_weight/fts_weight are
+            ignored.
 
     Returns:
         JSON object with chunks array and relevance hint.
@@ -685,19 +718,23 @@ def vstash_search(
         cfg = _get_config()
         store = _get_store()
 
-        # Defensive type coercion — MCP clients can be inconsistent and may
-        # send JSON strings where booleans or floats are expected. Mirror the
-        # existing pattern used for top_k / recency_boost / mmr_lambda.
+        # Defensive type coercion -- MCP clients can be inconsistent and
+        # may send JSON strings where booleans / floats / enums are
+        # expected. Mirror the existing pattern used for top_k /
+        # recency_boost / mmr_lambda.
         #
-        # Precedence (documented in docs/mcp-server.md): if fts_only is
-        # True, vec_weight and fts_weight are ignored. Resolve fts_only
-        # FIRST and short-circuit the weight coercion when it's on — that
-        # way a caller who sends an out-of-range or unparseable weight
-        # together with fts_only=True still gets a successful FTS-only
-        # query instead of a coercion-error bailout for an argument that
-        # was semantically meant to be ignored.
+        # Precedence (documented in docs/mcp-server.md): if retrieval_mode
+        # is non-hybrid (or the deprecated fts_only=True is set),
+        # vec_weight/fts_weight are ignored. Resolve the mode FIRST and
+        # short-circuit the weight coercion when it is non-hybrid --
+        # that way a caller who sends an out-of-range or unparseable
+        # weight together with retrieval_mode="fts_only" still gets a
+        # successful query instead of a coercion-error bailout for an
+        # argument that was semantically meant to be ignored.
+        mode_coerced = _coerce_retrieval_mode(retrieval_mode, "retrieval_mode")
         fts_only_coerced = _coerce_bool(fts_only, "fts_only")
-        if fts_only_coerced:
+        resolved_mode = VstashStore._resolve_retrieval_mode(mode_coerced, fts_only_coerced)
+        if resolved_mode != "hybrid":
             vec_weight_coerced = None
             fts_weight_coerced = None
         else:
@@ -718,7 +755,7 @@ def vstash_search(
             mmr_lambda=float(mmr_lambda),
             vec_weight=vec_weight_coerced,
             fts_weight=fts_weight_coerced,
-            fts_only=fts_only_coerced,
+            retrieval_mode=resolved_mode,
         )
 
         if not chunks:

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import TracebackType
+from typing import Literal
 
 from .chat import ask as _chat_ask
 from .config import VstashConfig, load_config
@@ -282,6 +283,7 @@ class Memory:
         vec_weight: float | None = None,
         fts_weight: float | None = None,
         fts_only: bool = False,
+        retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
         exact_match: str | None = None,
         exact_match_case_sensitive: bool = False,
     ) -> list[SearchResult]:
@@ -316,36 +318,51 @@ class Memory:
                 survive. #106, 2026-04-21.
             exact_match_case_sensitive: Whether ``exact_match`` is
                 case-sensitive. Default False (casefold compare).
-            fts_only: If True, run FTS5 keyword search only and skip the
-                vector ANN scan, distance cutoff, and adaptive RRF
-                entirely. Useful for debugging ranking, for queries
-                where vector embeddings are known to be diffuse
-                (cross-lingual, highly technical), or as a deliberate
-                fallback when the vector pool is expected to be empty.
-                MMR dedup still runs on the FTS-only result set. The
-                vector embedding is still computed (it costs ~1ms and
-                upstream code may need it), but it is never queried.
+            fts_only: DEPRECATED, use ``retrieval_mode="fts_only"``
+                instead. Still honoured for the v0.32 cycle with a
+                ``DeprecationWarning``. Will be removed in a future
+                release. Same short-circuit semantics: skip the vector
+                ANN scan, distance cutoff, and adaptive RRF.
+            retrieval_mode: Which search branches to run (default
+                ``"hybrid"``). Three values:
+
+                - ``"hybrid"`` (default): vector ANN + FTS5 + adaptive
+                  RRF + distance cutoff + MMR. This is the pipeline the
+                  paper and README benchmarks are measured against.
+                - ``"fts_only"`` (#152): skip the vector ANN scan,
+                  distance cutoff, and adaptive RRF. Useful for queries
+                  with diffuse vector representations (cross-lingual,
+                  highly technical) or as a fallback when the vector
+                  pool is expected to be empty.
+                - ``"vec_only"`` (#275): skip the FTS5 keyword search;
+                  force ``vec_weight=1.0``, ``fts_weight=0.0``. Useful
+                  when the corpus has no meaningful keyword signal
+                  (tabular data, code where identifiers are noise) or
+                  for benchmarking / ranking debug.
+
                 Mutually exclusive with ``vec_weight`` / ``fts_weight``:
-                when ``fts_only=True`` is set, any explicit weight
-                arguments are dropped *before* reaching
-                ``VstashStore.search`` — the validator will not see
-                them, so a nonsensical pair like
-                ``fts_only=True, vec_weight=1.5`` does not raise.
-                This is deliberate: ``fts_only`` is a stronger
-                statement of intent than pinned weights and should
-                not be rejected by a stale weight value.
+                non-``"hybrid"`` modes drop any explicit weight arguments
+                *before* reaching ``VstashStore.search`` so a nonsensical
+                pair like ``retrieval_mode="fts_only", vec_weight=1.5``
+                does not raise. The mode is a stronger statement of
+                intent than pinned weights.
 
         Returns:
             Ranked list of SearchResult ordered by relevance.
         """
         q_embedding = embed_query(query, self._cfg.embeddings.model)
-        # When fts_only is set, drop any caller-supplied weight
-        # arguments before they reach the store's validator. The store
-        # will force (vec_weight=0.0, fts_weight=1.0) internally on
-        # the fts_only branch, so forwarding caller weights would
-        # either no-op or raise `RRFWeightOutOfRangeError` for a
-        # nonsensical value the caller did not intend us to validate.
-        if fts_only:
+        # Resolve the mode at this layer so the deprecation warning
+        # fires at the Memory call site (not the store layer, which
+        # would show our own memory.py in the stacklevel).
+        _mode = self._store._resolve_retrieval_mode(retrieval_mode, fts_only)
+        # When a non-hybrid mode is active, drop any caller-supplied
+        # weight arguments before they reach the store's validator.
+        # The store will force the weights to (0.0, 1.0) or (1.0, 0.0)
+        # internally on the short-circuit branch, so forwarding caller
+        # weights would either no-op or raise
+        # ``RRFWeightOutOfRangeError`` for a nonsensical value the
+        # caller did not intend us to validate.
+        if _mode != "hybrid":
             vec_weight = None
             fts_weight = None
         return self._store.search(
@@ -354,7 +371,7 @@ class Memory:
             top_k=top_k,
             vec_weight=vec_weight,
             fts_weight=fts_weight,
-            fts_only=fts_only,
+            retrieval_mode=_mode,
             collection=self._resolve_collection(collection),
             project=self._resolve_project(project),
             layer=layer,
@@ -482,6 +499,7 @@ class Memory:
         vec_weight: float | None = None,
         fts_weight: float | None = None,
         fts_only: bool = False,
+        retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
     ) -> str:
         """Search memory + generate an LLM answer.
 
@@ -499,8 +517,9 @@ class Memory:
             vec_weight: Pin the RRF vector weight on the retrieval
                 call. See :meth:`search` for full semantics.
             fts_weight: Pin the RRF FTS weight on the retrieval call.
-            fts_only: If True, retrieve LLM context using FTS5 only —
-                no vector ANN, no distance cutoff. See :meth:`search`.
+            fts_only: DEPRECATED, use ``retrieval_mode="fts_only"``.
+            retrieval_mode: ``"hybrid"`` (default), ``"vec_only"``, or
+                ``"fts_only"``. See :meth:`search` for full semantics.
 
         Returns:
             Model response text.
@@ -518,6 +537,7 @@ class Memory:
             vec_weight=vec_weight,
             fts_weight=fts_weight,
             fts_only=fts_only,
+            retrieval_mode=retrieval_mode,
         )
         return _chat_ask(query, chunks, self._cfg, history)
 

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1559,13 +1559,16 @@ class VstashStore:
         added_after: str | None,
         added_before: str | None,
         mmr_lambda: float,
-        fts_only: bool,
+        retrieval_mode: str,
         cache_epoch: int,
     ) -> int:
         """Build the search cache key from the full set of query parameters.
 
         ``cache_epoch`` is mixed in so a write invalidates every cached
-        entry without having to scan the LRU.
+        entry without having to scan the LRU. ``retrieval_mode`` is
+        one of ``"hybrid" | "vec_only" | "fts_only"`` so queries that
+        short-circuit one branch do not collide with hybrid queries of
+        the same text.
         """
         emb_bytes = np.array(query_embedding, dtype=np.float32).tobytes()
         return hash(
@@ -1584,10 +1587,47 @@ class VstashStore:
                 added_after,
                 added_before,
                 mmr_lambda,
-                fts_only,
+                retrieval_mode,
                 cache_epoch,
             )
         )
+
+    @staticmethod
+    def _resolve_retrieval_mode(
+        retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None,
+        fts_only: bool,
+    ) -> Literal["hybrid", "vec_only", "fts_only"]:
+        """Normalize ``retrieval_mode`` + legacy ``fts_only`` into one enum.
+
+        Precedence: if ``retrieval_mode`` is set it wins. If only the
+        legacy ``fts_only=True`` is set, return ``"fts_only"`` and
+        emit a ``DeprecationWarning`` so callers migrate. Passing
+        ``fts_only=True`` together with a contradictory
+        ``retrieval_mode`` raises ``ValueError`` because there is no
+        obvious right choice.
+        """
+        if retrieval_mode is not None:
+            if fts_only and retrieval_mode != "fts_only":
+                raise ValueError(
+                    f"retrieval_mode={retrieval_mode!r} conflicts with fts_only=True; "
+                    "drop the legacy fts_only argument (it is deprecated)."
+                )
+            if retrieval_mode not in ("hybrid", "vec_only", "fts_only"):
+                raise ValueError(
+                    f"retrieval_mode must be one of 'hybrid', 'vec_only', 'fts_only'; "
+                    f"got {retrieval_mode!r}"
+                )
+            return retrieval_mode
+        if fts_only:
+            import warnings
+
+            warnings.warn(
+                "fts_only=True is deprecated, use retrieval_mode='fts_only' instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            return "fts_only"
+        return "hybrid"
 
     @staticmethod
     def _resolve_rrf_weights(
@@ -1826,6 +1866,7 @@ class VstashStore:
         added_before: str | None = None,
         mmr_lambda: float = 0.5,
         fts_only: bool = False,
+        retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
         exact_match: str | None = None,
         exact_match_case_sensitive: bool = False,
         _tracer: _PipelineTracer | None = None,
@@ -1863,22 +1904,36 @@ class VstashStore:
             exact_match_case_sensitive: Toggle for the above. Default
                 ``False`` does a casefold comparison which matches
                 typical retrieval-filter UX expectations.
-            fts_only: If True, short-circuit the pipeline to FTS5 only (#152):
-                no vector ANN scan, no distance cutoff, no adaptive
-                RRF weight computation. FTS5 hits are still fed
-                through the RRF scoring formula (with ``vec_weight=0.0``
-                and ``fts_weight=1.0``, so each hit scores
-                ``1/(60 + fts_rank)``), through MMR dedup, through the
-                optional recency boost, and through context expansion
-                — it is not a raw BM25 score dump.  Useful for
-                debugging ranking, for queries where vector embeddings
-                are known to be diffuse (cross-lingual, highly
-                technical), or as a deliberate fallback when the
-                vector pool is expected to be empty.
+            fts_only: DEPRECATED, use ``retrieval_mode="fts_only"``.
+                Will be removed in a future release.
+            retrieval_mode: Which search branches to run (default
+                ``"hybrid"``). Three values:
+
+                - ``"hybrid"`` (default): vector ANN + FTS5 + adaptive
+                  RRF + distance cutoff + MMR. This is the pipeline the
+                  paper and README benchmarks are measured against.
+                - ``"fts_only"`` (#152): skip the vector ANN scan,
+                  distance cutoff, and adaptive RRF. FTS5 hits still
+                  flow through RRF scoring (``vec_weight=0.0``,
+                  ``fts_weight=1.0``), MMR, recency boost, and context
+                  expansion — not a raw BM25 dump. Useful for queries
+                  with diffuse vector representations (cross-lingual,
+                  highly technical) or as a fallback when the vector
+                  pool is expected to be empty.
+                - ``"vec_only"`` (#275): symmetric to ``"fts_only"``.
+                  Skip the FTS5 keyword search; force
+                  ``vec_weight=1.0``, ``fts_weight=0.0``. Useful when
+                  the corpus has no meaningful keyword signal (tabular
+                  data, code where identifiers are noise, cross-lingual
+                  corpora where tokenization disagrees with the query)
+                  or for benchmarking / ranking debug.
 
         Returns:
             Ranked list of SearchResult ordered by descending score.
         """
+        _mode = self._resolve_retrieval_mode(retrieval_mode, fts_only)
+        _fts_only = _mode == "fts_only"
+        _vec_only = _mode == "vec_only"
         # Fail-safe validation at the public API boundary (#133).  Runs
         # before any work — if the caller passed a 50k-token query or a
         # negative top_k, we reject it here instead of crashing inside
@@ -1918,7 +1973,7 @@ class VstashStore:
                 added_after=added_after,
                 added_before=added_before,
                 mmr_lambda=mmr_lambda,
-                fts_only=fts_only,
+                retrieval_mode=_mode,
                 cache_epoch=self._cache_epoch,
             )
 
@@ -1961,16 +2016,28 @@ class VstashStore:
                     registry.counter_inc("query_cache_hits_total")
                     return cached
 
-            # FTS-only short-circuit (#152): bypass vector search entirely.
-            # This forces the weights to (0.0, 1.0) and disables adaptive
-            # RRF so the pipeline cannot silently re-enable the vector
-            # path.  The vector search, distance cutoff, and relevance
-            # filter blocks below are all guarded on `not fts_only` or
-            # on `vec_rows` being non-empty, so the downstream MMR /
-            # scoring path runs unchanged on FTS-only input.
-            if fts_only:
+            # Branch short-circuits for non-hybrid modes.
+            #
+            # FTS-only (#152): bypass vector search entirely. Force
+            # weights to (0.0, 1.0) and disable adaptive RRF so the
+            # pipeline cannot silently re-enable the vector path. The
+            # vector search, distance cutoff, and relevance filter
+            # blocks below are guarded on ``not _fts_only`` or on
+            # ``vec_rows`` being non-empty, so downstream MMR / scoring
+            # runs unchanged.
+            #
+            # Vec-only (#275): symmetric. Bypass the FTS5 query. Force
+            # weights to (1.0, 0.0) and disable adaptive RRF so the
+            # FTS path cannot re-enable itself via IDF signals. The
+            # ``fts_rows`` block below is skipped when ``_vec_only``
+            # so no FTS hits ever enter the RRF fusion.
+            if _fts_only:
                 vec_weight = 0.0
                 fts_weight = 1.0
+                adaptive_rrf = False
+            elif _vec_only:
+                vec_weight = 1.0
+                fts_weight = 0.0
                 adaptive_rrf = False
 
             # Adaptive RRF: compute weights from query characteristics (IDF + length)
@@ -1997,7 +2064,7 @@ class VstashStore:
 
             # --- Vector search ---
             vec_rows: list = []
-            if fts_only:
+            if _fts_only:
                 # #152: skip vector ANN entirely. No candidates, no
                 # distances, no distance-cutoff work downstream. Set
                 # last_best_distance to the worst possible so the
@@ -2015,12 +2082,12 @@ class VstashStore:
                     _tracer.record(
                         "vector_search",
                         passed=True,
-                        detail="fts_only=True: vector search intentionally skipped by caller",
+                        detail="retrieval_mode='fts_only': vector search intentionally skipped by caller",
                     )
                     _tracer.record(
                         "distance_cutoff",
                         passed=True,
-                        detail="fts_only=True: no distance cutoff applied",
+                        detail="retrieval_mode='fts_only': no distance cutoff applied",
                     )
             elif self._snap is not None and len(self._snap) > 0:
                 # SnapVec ANN search — returns list[(id, distance)]
@@ -2073,7 +2140,7 @@ class VstashStore:
             # In fts_only mode the "vector_search" and "distance_cutoff"
             # stages were already recorded as skipped above; don't
             # overwrite them with a generic "not found" verdict.
-            if track_target is not None and not fts_only:
+            if track_target is not None and not _fts_only:
                 target_vec_rank: int | None = None
                 target_vec_distance: float | None = None
                 for i, row in enumerate(vec_rows):
@@ -2186,54 +2253,69 @@ class VstashStore:
             # --- FTS5 search ---
             words = query_text.split()
             safe_query, quoted_words = self._build_fts_match_query(query_text, words)
-            try:
-                fts_rows = self._conn.execute(
-                    f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq,
-                           rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
-                    FROM fts_chunks f
-                    JOIN chunks c ON c.id = f.rowid
-                    JOIN documents d ON d.id = c.doc_id
-                    WHERE fts_chunks MATCH ?
-                      {col_clause}
-                    ORDER BY rank
-                    LIMIT ?
-                    """,
-                    [safe_query, *filter_params, candidate_pool],
-                ).fetchall()
-            except sqlite3.OperationalError:
-                # FTS5 query syntax error (e.g. single char) — fall back to no FTS
+            if _vec_only:
+                # #275: caller asked to bypass keyword search entirely.
+                # Produce no FTS rows; downstream RRF scoring uses
+                # weights (1.0, 0.0) so the absence cannot re-weight
+                # anything. Record the stage in the tracer as an
+                # intentional skip (not a miss) for parity with the
+                # fts_only path above.
                 fts_rows = []
-
-            # --- Track: FTS search stage ---
-            if track_target is not None:
-                target_fts_rank: int | None = None
-                for i, row in enumerate(fts_rows):
-                    if int(row["id"]) == track_target:
-                        target_fts_rank = i
-                        break
-                stemmed_terms = self._stem_terms(words) if words else []
-                if target_fts_rank is not None:
+                if track_target is not None and _tracer is not None:
                     _tracer.record(
                         "fts_search",
                         passed=True,
-                        rank=target_fts_rank,
-                        detail=(
-                            f"Matched FTS at rank {target_fts_rank + 1}/{len(fts_rows)}. "
-                            f"Stemmed query terms: {stemmed_terms}"
-                        ),
+                        detail="retrieval_mode='vec_only': FTS5 search intentionally skipped by caller",
                     )
-                else:
-                    _tracer.record(
-                        "fts_search",
-                        passed=False,
-                        detail=(
-                            f"Did not match FTS5. Stemmed query terms: {stemmed_terms}. "
-                            "The chunk text does not contain any of these stems "
-                            "(after porter stemming)."
-                        ),
-                        counterfactual="Would need a query containing words from the chunk's vocabulary",
-                    )
+            else:
+                try:
+                    fts_rows = self._conn.execute(
+                        f"""
+                        SELECT c.id, c.text, d.title, d.path, c.seq,
+                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
+                        FROM fts_chunks f
+                        JOIN chunks c ON c.id = f.rowid
+                        JOIN documents d ON d.id = c.doc_id
+                        WHERE fts_chunks MATCH ?
+                          {col_clause}
+                        ORDER BY rank
+                        LIMIT ?
+                        """,
+                        [safe_query, *filter_params, candidate_pool],
+                    ).fetchall()
+                except sqlite3.OperationalError:
+                    # FTS5 query syntax error (e.g. single char) — fall back to no FTS
+                    fts_rows = []
+
+                # --- Track: FTS search stage ---
+                if track_target is not None:
+                    target_fts_rank: int | None = None
+                    for i, row in enumerate(fts_rows):
+                        if int(row["id"]) == track_target:
+                            target_fts_rank = i
+                            break
+                    stemmed_terms = self._stem_terms(words) if words else []
+                    if target_fts_rank is not None:
+                        _tracer.record(
+                            "fts_search",
+                            passed=True,
+                            rank=target_fts_rank,
+                            detail=(
+                                f"Matched FTS at rank {target_fts_rank + 1}/{len(fts_rows)}. "
+                                f"Stemmed query terms: {stemmed_terms}"
+                            ),
+                        )
+                    else:
+                        _tracer.record(
+                            "fts_search",
+                            passed=False,
+                            detail=(
+                                f"Did not match FTS5. Stemmed query terms: {stemmed_terms}. "
+                                "The chunk text does not contain any of these stems "
+                                "(after porter stemming)."
+                            ),
+                            counterfactual="Would need a query containing words from the chunk's vocabulary",
+                        )
 
             # --- Adaptive fallback: vector pool empty (#156) ---
             # If the vector pool is empty — either the initial ANN scan
@@ -2285,7 +2367,7 @@ class VstashStore:
                 fts_weight=fts_weight,
                 relevant_chunk_ids=relevant_chunk_ids,
                 effective_k=effective_k,
-                fts_only=fts_only,
+                fts_only=_fts_only,
                 explain=explain,
             )
 


### PR DESCRIPTION
## Summary

Implements #275. Adds opt-in ``retrieval_mode`` parameter across every search surface (VstashStore, Memory, MCP, VstashRetriever). Three values:

- ``"hybrid"`` (default, unchanged)
- ``"vec_only"`` (new): symmetric to ``fts_only``, skip FTS5 branch
- ``"fts_only"`` (existing #152, now named consistently)

Default stays ``"hybrid"``. Changing the default was out of scope per the issue discussion: the paper + v3 model claim rests on the hybrid pipeline, and flipping the default would invalidate published numbers.

## Changes

- ``vstash/store.py`` -- ``retrieval_mode`` param on ``search``; new ``_resolve_retrieval_mode`` static helper normalises the legacy ``fts_only`` bool into the enum; ``_compute_search_cache_key`` now takes ``retrieval_mode: str`` so modes do not collide in the LRU cache; new short-circuit branch for ``vec_only`` (force weights ``(1.0, 0.0)``, disable adaptive RRF, skip FTS5 SQL entirely, record intent in the tracer for miss_analysis).
- ``vstash/memory.py`` -- ``Memory.search`` + ``Memory.ask`` plumb ``retrieval_mode`` through. Resolver called at the Memory layer so ``DeprecationWarning`` for legacy ``fts_only=True`` points at the caller's frame, not our internal code.
- ``vstash/mcp.py`` -- ``vstash_search`` + ``vstash_ask`` accept ``retrieval_mode`` as a string; new ``_coerce_retrieval_mode`` helper mirrors the defensive pattern used for floats/bools on the MCP boundary.
- ``vstash/langchain.py`` -- ``VstashRetriever.retrieval_mode`` field plumbed through ``search_kwargs``.

## Deprecation

``fts_only=True`` still works for one release with a ``DeprecationWarning`` that points at ``retrieval_mode='fts_only'``. Combining ``fts_only=True`` with a contradictory ``retrieval_mode`` raises ``ValueError`` rather than silently ignoring one of the inputs.

## Test plan

- [x] ``tests/test_retrieval_mode.py`` (9 new). Resolver contract, vec_only skips FTS (``_fuse_rrf_scores`` receives ``fts_rows=[]`` and weights ``(1.0, 0.0)``), hybrid non-regression, cache-key separation across modes.
- [x] ``tests/test_memory.py`` -- updated to assert Memory forwards ``retrieval_mode`` (not ``fts_only``) to the store boundary.
- [x] ``tests/test_mcp.py`` -- updated 8 existing tests + 1 new test for the unknown-mode-string error path.
- [x] Full suite: 1038 passed, 7 deselected (benchmarks + pre-existing #271 hermeticity failure).
- [x] **BEIR non-regression gate** (issue acceptance): ``tests/test_beir_regression.py::test_scifact_ndcg`` passes post-change, confirming hybrid default is byte-identical on the benchmarked dataset.

## Out of scope (stated in #275)

- Changing the default mode.
- Adding more modes (``mmr_only`` / ``exact_only``).
- Web UI surfacing (backend accepts it; UI wiring lives in a follow-up).

## CI note

Pre-existing ``ruff check`` errors remain only in untracked ``experiments/retrain_multimodel.ipynb`` (Jay's WIP). They are not visible to CI.