### PR TITLE
chore: pre-commit config matching CI ruff (#273 P0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,60 @@
+# pre-commit-config.yaml
+#
+# Runs the exact same two ruff checks that ``.github/workflows/ci.yml``
+# runs on every push / PR.  Matching the versions is what keeps the
+# feedback loop tight: a local ``ruff format .`` with a different
+# version than CI silently passes locally and then fails the remote
+# ``lint`` job.  See also the v0.34.0 cycle where a 0.14 -> 0.15 drift
+# made every feature PR re-push twice.
+#
+# Install once per clone:
+#     pip install pre-commit
+#     pre-commit install
+#
+# Run manually against every file without committing:
+#     pre-commit run --all-files
+#
+# Skip a hook on a single commit (rarely -- the whole point is not to):
+#     SKIP=ruff git commit ...
+#
+# Update pinned versions:
+#     pre-commit autoupdate
+
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in lockstep with the ``ruff`` pulled by CI.  Bump both at
+    # the same time and re-run ``pre-commit run --all-files`` when
+    # doing so -- minor versions occasionally reformat.
+    rev: v0.15.11
+    hooks:
+      - id: ruff-check
+        args: [--exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Fail fast on obvious footguns in non-Python files that neither
+      # ruff nor pytest would catch.  Keep this list short: every
+      # extra hook is a cache miss when the worktree is clean.
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      # ``benchmark/corpus/`` holds third-party public-domain texts
+      # (Alice in Wonderland, Art of War) used as fixed inputs for
+      # chunking / latency benchmarks.  Rewriting their whitespace
+      # would invalidate the benchmark baselines, so exclude them.
+      - id: end-of-file-fixer
+        exclude: |
+          (?x)^(
+            .*\.(ipynb|json)|
+            benchmark/corpus/.*
+          )$
+      - id: trailing-whitespace
+        exclude: |
+          (?x)^(
+            .*\.(md|ipynb)|
+            benchmark/corpus/.*
+          )$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to vstash
+
+## First-clone setup
+
+```bash
+pip install -e ".[all,dev]"
+pip install pre-commit
+pre-commit install
+```
+
+The ``pre-commit install`` step wires a local git hook that runs the
+same ``ruff check`` and ``ruff format --check`` commands CI runs.  This
+is the fastest way to avoid the "pushed, CI failed, pushed again"
+cycle -- hooks reject the commit before it lands.
+
+Run all hooks once against the whole tree (useful after ``git pull``):
+
+```bash
+pre-commit run --all-files
+```
+
+## Testing
+
+```bash
+python -m pytest tests/ -x -q
+```
+
+Benchmark-marked BEIR regression tests are gated off by default;
+run them explicitly with ``pytest -m benchmark``.  They need cached
+BEIR data under ``experiments/data/`` -- run
+``python -m experiments.beir_benchmark --datasets scifact`` once to
+populate the cache.
+
+## Branching
+
+Feature branches target ``develop``.  ``main`` is updated only via
+release PRs from ``develop`` and always matches the latest PyPI
+published version.  See ``CLAUDE.md`` for the release flow.
+
+## Commit style
+
+Conventional-commit prefixes (``feat``, ``fix``, ``docs``, ``chore``,
+``perf``, ``test``, ``style``).  Reference the relevant issue number
+in parentheses after the prefix when applicable, for example
+``fix(#289): ...``.


### PR DESCRIPTION
## Summary

Adds ``.pre-commit-config.yaml`` pinned to ``ruff 0.15.11`` -- the exact version CI installs via ``pip install ruff`` in ``.github/workflows/ci.yml``.  Local ruff versions older than CI silently pass checks that CI then rejects; the #286 release cycle burned two extra push rounds on exactly this failure mode.  Local hooks fix it at the pre-commit gate.

## Hooks

- ``ruff-check`` (new hook id, replaces the legacy ``ruff`` alias).
- ``ruff-format``.
- ``check-yaml`` / ``check-toml`` / ``check-merge-conflict`` -- fail fast on non-Python footguns that neither ruff nor pytest would catch.
- ``end-of-file-fixer`` / ``trailing-whitespace`` -- skipped on ``.md``, ``.ipynb``, ``.json``, and the third-party public-domain corpora under ``benchmark/corpus/`` (Alice in Wonderland / Art of War) whose whitespace is part of the benchmark baseline.

## Ship path

```
pip install pre-commit
pre-commit install
```

Once installed, every local ``git commit`` runs the same two ruff commands CI runs, and rejects the commit before it lands rather than after CI fails.

## Also

- ``CONTRIBUTING.md`` skeleton pointing at the ``pre-commit install`` step so fresh clones know to run it, plus a short note on branching and commit style.

## Checks

- ``pre-commit run --all-files`` -- all hooks pass on current ``develop``.  Matches the CI ``lint`` job output exactly.

## Upgrade

When CI changes the ruff version:
1. Update ``rev:`` in ``.pre-commit-config.yaml`` to match.
2. ``pre-commit run --all-files`` to apply any format drift.
3. Commit + push.

Part of the ``docs/professionalization-roadmap.md`` P0 list (#273).