### PR TITLE
fix: address Copilot + Gemini review feedback on #286 and #287

### DIFF
--- a/tests/test_encoder_resolver.py
+++ b/tests/test_encoder_resolver.py
@@ -496,3 +496,29 @@ class TestShapeValidation:
 
         with pytest.raises(ValueError, match="vector at index 1 with dimension 3"):
             embed_texts(["a", "b"], "ragged")
+
+    def test_flat_1d_output_raises_actionable_value_error(self) -> None:
+        """An encoder that returns a flat 1-D sequence (``[0.1, 0.2,
+        0.3]``) instead of a matrix can pass the row-count check when
+        ``batch_size == embedding_dim``.  The per-row ``len(v)`` then
+        hits a scalar and used to raise a bare ``TypeError``.  The
+        guard must reraise as ``ValueError`` with the offending type
+        so the caller sees the same failure shape as other malformed
+        outputs.
+        """
+
+        class Flat1D:
+            embedding_dim = 3
+
+            def encode(self, texts):
+                # Three "rows" of scalars -- a shape mistake that
+                # would silently pass a naive row-count check.
+                return [0.1, 0.2, 0.3]
+
+        def resolver(name: str) -> Any:
+            return Flat1D() if name == "flat" else None
+
+        register_encoder_resolver(resolver)
+
+        with pytest.raises(ValueError, match="non-sequence vector at index 0"):
+            embed_texts(["a", "b", "c"], "flat")

--- a/tests/test_encoder_resolver.py
+++ b/tests/test_encoder_resolver.py
@@ -342,3 +342,157 @@ class TestOutputNormalisation:
         assert all(isinstance(v, list) for v in vecs)
         assert all(all(isinstance(x, float) for x in v) for v in vecs)
         assert vecs == [[2.0] * 4, [2.0] * 4]
