### PR TITLE
feat(#278): custom encoder resolver hook in vstash.embed

### DIFF
--- a/tests/test_encoder_resolver.py
+++ b/tests/test_encoder_resolver.py
@@ -1,0 +1,344 @@
+"""Tests for the custom encoder resolver hook (#278).
+
+Covers registration / unregistration semantics, priority over every
+built-in backend, fall-through when no resolver claims the name, fault
+isolation between resolvers, dim discovery, and the ``get_embedding_dim``
+integration that callers need for store construction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import vstash.embed as embed_mod
+from vstash.embed import (
+    Encoder,
+    embed_query,
+    embed_texts,
+    get_embedding_dim,
+    register_encoder_resolver,
+    unregister_encoder_resolver,
+)
+
+
+class _StubEncoder:
+    """Minimal fake that satisfies the :class:`Encoder` protocol.
+
+    Returns deterministic one-hot vectors per text so tests can assert
+    which encoder actually produced an output without inspecting
+    floating-point equality.
+    """
+
+    def __init__(self, dim: int = 8, tag: float = 1.0) -> None:
+        self.embedding_dim = dim
+        self._tag = tag
+        self.calls: list[list[str]] = []
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        self.calls.append(list(texts))
+        return [[self._tag] * self.embedding_dim for _ in texts]
+
+
+class _NumpyStubEncoder:
+    """Alternative stub returning a numpy array, to cover the
+    ``.tolist()`` branch in :func:`_embed_via_custom`.
+    """
+
+    def __init__(self, dim: int = 4) -> None:
+        self.embedding_dim = dim
+
+    def encode(self, texts: list[str]):
+        import numpy as np
+
+        return np.full((len(texts), self.embedding_dim), 2.0, dtype=np.float32)
+
+
+@pytest.fixture(autouse=True)
+def _clean_resolvers():
+    """Clear the global resolver list around every test.
+
+    The resolver registry is process-global by design; tests must not
+    leak registrations across cases, so we snapshot before and restore
+    after.  This fixture is the contract that keeps the registry safe
+    to touch in unit tests.
+    """
+    before = list(embed_mod._encoder_resolvers)
+    embed_mod._encoder_resolvers.clear()
+    try:
+        yield
+    finally:
+        embed_mod._encoder_resolvers.clear()
+        embed_mod._encoder_resolvers.extend(before)
+
+
+# ------------------------------------------------------------------ #
+# Protocol conformance                                                 #
+# ------------------------------------------------------------------ #
+
+
+class TestEncoderProtocol:
+    def test_stub_satisfies_protocol_at_runtime(self) -> None:
+        enc = _StubEncoder()
+        assert isinstance(enc, Encoder)
+
+    def test_missing_embedding_dim_fails_isinstance(self) -> None:
+        class Bad:
+            def encode(self, texts: list[str]):
+                return []
+
+        assert not isinstance(Bad(), Encoder)
+
+
+# ------------------------------------------------------------------ #
+# Registration and unregistration                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestResolverRegistration:
+    def test_register_adds_to_list(self) -> None:
+        def resolver(name):
+            return None
+
+        register_encoder_resolver(resolver)
+        assert resolver in embed_mod._encoder_resolvers
+
+    def test_register_is_idempotent(self) -> None:
+        def resolver(name):
+            return None
+
+        register_encoder_resolver(resolver)
+        register_encoder_resolver(resolver)
+        assert embed_mod._encoder_resolvers.count(resolver) == 1
+
+    def test_unregister_removes(self) -> None:
+        def resolver(name):
+            return None
+
+        register_encoder_resolver(resolver)
+        unregister_encoder_resolver(resolver)
+        assert resolver not in embed_mod._encoder_resolvers
+
+    def test_unregister_unknown_is_noop(self) -> None:
+        def never_registered(name):
+            return None
+
+        # Must not raise.
+        unregister_encoder_resolver(never_registered)
+
+
+# ------------------------------------------------------------------ #
+# Resolver priority over built-ins                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestResolverPriority:
+    def test_resolver_wins_over_onnx_path(self) -> None:
+        """A registered resolver for a well-known FastEmbed model must
+        take priority over the default ONNX backend.  Proves the hook
+        runs before any backend detection.
+        """
+        stub = _StubEncoder(dim=4, tag=7.0)
+
+        def resolver(name: str) -> Any:
+            return stub if name == "BAAI/bge-small-en-v1.5" else None
+
+        register_encoder_resolver(resolver)
+
+        vecs = embed_texts(["hello", "world"], "BAAI/bge-small-en-v1.5")
+
+        assert stub.calls == [["hello", "world"]]
+        assert vecs == [[7.0] * 4, [7.0] * 4]
+
+    def test_resolver_wins_over_hf_onnx_detection(self) -> None:
+        """Names that look like HF repos (``owner/repo``) would normally
+        route through ``_embed_hf_onnx``.  The resolver must intercept
+        first, so a custom fine-tune that happens to share the naming
+        convention does not download the HF model behind the caller's
+        back.
+        """
+        stub = _StubEncoder(dim=6, tag=3.0)
+
+        def resolver(name: str) -> Any:
+            return stub if name == "me/private-lora-v5" else None
+
+        register_encoder_resolver(resolver)
+
+        vec = embed_query("q", "me/private-lora-v5")
+
+        assert stub.calls == [["q"]]
+        assert vec == [3.0] * 6
+
+    def test_first_resolver_wins(self) -> None:
+        """Registration order is priority order.  The first resolver
+        that returns a non-None encoder is used; later resolvers never
+        see the call.
+        """
+        first = _StubEncoder(dim=4, tag=1.0)
+        second = _StubEncoder(dim=4, tag=2.0)
+
+        def resolver_first(name):
+            return first if name == "custom" else None
+
+        def resolver_second(name):
+            return second if name == "custom" else None
+
+        register_encoder_resolver(resolver_first)
+        register_encoder_resolver(resolver_second)
+
+        vecs = embed_texts(["x"], "custom")
+
+        assert first.calls == [["x"]]
+        assert second.calls == []
+        assert vecs == [[1.0] * 4]
+
+
+# ------------------------------------------------------------------ #
+# Fall-through behaviour                                               #
+# ------------------------------------------------------------------ #
+
+
+class TestFallThrough:
+    def test_empty_texts_shortcircuits_before_resolver(self) -> None:
+        """``embed_texts([])`` returns ``[]`` without invoking any
+        resolver.  This keeps the empty-input contract cheap and avoids
+        surprising resolver authors with empty-list calls.
+        """
+        stub = _StubEncoder()
+
+        def resolver(name):
+            return stub
+
+        register_encoder_resolver(resolver)
+
+        assert embed_texts([], "anything") == []
+        assert stub.calls == []
+
+    def test_no_resolver_match_falls_through_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When every resolver returns None, the built-in ONNX path
+        fires.  We monkeypatch ``_embed_onnx`` so the test does not
+        need the fastembed model download.
+        """
+        called: list[tuple[list[str], str]] = []
+
+        def fake_onnx(texts, model_name):
+            called.append((list(texts), model_name))
+            return [[0.0] * 3 for _ in texts]
+
+        monkeypatch.setattr(embed_mod, "_embed_onnx", fake_onnx)
+        monkeypatch.setattr(embed_mod, "_check_daemon", lambda: None)
+        monkeypatch.setattr(embed_mod, "_resolve", lambda backend: "onnx")
+        monkeypatch.setattr(embed_mod, "_is_gemma_model", lambda name: False)
+        monkeypatch.setattr(embed_mod, "_is_hf_onnx_model", lambda name: False)
+
+        def resolver(name):
+            return None  # always defers
+
+        register_encoder_resolver(resolver)
+
+        embed_texts(["a", "b"], "BAAI/bge-small-en-v1.5")
+
+        assert called == [(["a", "b"], "BAAI/bge-small-en-v1.5")]
+
+
+# ------------------------------------------------------------------ #
+# Fault isolation                                                      #
+# ------------------------------------------------------------------ #
+
+
+class TestResolverFaultIsolation:
+    def test_raising_resolver_is_skipped(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A resolver that raises must not poison the registry -- later
+        resolvers still get their turn.  One bad resolver should not
+        silently disable custom encoders for the whole process.
+        """
+        good = _StubEncoder(dim=2, tag=9.0)
+
+        def resolver_bad(name):
+            raise RuntimeError("resolver is broken")
+
+        def resolver_good(name):
+            return good if name == "custom" else None
+
+        register_encoder_resolver(resolver_bad)
+        register_encoder_resolver(resolver_good)
+
+        import logging
+
+        with caplog.at_level(logging.ERROR, logger="vstash.embed"):
+            vecs = embed_texts(["z"], "custom")
+
+        assert vecs == [[9.0, 9.0]]
+        assert any("resolver is broken" in rec.message or rec.exc_info for rec in caplog.records)
+
+
+# ------------------------------------------------------------------ #
+# get_embedding_dim integration                                        #
+# ------------------------------------------------------------------ #
+
+
+class TestGetEmbeddingDimIntegration:
+    def test_custom_resolver_claims_unknown_name(self) -> None:
+        """``get_embedding_dim`` must honour the resolver for names
+        absent from ``KNOWN_DIMS`` -- otherwise callers cannot size a
+        new ``VstashStore`` for a plugged-in encoder.
+        """
+        stub = _StubEncoder(dim=512)
+
+        def resolver(name: str) -> Any:
+            return stub if name == "my-lora" else None
+
+        register_encoder_resolver(resolver)
+
+        assert get_embedding_dim("my-lora") == 512
+
+    def test_custom_resolver_overrides_known_dim(self) -> None:
+        """If a resolver registers a custom ``my/fork`` it may carry a
+        different dim than any built-in default; the resolver wins.
+        """
+        stub = _StubEncoder(dim=123)
+
+        def resolver(name: str) -> Any:
+            return stub if name == "BAAI/bge-small-en-v1.5" else None
+
+        register_encoder_resolver(resolver)
+
+        assert get_embedding_dim("BAAI/bge-small-en-v1.5") == 123
+
+    def test_unknown_name_still_raises(self) -> None:
+        """Without a resolver match, an unknown model still raises with
+        the hint to register one or update ``KNOWN_DIMS``.
+        """
+        with pytest.raises(ValueError, match="register_encoder_resolver"):
+            get_embedding_dim("totally-unknown-model-xyz")
+
+
+# ------------------------------------------------------------------ #
+# Output normalisation                                                 #
+# ------------------------------------------------------------------ #
+
+
+class TestOutputNormalisation:
+    def test_numpy_output_is_converted_to_lists(self) -> None:
+        """Encoders that return numpy arrays (the SentenceTransformer
+        default) must end up as ``list[list[float]]`` so downstream
+        ``_serialize`` in the store can handle them uniformly.
+        """
+        np = pytest.importorskip("numpy")  # noqa: F841
+
+        stub = _NumpyStubEncoder(dim=4)
+
+        def resolver(name: str) -> Any:
+            return stub if name == "np-stub" else None
+
+        register_encoder_resolver(resolver)
+
+        vecs = embed_texts(["a", "b"], "np-stub")
+
+        assert len(vecs) == 2
+        assert all(isinstance(v, list) for v in vecs)
+        assert all(all(isinstance(x, float) for x in v) for v in vecs)
+        assert vecs == [[2.0] * 4, [2.0] * 4]

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -20,12 +20,119 @@ import os
 import platform
 import threading
 import urllib.request
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from fastembed import TextEmbedding
 
 _logger = logging.getLogger(__name__)
+
+
+# ------------------------------------------------------------------ #
+# Custom encoder plug-in hook (#278)                                   #
+# ------------------------------------------------------------------ #
+
+
+@runtime_checkable
+class Encoder(Protocol):
+    """Shape a plugged-in encoder must satisfy.
+
+    ``embedding_dim`` lets callers of :func:`get_embedding_dim` discover
+    the output size without running the model.  ``encode`` returns a
+    matrix of shape ``(len(texts), embedding_dim)``; lists of floats or
+    numpy arrays both work.  SentenceTransformer and PEFT-wrapped ST
+    models already match this protocol; see #278 for motivation.
+    """
+
+    embedding_dim: int
+
+    def encode(self, texts: list[str]):  # -> list[list[float]] | np.ndarray
+        ...
+
+
+#: Global list of custom encoder resolvers, consulted in registration
+#: order.  Each resolver receives a ``model_name`` string and returns
+#: an :class:`Encoder` if it handles that name, otherwise ``None`` to
+#: defer to the built-in backends.  See :func:`register_encoder_resolver`.
+_encoder_resolvers: list[Callable[[str], "Encoder | None"]] = []
+_encoder_resolvers_lock = threading.Lock()
+
+
+def register_encoder_resolver(resolver: Callable[[str], "Encoder | None"]) -> None:
+    """Register a custom encoder resolver.
+
+    Resolvers are consulted **before** every built-in embedding path
+    (daemon delegation, Gemma, HF ONNX, MLX, FastEmbed).  The first
+    resolver that returns a non-``None`` encoder wins; its ``encode``
+    method is then used for the call.  This lets callers plug in
+    LoRA-adapted, locally-fine-tuned, or otherwise-unnamable encoders
+    without monkey-patching :func:`embed_texts`.
+
+    Resolvers are process-global.  Callers are responsible for
+    registering them before any ingest or search uses the matching
+    model name.  Registrations are idempotent per object identity
+    (duplicate ``register`` calls with the same function are a no-op).
+
+    Args:
+        resolver: Callable taking a ``model_name`` and returning an
+            object that satisfies the :class:`Encoder` protocol, or
+            ``None`` to defer to the next resolver / built-in.
+
+    See :func:`unregister_encoder_resolver`.
+    """
+    with _encoder_resolvers_lock:
+        if resolver not in _encoder_resolvers:
+            _encoder_resolvers.append(resolver)
+
+
+def unregister_encoder_resolver(resolver: Callable[[str], "Encoder | None"]) -> None:
+    """Remove a previously-registered resolver.
+
+    No-op if the resolver was never registered.  Primarily useful in
+    tests that want process-level hygiene between cases.
+    """
+    with _encoder_resolvers_lock:
+        try:
+            _encoder_resolvers.remove(resolver)
+        except ValueError:
+            pass
+
+
+def _resolve_custom_encoder(model_name: str) -> "Encoder | None":
+    """Walk the resolver list and return the first encoder that claims
+    ``model_name``.  Never raises -- a resolver that throws is logged
+    and treated as ``None`` so one bad resolver does not brick others.
+    """
+    # Snapshot under the lock so concurrent (un)register does not mutate
+    # the list mid-iteration; but call the resolver callbacks outside
+    # the lock to avoid holding it across user code.
+    with _encoder_resolvers_lock:
+        snapshot = list(_encoder_resolvers)
+    for resolver in snapshot:
+        try:
+            encoder = resolver(model_name)
+        except Exception:
+            _logger.exception(
+                "custom encoder resolver %r raised for model_name=%r; skipping",
+                resolver,
+                model_name,
+            )
+            continue
+        if encoder is not None:
+            return encoder
+    return None
+
+
+def _embed_via_custom(texts: list[str], encoder: "Encoder") -> list[list[float]]:
+    """Run a custom encoder and normalise its output to ``list[list[float]]``.
+
+    Accepts numpy arrays, nested lists, or any object with ``tolist``.
+    """
+    vecs = encoder.encode(texts)
+    tolist = getattr(vecs, "tolist", None)
+    if tolist is not None:
+        vecs = tolist()
+    return [list(map(float, v)) for v in vecs]
 
 
 # ------------------------------------------------------------------ #
@@ -74,21 +181,32 @@ BackendType = Literal["onnx", "mlx", "auto"]
 def get_embedding_dim(model_name: str) -> int:
     """Get the embedding dimensionality for a known model.
 
+    Custom encoders registered via :func:`register_encoder_resolver`
+    are consulted first -- their ``embedding_dim`` attribute is
+    authoritative for names they handle.  Built-in FastEmbed models
+    fall back to :data:`KNOWN_DIMS`.
+
     Args:
-        model_name: FastEmbed model identifier.
+        model_name: Model identifier (FastEmbed name or a custom name
+            handled by a registered resolver).
 
     Returns:
-        Embedding dimension for known models.
+        Embedding dimension.
 
     Raises:
-        ValueError: If the model is not in the known registry.
+        ValueError: If the model is not in the known registry and no
+            registered resolver claims the name.
     """
+    custom = _resolve_custom_encoder(model_name)
+    if custom is not None:
+        return int(custom.embedding_dim)
     dim = KNOWN_DIMS.get(model_name)
     if dim is None:
         raise ValueError(
             f"Unknown embedding model: '{model_name}'. "
             f"Known models: {', '.join(sorted(KNOWN_DIMS))}. "
-            "Add it to KNOWN_DIMS in embed.py with its dimension."
+            "Add it to KNOWN_DIMS in embed.py with its dimension, or "
+            "register a custom resolver via register_encoder_resolver()."
         )
     return dim
 
@@ -685,6 +803,17 @@ def embed_texts(
     Returns:
         List of float vectors, one per input text.
     """
+    if not texts:
+        return []
+
+    # Custom resolvers win over every built-in path -- the daemon only
+    # has the default model loaded, and name-based backend detection
+    # (_is_gemma_model, _is_hf_onnx_model) would false-match a custom
+    # name that happens to share a prefix.
+    custom = _resolve_custom_encoder(model_name)
+    if custom is not None:
+        return _embed_via_custom(texts, custom)
+
     url = _check_daemon()
     if url is not None:
         result = _daemon_embed_texts(texts, url, model_name)
@@ -719,6 +848,12 @@ def embed_query(
     Returns:
         Float vector for the query.
     """
+    # Custom resolvers win over every built-in path (see embed_texts).
+    custom = _resolve_custom_encoder(model_name)
+    if custom is not None:
+        vecs = _embed_via_custom([text], custom)
+        return vecs[0]
+
     url = _check_daemon()
     if url is not None:
         result = _daemon_embed_query(text, url, model_name)


### PR DESCRIPTION
## Summary

Closes #278 (minimum viable slice).

Adds `register_encoder_resolver(fn)` / `unregister_encoder_resolver`
plus an `Encoder` `Protocol` at the top of `vstash/embed.py`.
`embed_texts`, `embed_query`, and `get_embedding_dim` now consult the
registry **before** any built-in path (daemon delegation, Gemma, HF
ONNX, MLX, FastEmbed).  The first resolver that returns a non-None
encoder handles the call; otherwise the existing resolution fires.

## Motivation

Every built-in backend takes a `model_name: str` that must be resolvable
by a FastEmbed-style name.  LoRA / PEFT adapters, locally fine-tuned
checkpoints, and composed encoders have no such name -- they are
in-memory objects.  The resolver hook is the smallest API that lets
callers plug one in without monkey-patching.

Driver use case (not in this PR): `v5-lora` LongMemEval fine-tune of
BGE-small.  Measured +8.9 pp R@1 over base BGE on LME dev, ships as
sibling not replacement -- only opt-in callers should see it.  This
PR unblocks exactly that scenario without touching the store schema.

## Design highlights

- **Priority**: custom resolvers win over daemon + every name-based
  backend detection.  A custom name that happens to look like an HF
  repo (`owner/repo`) would otherwise silently download the HF model.
- **Fault isolation**: a resolver that raises is logged and skipped;
  one bad resolver cannot brick the others.
- **Snapshot-then-call**: the resolver list is copied under a lock;
  callbacks run outside the lock so user code cannot deadlock a
  re-entrant register.
- **Output normalisation**: accepts numpy arrays or nested lists,
  returns `list[list[float]]` uniformly so downstream `_serialize`
  in the store handles it like any other backend.
- **Process-global**: callers register once at process start; the
  registry is module-level state shared by CLI, MCP, and SDK paths.

## Encoder protocol

```python
@runtime_checkable
class Encoder(Protocol):
    embedding_dim: int
    def encode(self, texts: list[str]):  # list[list[float]] | np.ndarray
        ...
```

`SentenceTransformer` and PEFT-wrapped ST models already match.

## Out of scope (follow-up)

- Per-collection encoder routing in the store.  Today `store.search
  (collection=X)` does not consult a collection-level encoder; the
  caller already controls the query embedding it passes in, so the
  minimum slice is enough for the LoRA use case that motivated #278.
- Mixed-dim-per-collection via per-collection `vec_chunks_<name>`
  tables.  Would require a v2 -> v3 schema migration; worth a
  separate issue once someone needs two dims in one DB.
- `vstash serve` daemon resolver registration.  The daemon runs in
  a subprocess that does not share the parent's registry; custom
  encoders always fall back to the in-process code path today.

## Tests

16 new cases in `tests/test_encoder_resolver.py` cover:

- Protocol conformance (runtime `isinstance`).
- Register idempotency, unregister-unknown no-op.
- Priority over ONNX default and HF ONNX name detection.
- First-resolver-wins ordering.
- Fall-through when every resolver returns `None`.
- Empty-input short-circuit.
- Fault isolation on a raising resolver.
- `get_embedding_dim` integration (unknown-but-custom, override
  known dim, raise with hint for unknown).
- Numpy output normalisation.

Full suite: **1081 passing**, 6 deselected.  Ruff + format clean.