### PR TITLE
fix(#289): convert snapvec similarity to cosine distance at call site

### DIFF
--- a/tests/test_snapvec_backend.py
+++ b/tests/test_snapvec_backend.py
@@ -99,6 +99,101 @@ class TestSnapvecSearch:
         assert len(results) <= 2
 
 
+class TestSnapvecDistanceSemantics:
+    """Regression tests for #289.
+
+    ``snapvec.SnapIndex.search`` returns (id, similarity) in [-1, 1],
+    but downstream ``distance_cutoff``, ``relevance_tier``, and
+    ``last_best_distance`` all live in cosine-distance space [0, 2].
+    The store must convert on read.  Before the fix, these invariants
+    all failed: a perfect match reported distance ~0.94 (similarity),
+    classified ``"low"`` by ``relevance_tier``, and the distance
+    cutoff never fired.
+    """
+
+    def test_last_best_distance_stays_in_cosine_range(self, snap_store):
+        """``last_best_distance`` must be in [0, 2] after a snapvec
+        search, matching the sqlite-vec backend contract.  A same-
+        vector query should land near 0, not near 1 (which would mean
+        similarity was leaking through).
+        """
+        emb = np.random.default_rng(0).standard_normal(DIM).tolist()
+        snap_store.add_document(
+            path="/s/a.md",
+            title="a",
+            chunks=["hello"],
+            embeddings=[emb],
+        )
+        snap_store.search(query_embedding=emb, query_text="hello", top_k=1)
+        assert 0.0 <= snap_store.last_best_distance <= 2.0
+        # Same vector -> similarity ~1 -> cos_dist ~0.  Allow slack for
+        # the snapvec 4-bit quantization (similarity comes back ~0.94
+        # on 32-dim random vectors, so distance ~0.06).
+        assert snap_store.last_best_distance <= 0.15
+
+    def test_relevance_tier_high_for_near_match(self, snap_store):
+        """A near-identical query produces ``"high"`` confidence under
+        cosine-space thresholds (``RELEVANCE_TIER_HIGH_MAX = 0.4513``).
+        Without the similarity->distance conversion, the store would
+        report the cosine similarity (~0.94) which falls in ``"low"``.
+        """
+        from vstash.store import relevance_tier
+
+        emb = np.random.default_rng(7).standard_normal(DIM).tolist()
+        snap_store.add_document(
+            path="/s/h.md",
+            title="h",
+            chunks=["topic"],
+            embeddings=[emb],
+        )
+        snap_store.search(query_embedding=emb, query_text="topic", top_k=1)
+        assert relevance_tier(snap_store.last_best_distance) == "high"
+
+    def test_distance_cutoff_drops_far_chunks(self, snap_store):
+        """The distance cutoff must actually gate results: an embedding
+        that points away from the query should be filterable.  Under
+        the pre-fix behaviour the similarity-as-distance inversion made
+        the cutoff a no-op for snapvec.
+        """
+        # Two clearly different directions in 32-dim space.
+        close_emb = np.zeros(DIM, dtype=np.float32)
+        close_emb[0] = 1.0
+        far_emb = np.zeros(DIM, dtype=np.float32)
+        far_emb[16] = 1.0  # orthogonal to close_emb
+        snap_store.add_document(
+            path="/s/close.md",
+            title="close",
+            chunks=["near topic"],
+            embeddings=[close_emb.tolist()],
+        )
+        snap_store.add_document(
+            path="/s/far.md",
+            title="far",
+            chunks=["distant topic"],
+            embeddings=[far_emb.tolist()],
+        )
+        # Tight cutoff: with correct distances the orthogonal chunk
+        # (cos_dist ~1.0) must be dropped when the near chunk is at
+        # cos_dist ~0.  1.15 * 0 ~ 0, so anything > 0 drops.
+        # ``retrieval_mode="vec_only"`` isolates the vec path so the
+        # FTS hit on the shared word "topic" cannot reintroduce the
+        # far chunk after the cutoff.
+        results = snap_store.search(
+            query_embedding=close_emb.tolist(),
+            query_text="topic",
+            top_k=5,
+            distance_cutoff=1.15,
+            adaptive_rrf=False,
+            retrieval_mode="vec_only",
+        )
+        paths = {r.path for r in results}
+        assert "/s/close.md" in paths
+        assert "/s/far.md" not in paths, (
+            f"distance_cutoff failed to drop the orthogonal chunk under snapvec; "
+            f"paths={paths}, last_best_distance={snap_store.last_best_distance}"
+        )
+
+
 class TestSnapvecDelete:
     def test_delete_removes_from_snap_index(self, populated_snap_store):
         initial_count = len(populated_snap_store._snap)

--- a/tests/test_snapvec_backend.py
+++ b/tests/test_snapvec_backend.py
@@ -114,9 +114,12 @@ class TestSnapvecDistanceSemantics:
     def test_last_best_distance_stays_in_cosine_range(self, snap_store):
         """``last_best_distance`` must be in [0, 2] after a snapvec
         search, matching the sqlite-vec backend contract.  A same-
-        vector query should land near 0, not near 1 (which would mean
-        similarity was leaking through).
+        vector query should land in the ``"high"`` relevance tier,
+        not ``"low"`` (which would mean similarity was leaking
+        through and ~0.94 was treated as distance).
         """
+        from vstash.store import RELEVANCE_TIER_HIGH_MAX
+
         emb = np.random.default_rng(0).standard_normal(DIM).tolist()
         snap_store.add_document(
             path="/s/a.md",
@@ -126,10 +129,12 @@ class TestSnapvecDistanceSemantics:
         )
         snap_store.search(query_embedding=emb, query_text="hello", top_k=1)
         assert 0.0 <= snap_store.last_best_distance <= 2.0
-        # Same vector -> similarity ~1 -> cos_dist ~0.  Allow slack for
-        # the snapvec 4-bit quantization (similarity comes back ~0.94
-        # on 32-dim random vectors, so distance ~0.06).
-        assert snap_store.last_best_distance <= 0.15
+        # Contract-based upper bound: a same-vector query must land
+        # in the ``"high"`` tier regardless of the bit-depth /
+        # quantization quirks of the snapvec backend.  Hardcoding a
+        # specific delta (e.g. 0.15) would couple the test to the
+        # 4-bit quantization error.
+        assert snap_store.last_best_distance <= RELEVANCE_TIER_HIGH_MAX
 
     def test_relevance_tier_high_for_near_match(self, snap_store):
         """A near-identical query produces ``"high"`` confidence under
@@ -172,14 +177,25 @@ class TestSnapvecDistanceSemantics:
             chunks=["distant topic"],
             embeddings=[far_emb.tolist()],
         )
+        # Query is ``close_emb`` with a small perturbation on a
+        # different index.  That guarantees cos_dist to the close
+        # chunk is > 0 (tiny, but nonzero), so we do not accidentally
+        # trigger the ``best_distance == 0`` cutoff-bypass in
+        # ``VstashStore.search`` (store.py:2368).  Without the
+        # perturbation, a snapvec build that returned an exact
+        # similarity of 1.0 on the identical vector would skip the
+        # cutoff entirely and leave the far chunk in the results,
+        # masking a real regression as a pass.
+        query_emb = close_emb.copy()
+        query_emb[1] = 0.05
+
         # Tight cutoff: with correct distances the orthogonal chunk
         # (cos_dist ~1.0) must be dropped when the near chunk is at
-        # cos_dist ~0.  1.15 * 0 ~ 0, so anything > 0 drops.
-        # ``retrieval_mode="vec_only"`` isolates the vec path so the
-        # FTS hit on the shared word "topic" cannot reintroduce the
-        # far chunk after the cutoff.
+        # cos_dist ~0.  ``retrieval_mode="vec_only"`` isolates the
+        # vec path so the FTS hit on the shared word "topic" cannot
+        # reintroduce the far chunk after the cutoff.
         results = snap_store.search(
-            query_embedding=close_emb.tolist(),
+            query_embedding=query_emb.tolist(),
             query_text="topic",
             top_k=5,
             distance_cutoff=1.15,

--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -164,6 +164,43 @@ class TestVstashStoreIVFPQIntegration:
         assert store._ivfpq_path.exists()
         store.close()
 
+    def test_ivfpq_last_best_distance_in_cosine_range(self, tmp_path):
+        """Regression test for #289: the per-backend branch in
+        ``VstashStore.search`` must not double-invert ``IVFPQBackend
+        .search`` output.  ``IVFPQBackend`` already returns cosine
+        distance in ``[0, 2]`` (see ``_ivfpq_backend.py``), so a same-
+        vector query under ``snapvec-ivfpq`` must land in the
+        ``"high"`` tier, not the ``"low"`` tier that double-inversion
+        would produce.
+        """
+        from vstash.store import RELEVANCE_TIER_HIGH_MAX, relevance_tier
+
+        store = VstashStore(
+            str(tmp_path / "ivfpq_dist.db"),
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+            ivfpq_rerank_candidates=32,
+        )
+        rng = np.random.default_rng(5)
+        vecs = _unit_vectors(rng, N, DIM)
+        store.add_document(
+            path="/t/dist.md",
+            title="Dist",
+            chunks=[f"chunk {i}" for i in range(N)],
+            embeddings=vecs.tolist(),
+            source_type="text",
+        )
+        store.fit_ivfpq(training_sample=N)
+
+        store.search(vecs[0].tolist(), "chunk 0", top_k=1)
+        assert 0.0 <= store.last_best_distance <= 2.0
+        assert store.last_best_distance <= RELEVANCE_TIER_HIGH_MAX
+        assert relevance_tier(store.last_best_distance) == "high"
+        store.close()
+
     def test_fit_ivfpq_rejects_non_ivfpq_backend(self, tmp_path):
         store = VstashStore(
             str(tmp_path / "s.db"),

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -2261,20 +2261,34 @@ class VstashStore:
                         detail="retrieval_mode='fts_only': no distance cutoff applied",
                     )
             elif self._snap is not None and len(self._snap) > 0:
-                # SnapVec ANN search: returns list[(id, similarity)]
-                # with similarity in [-1, 1], descending.  Downstream
-                # ``distance_cutoff`` + ``relevance_tier`` +
-                # ``last_best_distance`` all live in cosine-distance
-                # space ([0, 2]), so convert here: cos_dist = max(0,
-                # 1 - similarity).  ``max(0, ...)`` guards against
-                # tiny numerical overshoot on near-identical vectors.
-                # The sibling IVFPQ backend does the same conversion
-                # internally in ``_ivfpq_backend.py`` (#289).
+                # The two snapvec backends disagree on their return
+                # semantics and this shared call site has to reconcile
+                # them to the cosine-distance contract the rest of
+                # the pipeline assumes (#289).
+                #
+                # - Flat ``snapvec`` (``SnapIndex``) returns
+                #   ``(id, similarity)`` in ``[-1, 1]`` sorted
+                #   descending and needs the ``1 - similarity``
+                #   conversion here.
+                # - ``snapvec-ivfpq`` (``IVFPQBackend``) already
+                #   applies ``1 - similarity`` inside its own
+                #   ``search()`` (see ``_ivfpq_backend.py``) and
+                #   must not be double-inverted.
+                #
+                # ``min / max`` clamps keep the invariant that
+                # ``last_best_distance`` and ``relevance_tier`` both
+                # assume (``[0, 2]``), even if an implementation
+                # quirk yields a value slightly outside ``[-1, 1]``.
                 snap_results = self._snap.search(
                     np.array(query_embedding, dtype=np.float32), k=candidate_pool
                 )
                 snap_ids = [int(r[0]) for r in snap_results]
-                snap_dists = {int(r[0]): max(0.0, 1.0 - float(r[1])) for r in snap_results}
+                if self._vector_backend == "snapvec":
+                    snap_dists = {
+                        int(r[0]): min(2.0, max(0.0, 1.0 - float(r[1]))) for r in snap_results
+                    }
+                else:
+                    snap_dists = {int(r[0]): min(2.0, max(0.0, float(r[1]))) for r in snap_results}
 
                 if snap_ids:
                     placeholders = ",".join("?" * len(snap_ids))

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -2261,12 +2261,20 @@ class VstashStore:
                         detail="retrieval_mode='fts_only': no distance cutoff applied",
                     )
             elif self._snap is not None and len(self._snap) > 0:
-                # SnapVec ANN search — returns list[(id, distance)]
+                # SnapVec ANN search: returns list[(id, similarity)]
+                # with similarity in [-1, 1], descending.  Downstream
+                # ``distance_cutoff`` + ``relevance_tier`` +
+                # ``last_best_distance`` all live in cosine-distance
+                # space ([0, 2]), so convert here: cos_dist = max(0,
+                # 1 - similarity).  ``max(0, ...)`` guards against
+                # tiny numerical overshoot on near-identical vectors.
+                # The sibling IVFPQ backend does the same conversion
+                # internally in ``_ivfpq_backend.py`` (#289).
                 snap_results = self._snap.search(
                     np.array(query_embedding, dtype=np.float32), k=candidate_pool
                 )
                 snap_ids = [int(r[0]) for r in snap_results]
-                snap_dists = {int(r[0]): float(r[1]) for r in snap_results}
+                snap_dists = {int(r[0]): max(0.0, 1.0 - float(r[1])) for r in snap_results}
 
                 if snap_ids:
                     placeholders = ",".join("?" * len(snap_ids))


### PR DESCRIPTION
## Summary

Closes #289.

``snapvec.SnapIndex.search`` returns ``(id, similarity)`` in ``[-1, 1]``, sorted descending.  The store was feeding that value into ``distance_cutoff``, ``relevance_tier``, and ``last_best_distance`` as if it were cosine distance in ``[0, 2]``.  Ranking worked by accident (descending similarity = ascending distance monotonically), but every downstream distance-valued signal was corrupted whenever ``vector_backend=\"snapvec\"``.

The sibling IVFPQ backend already does the right thing internally -- flat snapvec just never got the same treatment.  One-line fix at the call site.

## Impact before the fix

- ``distance_cutoff`` was effectively disabled: a similarity of 0.6 is always ``<= best_similarity * 1.15``, so nothing was dropped.
- ``relevance_tier`` reported ``\"low\"`` for a perfect match (similarity 0.94 is above the 0.4802 cosine-distance medium ceiling).
- ``last_best_distance`` telemetry was inconsistent with the ``[0, 2]`` contract the sqlite-vec and snapvec-ivfpq backends hold, so MCP ``best_distance`` + ``vstash why --recent`` mis-reported confidence.

## Fix

```python
# vstash/store.py, flat snapvec branch:
-    snap_dists = {int(r[0]): float(r[1]) for r in snap_results}
+    snap_dists = {
+        int(r[0]): max(0.0, 1.0 - float(r[1])) for r in snap_results
+    }
```

Same ``max(0.0, 1.0 - score)`` conversion that ``IVFPQBackend.search`` already applies in ``vstash/_ivfpq_backend.py:146``.  ``max(0, ...)`` guards against tiny numerical overshoot on near-identical vectors.  The existing ``2.0`` fallback for missing rowids stays valid (cosine-distance ceiling).

## Tests

Three new cases in ``tests/test_snapvec_backend.py``:

- ``last_best_distance`` stays in ``[0, 2]`` and lands near ``0`` for a same-vector query.
- ``relevance_tier`` returns ``\"high\"`` for a near-identical match under the snapvec backend (parity with sqlite-vec).
- ``distance_cutoff`` drops orthogonal chunks under snapvec.  Uses ``retrieval_mode=\"vec_only\"`` to isolate the vec path so the shared-keyword FTS hit cannot reintroduce a filtered chunk.

Full suite: **1090 passing**, 6 deselected.  Ruff + format clean.

## Scope

No schema change, no migration, no backend API change.  Patch-level fix.