+
+
+# ------------------------------------------------------------------ #
+# Identity-based registration                                          #
+# ------------------------------------------------------------------ #
+
+
+class TestIdentityRegistration:
+    def test_equal_but_distinct_resolvers_coexist(self) -> None:
+        """Registration is by identity (``is``), not equality.  Two
+        resolvers that compare ``==`` but are different objects stay
+        distinct in the registry, because a custom ``__eq__`` on
+        resolvers (e.g. ``functools.partial`` comparing by args) would
+        otherwise silently collapse registrations.
+        """
+
+        class EqResolver:
+            def __init__(self, tag):
+                self.tag = tag
+                self.stub = _StubEncoder(dim=2, tag=tag)
+
+            def __eq__(self, other):  # all instances compare equal
+                return isinstance(other, EqResolver)
+
+            def __hash__(self):
+                return 0
+
+            def __call__(self, name):
+                return self.stub if name == "custom" else None
+
+        a = EqResolver(tag=1.0)
+        b = EqResolver(tag=2.0)
+        assert a == b  # value-equal
+        assert a is not b
+
+        register_encoder_resolver(a)
+        register_encoder_resolver(b)
+
+        # Both are in the registry despite value equality.
+        assert sum(1 for r in embed_mod._encoder_resolvers if r is a) == 1
+        assert sum(1 for r in embed_mod._encoder_resolvers if r is b) == 1
+
+    def test_unregister_matches_by_identity(self) -> None:
+        """``unregister`` removes the exact object, not a value-equal
+        peer.  Symmetric with registration.
+        """
+
+        class EqResolver:
+            def __eq__(self, other):
+                return isinstance(other, EqResolver)
+
+            def __hash__(self):
+                return 0
+
+            def __call__(self, name):
+                return None
+
+        a = EqResolver()
+        b = EqResolver()
+        register_encoder_resolver(a)
+        register_encoder_resolver(b)
+
+        unregister_encoder_resolver(a)
+
+        assert not any(r is a for r in embed_mod._encoder_resolvers)
+        assert any(r is b for r in embed_mod._encoder_resolvers)
+
+
+# ------------------------------------------------------------------ #
+# Encoder protocol validation at resolve time                          #
+# ------------------------------------------------------------------ #
+
+
+class TestEncoderProtocolValidation:
+    def test_malformed_encoder_is_skipped_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A resolver that returns an object missing ``.encode`` or
+        ``.embedding_dim`` is logged and skipped.  Without this, the
+        caller would see a cryptic ``AttributeError`` deep in
+        :func:`_embed_via_custom`.
+        """
+
+        class Malformed:
+            # No ``encode`` method, no ``embedding_dim`` attribute.
+            pass
+
+        good = _StubEncoder(dim=3, tag=4.0)
+
+        def resolver_bad(name):
+            return Malformed() if name == "x" else None
+
+        def resolver_good(name):
+            return good if name == "x" else None
+
+        register_encoder_resolver(resolver_bad)
+        register_encoder_resolver(resolver_good)
+
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="vstash.embed"):
+            vecs = embed_texts(["q"], "x")
+
+        assert vecs == [[4.0, 4.0, 4.0]]
+        assert any("does not satisfy the Encoder protocol" in rec.message for rec in caplog.records)
+
+
+# ------------------------------------------------------------------ #
+# Shape validation                                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestShapeValidation:
+    def test_wrong_row_count_raises(self) -> None:
+        """A custom encoder that returns the wrong number of rows
+        raises :class:`ValueError` with a clear message, instead of
+        cascading into an obscure sqlite-vec shape error during
+        ingest.
+        """
+
+        class BadRowCount:
+            embedding_dim = 3
+
+            def encode(self, texts):
+                # Return one fewer row than asked for.
+                return [[0.0, 0.0, 0.0] for _ in range(len(texts) - 1)]
+
+        def resolver(name: str) -> Any:
+            return BadRowCount() if name == "short" else None
+
+        register_encoder_resolver(resolver)
+
+        with pytest.raises(ValueError, match="returned 1 vectors for 2 texts"):
+            embed_texts(["a", "b"], "short")
+
+    def test_wrong_vector_dim_raises(self) -> None:
+        """A custom encoder returning the wrong dim per vector raises
+        with the offending index so the caller can locate it.
+        """
+
+        class BadDim:
+            embedding_dim = 4
+
+            def encode(self, texts):
+                # Second vector has 3 dims instead of 4.
+                return [[0.0] * 4, [0.0] * 3]
+
+        def resolver(name: str) -> Any:
+            return BadDim() if name == "ragged" else None
+
+        register_encoder_resolver(resolver)
+
+        with pytest.raises(ValueError, match="vector at index 1 with dimension 3"):
+            embed_texts(["a", "b"], "ragged")

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -166,23 +166,29 @@ def _embed_via_custom(texts: list[str], encoder: "Encoder") -> list[list[float]]
 
     Accepts numpy arrays, nested lists, or any object with ``tolist``.
     Validates shape: raises :class:`ValueError` if the returned batch
-    has the wrong row count or a vector has the wrong dimension, so
-    malformed custom encoders surface with an actionable message
-    instead of cascading into an obscure sqlite-vec shape error.
+    has the wrong row count, a row is not a sequence, or a vector has
+    the wrong dimension -- malformed custom encoders surface with an
+    actionable message instead of cascading into an obscure sqlite-vec
+    shape error or a bare ``TypeError`` from ``map(float, scalar)``.
 
     ``.tolist()`` on a numpy float array already returns Python floats,
-    so we can skip the ``map(float, ...)`` fallback on the hot path
-    and use it only for untyped nested lists.
+    so we skip the ``map(float, ...)`` pass on that hot path and only
+    coerce on the untyped-nested-list branch.
     """
     vecs = encoder.encode(texts)
     tolist = getattr(vecs, "tolist", None)
     if tolist is not None:
+        # numpy array -> list[list[float]] with Python floats already.
+        # No per-row coercion needed.
         normalized = tolist()
+        needs_float_coerce = False
     else:
-        # Untyped nested iterable (e.g. a plain Python list of lists).
-        # ``float()`` here rejects non-numeric elements with a clear
-        # ``TypeError`` before the vectors reach the store.
-        normalized = [list(map(float, v)) for v in vecs]
+        # Untyped nested iterable -- materialize without per-row
+        # coercion so the shape-validation loop below can raise a
+        # clear ``ValueError`` before any ``map(float, scalar)`` blows
+        # up as a bare ``TypeError`` on a flat 1-D output.
+        normalized = list(vecs)
+        needs_float_coerce = True
 
     if len(normalized) != len(texts):
         raise ValueError(
@@ -190,11 +196,29 @@ def _embed_via_custom(texts: list[str], encoder: "Encoder") -> list[list[float]]
         )
     expected_dim = int(encoder.embedding_dim)
     for i, v in enumerate(normalized):
-        if len(v) != expected_dim:
+        try:
+            row_dim = len(v)
+        except TypeError as e:
+            # ``len()`` on a scalar raises ``TypeError``; this happens
+            # when an encoder returns a 1-D list of floats (``[0.1,
+            # 0.2, 0.3]``) whose length happens to equal ``len(texts)``
+            # but which is actually a single flattened vector.  Re-raise
+            # as the ``ValueError`` the caller catches alongside every
+            # other shape-validation failure.
+            raise ValueError(
+                f"Custom encoder returned non-sequence vector at index {i}: "
+                f"{type(v).__name__}; expected a sequence of dimension {expected_dim}"
+            ) from e
+        if row_dim != expected_dim:
             raise ValueError(
                 f"Custom encoder returned vector at index {i} with "
-                f"dimension {len(v)}; expected {expected_dim}"
+                f"dimension {row_dim}; expected {expected_dim}"
             )
+        if needs_float_coerce:
+            try:
+                normalized[i] = list(map(float, v))
+            except (TypeError, ValueError) as e:
+                raise ValueError(f"Custom encoder returned non-numeric element at index {i}") from e
     return normalized
 
 

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -40,8 +40,26 @@ class Encoder(Protocol):
     ``embedding_dim`` lets callers of :func:`get_embedding_dim` discover
     the output size without running the model.  ``encode`` returns a
     matrix of shape ``(len(texts), embedding_dim)``; lists of floats or
-    numpy arrays both work.  SentenceTransformer and PEFT-wrapped ST
-    models already match this protocol; see #278 for motivation.
+    numpy arrays both work.
+
+    SentenceTransformer instances expose
+    ``get_sentence_embedding_dimension()`` rather than the
+    ``embedding_dim`` attribute this protocol expects, so a small
+    adapter is needed::
+
+        from sentence_transformers import SentenceTransformer
+
+        class STEncoder:
+            def __init__(self, model: SentenceTransformer) -> None:
+                self._m = model
+                self.embedding_dim = model.get_sentence_embedding_dimension()
+
+            def encode(self, texts: list[str]):
+                return self._m.encode(texts, normalize_embeddings=True)
+
+    PEFT-wrapped ST instances, custom pooling heads, and any other
+    ``.encode``-speaking object follow the same shape.  See #278 for
+    motivation.
     """
 
     embedding_dim: int
@@ -70,8 +88,10 @@ def register_encoder_resolver(resolver: Callable[[str], "Encoder | None"]) -> No
 
     Resolvers are process-global.  Callers are responsible for
     registering them before any ingest or search uses the matching
-    model name.  Registrations are idempotent per object identity
-    (duplicate ``register`` calls with the same function are a no-op).
+    model name.  Registrations are idempotent by **object identity**
+    (``is`` comparison), not value equality: a callable that defines
+    ``__eq__`` is still registered distinctly from its peers, which
+    matches what resolvers usually are (closures or bound methods).
 
     Args:
         resolver: Callable taking a ``model_name`` and returning an
@@ -81,27 +101,34 @@ def register_encoder_resolver(resolver: Callable[[str], "Encoder | None"]) -> No
     See :func:`unregister_encoder_resolver`.
     """
     with _encoder_resolvers_lock:
-        if resolver not in _encoder_resolvers:
+        if not any(r is resolver for r in _encoder_resolvers):
             _encoder_resolvers.append(resolver)
 
 
 def unregister_encoder_resolver(resolver: Callable[[str], "Encoder | None"]) -> None:
     """Remove a previously-registered resolver.
 
+    Identity-based match: removes the entry ``r`` where ``r is resolver``.
     No-op if the resolver was never registered.  Primarily useful in
     tests that want process-level hygiene between cases.
     """
     with _encoder_resolvers_lock:
-        try:
-            _encoder_resolvers.remove(resolver)
-        except ValueError:
-            pass
+        for i, r in enumerate(_encoder_resolvers):
+            if r is resolver:
+                del _encoder_resolvers[i]
+                return
 
 
 def _resolve_custom_encoder(model_name: str) -> "Encoder | None":
-    """Walk the resolver list and return the first encoder that claims
-    ``model_name``.  Never raises -- a resolver that throws is logged
-    and treated as ``None`` so one bad resolver does not brick others.
+    """Walk the resolver list and return the first valid encoder that
+    claims ``model_name``.
+
+    Never raises -- a resolver that throws is logged and treated as
+    ``None`` so one bad resolver does not brick the others.  A resolver
+    that returns something that does not satisfy the :class:`Encoder`
+    protocol (missing ``encode`` or ``embedding_dim``) is also logged
+    and skipped, so a malformed encoder does not surface as a
+    hard-to-trace ``AttributeError`` deep in the embedding call.
     """
     # Snapshot under the lock so concurrent (un)register does not mutate
     # the list mid-iteration; but call the resolver callbacks outside
@@ -118,8 +145,19 @@ def _resolve_custom_encoder(model_name: str) -> "Encoder | None":
                 model_name,
             )
             continue
-        if encoder is not None:
-            return encoder
+        if encoder is None:
+            continue
+        if not isinstance(encoder, Encoder):
+            _logger.warning(
+                "custom encoder resolver %r returned %r for model_name=%r, "
+                "which does not satisfy the Encoder protocol (needs "
+                "``embedding_dim`` and ``encode``); skipping",
+                resolver,
+                encoder,
+                model_name,
+            )
+            continue
+        return encoder
     return None
 
 
@@ -127,12 +165,37 @@ def _embed_via_custom(texts: list[str], encoder: "Encoder") -> list[list[float]]
     """Run a custom encoder and normalise its output to ``list[list[float]]``.
 
     Accepts numpy arrays, nested lists, or any object with ``tolist``.
+    Validates shape: raises :class:`ValueError` if the returned batch
+    has the wrong row count or a vector has the wrong dimension, so
+    malformed custom encoders surface with an actionable message
+    instead of cascading into an obscure sqlite-vec shape error.
+
+    ``.tolist()`` on a numpy float array already returns Python floats,
+    so we can skip the ``map(float, ...)`` fallback on the hot path
+    and use it only for untyped nested lists.
     """
     vecs = encoder.encode(texts)
     tolist = getattr(vecs, "tolist", None)
     if tolist is not None:
-        vecs = tolist()
-    return [list(map(float, v)) for v in vecs]
+        normalized = tolist()
+    else:
+        # Untyped nested iterable (e.g. a plain Python list of lists).
+        # ``float()`` here rejects non-numeric elements with a clear
+        # ``TypeError`` before the vectors reach the store.
+        normalized = [list(map(float, v)) for v in vecs]
+
+    if len(normalized) != len(texts):
+        raise ValueError(
+            f"Custom encoder returned {len(normalized)} vectors for {len(texts)} texts"
+        )
+    expected_dim = int(encoder.embedding_dim)
+    for i, v in enumerate(normalized):
+        if len(v) != expected_dim:
+            raise ValueError(
+                f"Custom encoder returned vector at index {i} with "
+                f"dimension {len(v)}; expected {expected_dim}"
+            )
+    return normalized
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -996,21 +996,37 @@ class VstashStore:
             # embedding blob in Python memory -- at 384-dim float32 a
             # million rows is ~1.5 GB which a naive ``fetchall`` +
             # ``executemany`` would paginate through Python lists.
-            # The backup is a regular ``TABLE`` (not ``vec0``) so the
-            # vec0 shadow tables don't collide with the real
-            # ``vec_chunks`` ones during the rebuild; ``ALTER TABLE
-            # RENAME`` on vec0 is a trap because the shadow tables
-            # (``vec_chunks_chunks``, ``vec_chunks_rowids``, ...) keep
-            # the original name and every subsequent query fails with
-            # ``no such table: main.vec_chunks_chunks``.
+            #
+            # Two non-obvious choices:
+            #
+            # 1. The backup is a regular (not ``vec0``) table so the
+            #    vec0 shadow tables don't collide with the real
+            #    ``vec_chunks`` ones during the rebuild.  ``ALTER TABLE
+            #    RENAME`` on vec0 is a trap because the shadow tables
+            #    (``vec_chunks_chunks``, ``vec_chunks_rowids``, ...)
+            #    keep the original name and every subsequent query
+            #    fails with ``no such table: main.vec_chunks_chunks``.
+            #
+            # 2. The backup lives in ``TEMP`` so it does not grow the
+            #    main DB file.  SQLite does not auto-shrink the main
+            #    DB after ``DROP TABLE``; pages stay on the freelist
+            #    and a migration on a large store would permanently
+            #    ~double the file size until a manual ``VACUUM``.
+            #    TEMP tables write to the per-connection temp DB and
+            #    disappear on connection close.
             conn.execute(
-                "CREATE TABLE _vec_chunks_v2_backup (rowid INTEGER PRIMARY KEY, embedding BLOB)"
+                "CREATE TEMP TABLE _vec_chunks_v2_backup "
+                "(rowid INTEGER PRIMARY KEY, embedding BLOB)"
             )
-            conn.execute(
+            # ``cursor.rowcount`` on an ``INSERT INTO ... SELECT``
+            # returns the number of rows inserted without the extra
+            # table scan that a follow-up ``SELECT COUNT(*)`` would
+            # cost on large stores.
+            cursor = conn.execute(
                 "INSERT INTO _vec_chunks_v2_backup (rowid, embedding) "
                 "SELECT rowid, embedding FROM vec_chunks"
             )
-            row_count = conn.execute("SELECT COUNT(*) FROM _vec_chunks_v2_backup").fetchone()[0]
+            row_count = cursor.rowcount
             conn.execute("DROP TABLE vec_chunks")
             conn.execute(
                 f"CREATE VIRTUAL TABLE vec_chunks "

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -992,20 +992,35 @@ class VstashStore:
                 conn.rollback()
                 return False
 
-            # For large DBs this is a one-shot O(N) read; at 384-dim
-            # float32 one million rows is ~1.5 GB.  Acceptable for the
-            # one-time migration.
-            rows = conn.execute("SELECT rowid, embedding FROM vec_chunks").fetchall()
+            # Copy entirely in SQL so we never materialize the full
+            # embedding blob in Python memory -- at 384-dim float32 a
+            # million rows is ~1.5 GB which a naive ``fetchall`` +
+            # ``executemany`` would paginate through Python lists.
+            # The backup is a regular ``TABLE`` (not ``vec0``) so the
+            # vec0 shadow tables don't collide with the real
+            # ``vec_chunks`` ones during the rebuild; ``ALTER TABLE
+            # RENAME`` on vec0 is a trap because the shadow tables
+            # (``vec_chunks_chunks``, ``vec_chunks_rowids``, ...) keep
+            # the original name and every subsequent query fails with
+            # ``no such table: main.vec_chunks_chunks``.
+            conn.execute(
+                "CREATE TABLE _vec_chunks_v2_backup (rowid INTEGER PRIMARY KEY, embedding BLOB)"
+            )
+            conn.execute(
+                "INSERT INTO _vec_chunks_v2_backup (rowid, embedding) "
+                "SELECT rowid, embedding FROM vec_chunks"
+            )
+            row_count = conn.execute("SELECT COUNT(*) FROM _vec_chunks_v2_backup").fetchone()[0]
             conn.execute("DROP TABLE vec_chunks")
             conn.execute(
                 f"CREATE VIRTUAL TABLE vec_chunks "
                 f"USING vec0(embedding float[{self.embedding_dim}] distance_metric=cosine)"
             )
-            if rows:
-                conn.executemany(
-                    "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
-                    [(r["rowid"], r["embedding"]) for r in rows],
-                )
+            conn.execute(
+                "INSERT INTO vec_chunks (rowid, embedding) "
+                "SELECT rowid, embedding FROM _vec_chunks_v2_backup"
+            )
+            conn.execute("DROP TABLE _vec_chunks_v2_backup")
             # Clear adaptive-threshold history: spread values recorded
             # under L2 are not comparable to cosine spreads.  Dropping
             # them lets the rolling window repopulate from v2 searches.
@@ -1017,7 +1032,7 @@ class VstashStore:
 
         logger.info(
             "Migrated vec_chunks from L2 to cosine metric (schema v1 -> v2, %d embeddings rebuilt)",
-            len(rows),
+            row_count,
         )
         return True
 


### PR DESCRIPTION
## Summary

Post-merge review feedback on #286 and #287 (both Copilot and Gemini) flagged five real issues.  This PR addresses all of them.

## #286 followups

### Migration OOM on large stores (flagged by Copilot + Gemini)

``_migrate_v1_to_v2`` was materializing every embedding in Python via ``fetchall()`` + ``executemany``.  At 384-dim float32 a million rows is ~1.5 GB of Python-side pressure during the one-time migration.

Fix: copy in SQL via a regular backup table.

```
CREATE TABLE _vec_chunks_v2_backup(rowid INTEGER PRIMARY KEY, embedding BLOB)
INSERT INTO _vec_chunks_v2_backup SELECT rowid, embedding FROM vec_chunks
DROP TABLE vec_chunks
CREATE VIRTUAL TABLE vec_chunks USING vec0(... distance_metric=cosine)
INSERT INTO vec_chunks SELECT rowid, embedding FROM _vec_chunks_v2_backup
DROP TABLE _vec_chunks_v2_backup
```

Why a plain ``TABLE`` (not another ``vec0``) as backup: Copilot suggested an ``ALTER TABLE RENAME`` path on a sibling vec0 table.  Verified by probe that this "works" (the RENAME accepts) but breaks every subsequent query with ``no such table: main.vec_chunks_chunks`` -- the vec0 shadow tables keep their original names and desynchronize from the renamed main table.

## #287 followups

### SentenceTransformer protocol mismatch (Gemini)

The ``Encoder`` docstring claimed ``SentenceTransformer`` already matches the protocol.  It doesn't -- ST exposes ``get_sentence_embedding_dimension()``, not ``embedding_dim``, so ``isinstance(st_model, Encoder)`` was returning ``False``.  Replaced the misleading claim with a documented adapter recipe inline.

### Identity-based registration (Copilot)

``register_encoder_resolver`` used ``in _encoder_resolvers`` (``==``) but the docstring claimed identity semantics.  A ``functools.partial`` or any ``__eq__``-defining callable would silently collapse registrations.  Switched to identity comparison (``any(r is resolver for r in ...)``) and mirrored it in ``unregister``.

### Protocol validation at resolve time (Copilot)

``_resolve_custom_encoder`` returned whatever the resolver gave back, so a malformed object surfaced later as ``AttributeError`` deep in the call path.  Now guards with ``isinstance(encoder, Encoder)`` and logs a warning + skips on mismatch -- the next resolver still gets a turn.

### Shape validation (Copilot)

``_embed_via_custom`` did not check row count or vector dim.  A buggy custom encoder would cascade into a confusing sqlite-vec shape error during ingest.  Now raises ``ValueError`` with the offending index / dims.

### Redundant ``map(float, v)`` after ``.tolist()`` (Gemini)

``numpy.ndarray.tolist()`` already returns Python floats; iterating again with ``map(float, v)`` was redundant.  Removed the extra pass on the numpy branch, kept the ``map(float, ...)`` fallback for untyped nested lists where element type is not guaranteed.

## Tests

5 new cases in ``tests/test_encoder_resolver.py``:

- Identity-based register / unregister when resolver defines ``__eq__``.
- Malformed encoder (missing protocol members) logged + skipped; later resolver still fires.
- Wrong row count raises ``ValueError``.
- Wrong vector dim raises ``ValueError``.

Full suite: **1086 passing**, 6 deselected.  Ruff + format clean.