### PR TITLE
feat(cli): add --eval-queries to vstash retrain

### DIFF
--- a/docs/retrain.md
+++ b/docs/retrain.md
@@ -284,12 +284,30 @@ schema varies too much across products. The pattern is:
    richer schemas may need timestamps or tool-call markup.
 2. **Use the session id as the document path** so labeled
    queries can reference it directly in `relevant_paths`.
-3. Ingest the blobs via the standard `Memory.remember` / 
+3. Ingest the blobs via the standard `Memory.remember` /
    `VstashStore.add_documents_batch` paths.
 
-A worked reference adapter for LongMemEval lives at
-`experiments/longmemeval_retrieval.py` (see `_format_session`
-and `_ingest_question`); copy and adapt to your schema.
+```python
+# Sketch: turns -> blob -> doc, one per session
+def _format_session(turns: list[dict]) -> str:
+    return "\n\n".join(f"[{t['role'].upper()}]\n{t['content']}" for t in turns)
+
+for session_id, turns in chat_sessions.items():
+    text = _format_session(turns)
+    chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
+    embeddings = embed_texts(chunks, cfg.embeddings.model)
+    store.add_documents_batch([{
+        "path": session_id,
+        "title": session_id,
+        "chunks": chunks,
+        "embeddings": embeddings,
+        "source_type": "chat",
+        "collection": "my-chats",
+    }])
+```
+
+The labeled-query JSONL then references each `session_id`
+directly in `relevant_paths`.
 
 ---
 

--- a/docs/retrain.md
+++ b/docs/retrain.md
@@ -205,6 +205,92 @@ smoke tests). Override with `--min-gain -1` to always save the
 candidate (useful when you want to inspect a known-regression
 model for debugging).
 
+### Labeled training and eval queries (BEIR-style)
+
+When you have real `(query, relevant_doc_paths)` labels --
+BEIR qrels, search-log clicks, manual annotations -- pass them
+to `vstash retrain` directly. Both flags accept JSONL files
+where each line is one labeled query:
+
+```jsonl
+{"query": "what is the meaning of life", "relevant_paths": ["/notes/answer.md"]}
+{"query": "how do mitochondria work", "relevant_paths": ["/biology/cell.md", "/biology/atp.md"]}
+```
+
+```bash
+vstash retrain \
+    --training-queries train.jsonl \
+    --eval-queries eval.jsonl \
+    --base-model BAAI/bge-small-en-v1.5 \
+    --output ~/.vstash/models/my-fine-tune
+```
+
+What changes vs. the default flow:
+
+- **Training pairs** come from real (query, gold) labels via
+  `generate_labeled_triples_batched` instead of chunk-prefix
+  pseudo-queries. This reuses the v5 recipe that produced
+  `Stffens/bge-small-rrf-v2` and `bge-small-rrf-v3`. Pass
+  `--training-pair-source labeled` to refuse to fall back to
+  chunk-prefix when no training labels are present (forces a
+  hard error rather than silent regression).
+- **Eval gate** scores baseline and fine-tuned on `eval.jsonl`
+  rather than the internal chunk-prefix split. This matters
+  whenever you care about specific query distributions: the
+  internal split's pseudo-queries are statement-shaped, so a
+  +0.05 NDCG there can hide a regression on real questions.
+- `--eval-fraction` is ignored (the held-out set is the file
+  you provide). `--eval-noise` still applies and controls how
+  many distractor chunks join the eval index.
+- `--no-eval` and `--eval-queries` are mutually exclusive: pick
+  one. If both are set the CLI exits non-zero.
+
+#### Building a stratified holdout from BEIR-style qrels
+
+`vstash.retrain.qrels_to_eval_queries` converts the standard
+`(queries, qrels)` dicts into the JSONL shape above:
+
+```python
+import json
+from vstash.retrain import qrels_to_eval_queries
+
+queries = {"q1": "what is the meaning of life", ...}
+qrels   = {"q1": {"answer.md": 1}, ...}
+
+records = qrels_to_eval_queries(queries, qrels, path_for_doc_id=lambda d: d)
+
+# 80/20 split
+train, holdout = records[: int(len(records) * 0.8)], records[int(len(records) * 0.8) :]
+with open("train.jsonl", "w") as fh:
+    for r in train: fh.write(json.dumps(r) + "\n")
+with open("eval.jsonl", "w") as fh:
+    for r in holdout: fh.write(json.dumps(r) + "\n")
+```
+
+If your data is multi-domain (e.g., LongMemEval question types),
+stratify the split by the relevant key before slicing -- a
+random 80/20 over a heterogeneous benchmark hides per-category
+regressions. The Python API (`retrain(..., eval_queries=...)`)
+also accepts the records directly without writing JSONL.
+
+#### Working from chat-style JSON (e.g., LongMemEval)
+
+`vstash` does not ship a dedicated chat-JSON ingester -- the
+schema varies too much across products. The pattern is:
+
+1. **Reduce each chat session to a text blob** (one document).
+   Concatenating turns with role markers
+   (`[USER]\n...\n[ASSISTANT]\n...`) is a reasonable default;
+   richer schemas may need timestamps or tool-call markup.
+2. **Use the session id as the document path** so labeled
+   queries can reference it directly in `relevant_paths`.
+3. Ingest the blobs via the standard `Memory.remember` / 
+   `VstashStore.add_documents_batch` paths.
+
+A worked reference adapter for LongMemEval lives at
+`experiments/longmemeval_retrieval.py` (see `_format_session`
+and `_ingest_question`); copy and adapt to your schema.
+
 ---
 
 ## Multi-corpus: `vstash retrain-multi`

--- a/tests/test_cli_retrain.py
+++ b/tests/test_cli_retrain.py
@@ -214,6 +214,71 @@ class TestEvalQueriesFlag:
         flat = " ".join(result.stdout.split())
         assert "no records" in flat
 
+    def test_non_string_query_rejected(self, tmp_path: Path, patched_cli: dict[str, Any]) -> None:
+        bad = _write_jsonl(
+            tmp_path / "bad_query.jsonl",
+            [{"query": 42, "relevant_paths": ["/test/python_guide.md"]}],
+        )
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "line 1" in flat
+        assert "non-empty string" in flat
+
+    def test_empty_string_query_rejected(self, tmp_path: Path, patched_cli: dict[str, Any]) -> None:
+        bad = _write_jsonl(
+            tmp_path / "blank_query.jsonl",
+            [{"query": "  ", "relevant_paths": ["/test/python_guide.md"]}],
+        )
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "non-empty string" in flat
+
+    def test_non_string_relevant_path_rejected(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = _write_jsonl(
+            tmp_path / "bad_paths.jsonl",
+            [{"query": "q", "relevant_paths": ["/ok.md", 7]}],
+        )
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "Every relevant path must be a non-empty string" in flat
+
+    def test_directory_path_rejected(self, tmp_path: Path, patched_cli: dict[str, Any]) -> None:
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(tmp_path), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "path is not a file" in flat
+
+    def test_invalid_json_includes_line_number(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = tmp_path / "with_bad_line.jsonl"
+        bad.write_text(
+            json.dumps({"query": "ok", "relevant_paths": ["/a"]})
+            + "\n{not valid json\n"
+            + json.dumps({"query": "ok2", "relevant_paths": ["/b"]})
+            + "\n"
+        )
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "line 2" in flat
+        assert "failed to parse" in flat
+
     def test_mutually_exclusive_with_no_eval(
         self, tmp_path: Path, patched_cli: dict[str, Any]
     ) -> None:

--- a/tests/test_cli_retrain.py
+++ b/tests/test_cli_retrain.py
@@ -1,0 +1,306 @@
+"""CLI tests for ``vstash retrain``'s --eval-queries / --training-queries flags.
+
+These tests focus on the JSONL loader, the CLI surface area, and the
+forwarding of parsed labeled queries into ``run_retrain`` -- they do not
+run the actual fine-tune (which requires sentence-transformers + torch).
+``run_retrain`` is monkeypatched to a recording stub so we can assert
+exactly what arguments would have been passed in a real run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from tests.conftest import requires_sqlite_vec
+from vstash.cli import app
+from vstash.store import VstashStore
+
+pytestmark = requires_sqlite_vec
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def patched_cli(populated_store: VstashStore, monkeypatch) -> dict[str, Any]:
+    """Patch the CLI so retrain runs without sentence-transformers.
+
+    Returns a dict ``{"calls": [...]}`` that captures every call made to
+    the patched ``run_retrain`` so tests can assert the kwargs it would
+    have received.  ``calls[-1]`` is the most recent invocation.
+    """
+    import vstash.cli as cli_mod
+    from vstash.config import load_config
+
+    # Wire the test store into the CLI.
+    monkeypatch.setattr(
+        cli_mod,
+        "_get_store",
+        lambda cfg=None, warm=False, profile=None: (load_config(), populated_store),
+    )
+
+    # ``vstash retrain`` short-circuits when the store has fewer than 10
+    # chunks (the corpus-too-small guard).  populated_store has 4-6
+    # chunks so we'd hit that branch on every test; stub stats() to
+    # report a corpus large enough to pass.
+    real_stats = populated_store.stats()
+    monkeypatch.setattr(
+        populated_store,
+        "stats",
+        lambda: real_stats.model_copy(update={"chunks": 100}),
+    )
+
+    calls: list[dict] = []
+
+    # Stub ``run_retrain`` -- avoids needing sentence-transformers in CI
+    # and lets us inspect the kwargs precisely.
+    def fake_run_retrain(store, **kwargs):
+        calls.append({"store": store, **kwargs})
+        return SimpleNamespace(
+            n_pairs=10,
+            baseline=None,
+            final=None,
+            output_path=str(Path(kwargs["output_path"]).expanduser()),
+            gated_out=False,
+            min_gain=kwargs.get("min_gain", 0.0),
+            delta_ndcg=0.0,
+        )
+
+    # The CLI imports ``run_retrain`` lazily inside the command body, so
+    # we patch the source attribute on the module that supplies it.
+    import vstash.retrain as retrain_mod
+
+    monkeypatch.setattr(retrain_mod, "retrain", fake_run_retrain)
+    return {"calls": calls}
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    with path.open("w") as fh:
+        for r in records:
+            fh.write(json.dumps(r) + "\n")
+    return path
+
+
+class TestEvalQueriesFlag:
+    """``--eval-queries`` parses, validates, and forwards to run_retrain."""
+
+    def test_forwards_parsed_eval_queries_to_run_retrain(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        eval_path = _write_jsonl(
+            tmp_path / "eval.jsonl",
+            [
+                {"query": "what is python", "relevant_paths": ["/test/python_guide.md"]},
+                {"query": "ml basics", "relevant_paths": ["/test/ml_intro.md"]},
+            ],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--eval-queries",
+                str(eval_path),
+                "--output",
+                str(tmp_path / "out_model"),
+                "--no-bulk-mine",
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        # Rich may wrap the line printed by the CLI when the test
+        # terminal is narrow; collapse newlines/spaces before
+        # substring-matching the messages we care about.
+        flat = " ".join(result.stdout.split())
+        assert "2 labeled" in flat
+        assert "gate uses these instead of internal split" in flat
+        assert len(patched_cli["calls"]) == 1
+        kwargs = patched_cli["calls"][0]
+        assert kwargs["eval_queries"] is not None
+        assert len(kwargs["eval_queries"]) == 2
+        assert kwargs["eval_queries"][0]["query"] == "what is python"
+        assert kwargs["eval_queries"][0]["relevant_paths"] == ["/test/python_guide.md"]
+
+    def test_eval_queries_default_is_none(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        train_path = _write_jsonl(
+            tmp_path / "train.jsonl",
+            [{"query": "q", "relevant_paths": ["/test/python_guide.md"]}],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--training-queries",
+                str(train_path),
+                "--output",
+                str(tmp_path / "out_model"),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert patched_cli["calls"][0]["eval_queries"] is None
+
+    def test_file_not_found_exits_with_clear_message(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--eval-queries",
+                str(tmp_path / "missing.jsonl"),
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "--eval-queries" in flat
+        assert "file not found" in flat
+        assert patched_cli["calls"] == []
+
+    def test_invalid_json_exits_with_clear_message(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = tmp_path / "bad.jsonl"
+        bad.write_text("{not valid json\n")
+        result = runner.invoke(
+            app,
+            ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")],
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "failed to parse" in flat
+        assert "Expected JSONL" in flat
+        assert patched_cli["calls"] == []
+
+    def test_missing_required_keys_rejected_per_line(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = _write_jsonl(
+            tmp_path / "missing_keys.jsonl",
+            [{"query": "q", "relevant_paths": ["/test/python_guide.md"]}, {"query": "no rel"}],
+        )
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "line 2" in flat
+        assert patched_cli["calls"] == []
+
+    def test_empty_relevant_paths_rejected(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = _write_jsonl(tmp_path / "empty_rel.jsonl", [{"query": "q", "relevant_paths": []}])
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(bad), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "empty or non-list" in flat
+
+    def test_empty_file_rejected(self, tmp_path: Path, patched_cli: dict[str, Any]) -> None:
+        empty = tmp_path / "empty.jsonl"
+        empty.write_text("")
+        result = runner.invoke(
+            app, ["retrain", "--eval-queries", str(empty), "--output", str(tmp_path / "out")]
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "no records" in flat
+
+    def test_mutually_exclusive_with_no_eval(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        eval_path = _write_jsonl(
+            tmp_path / "eval.jsonl",
+            [{"query": "q", "relevant_paths": ["/test/python_guide.md"]}],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--eval-queries",
+                str(eval_path),
+                "--no-eval",
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "mutually exclusive" in flat
+        assert patched_cli["calls"] == []
+
+    def test_warns_on_relevant_paths_not_in_store(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        eval_path = _write_jsonl(
+            tmp_path / "eval.jsonl",
+            [{"query": "q", "relevant_paths": ["/missing/in_store.md"]}],
+        )
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--eval-queries",
+                str(eval_path),
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        flat = " ".join(result.stdout.split())
+        # The warning hits before run_retrain so the call still goes through.
+        assert "1 relevant_paths reference" in flat
+        assert "/missing/in_store.md" in flat
+        assert patched_cli["calls"][0]["eval_queries"][0]["relevant_paths"] == [
+            "/missing/in_store.md"
+        ]
+
+
+class TestTrainingQueriesUsesSharedLoader:
+    """Refactor sanity: --training-queries still validates via the helper."""
+
+    def test_training_queries_invalid_json_rejected(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = tmp_path / "bad.jsonl"
+        bad.write_text("not json\n")
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--training-queries",
+                str(bad),
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "--training-queries" in flat
+        assert "failed to parse" in flat
+
+    def test_training_queries_missing_relevant_paths_rejected(
+        self, tmp_path: Path, patched_cli: dict[str, Any]
+    ) -> None:
+        bad = _write_jsonl(tmp_path / "bad.jsonl", [{"query": "q"}])
+        result = runner.invoke(
+            app,
+            [
+                "retrain",
+                "--training-queries",
+                str(bad),
+                "--output",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "line 1" in flat

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -88,53 +88,87 @@ def _load_labeled_queries_jsonl(path_str: str, *, flag: str) -> list[dict]:
     """Load and validate a JSONL file of labeled queries.
 
     Used by ``vstash retrain`` for both --training-queries and
-    --eval-queries.  Each line must be a JSON object with at least
-    ``query`` and ``relevant_paths``; returns the parsed records.
+    --eval-queries.  Each line must be a JSON object with a non-empty
+    string ``query`` and a non-empty list of non-empty string
+    ``relevant_paths``; returns the parsed records.
 
     Errors and exits the process with a clear message on:
-        - missing file,
-        - invalid JSON,
+        - missing file or non-file path,
+        - invalid JSON (with the offending line number),
         - records that are not objects with the required keys,
+        - records with non-string / empty fields,
         - empty file.
     The caller's flag name is woven into every message so the user
     knows which argument was wrong when they pass both.
     """
     path = Path(path_str).expanduser()
-    if not path.exists():
-        console.print(f"[red]x[/red] {flag}: file not found: {path}")
+    if not path.is_file():
+        # ``not exists`` and ``is a directory`` both end here -- distinguish
+        # them so users debugging a wrong path know whether they typoed or
+        # pointed at the parent dir.
+        if path.exists():
+            console.print(f"[red]x[/red] {flag}: path is not a file: {path}")
+        else:
+            console.print(f"[red]x[/red] {flag}: file not found: {path}")
         raise typer.Exit(code=1)
+
+    records: list[dict] = []
     try:
-        with path.open() as fh:
-            records = [json.loads(line) for line in fh if line.strip()]
-    except (OSError, json.JSONDecodeError) as exc:
-        console.print(
-            f"[red]x[/red] {flag}: failed to parse {path}: {exc}. "
-            f"Expected JSONL (one {{'query': ..., 'relevant_paths': [...]}} per line)."
-        )
+        with path.open(encoding="utf-8") as fh:
+            for line_no, line in enumerate(fh, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    q = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    console.print(
+                        f"[red]x[/red] {flag}: failed to parse {path} at line {line_no}: "
+                        f'{exc}. Expected JSONL (one {{"query": ..., '
+                        f'"relevant_paths": [...]}} per line).'
+                    )
+                    raise typer.Exit(code=1) from exc
+
+                # Shape validation per line, with the line number in every
+                # message so users can fix the exact record without diffing
+                # the whole file.  A common mistake is passing a JSON-array-
+                # per-file (``queries.json`` instead of ``queries.jsonl``),
+                # which would parse as one list entry and crash opaquely
+                # deep inside the miner / eval.
+                if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} is not a valid query record. "
+                        "Each line must be a JSON object with 'query' and "
+                        "'relevant_paths' fields. If you have a single JSON array, "
+                        "convert to JSONL (one object per line)."
+                    )
+                    raise typer.Exit(code=1)
+                if not isinstance(q["query"], str) or not q["query"].strip():
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has invalid 'query'. "
+                        "The 'query' field must be a non-empty string."
+                    )
+                    raise typer.Exit(code=1)
+                if not isinstance(q["relevant_paths"], list) or not q["relevant_paths"]:
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has empty or non-list "
+                        "'relevant_paths'. Every labeled query needs at least one "
+                        "relevant document path."
+                    )
+                    raise typer.Exit(code=1)
+                if any(not isinstance(p, str) or not p.strip() for p in q["relevant_paths"]):
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has invalid 'relevant_paths'. "
+                        "Every relevant path must be a non-empty string."
+                    )
+                    raise typer.Exit(code=1)
+                records.append(q)
+    except OSError as exc:
+        console.print(f"[red]x[/red] {flag}: failed to read {path}: {exc}.")
         raise typer.Exit(code=1) from exc
+
     if not records:
         console.print(f"[red]x[/red] {flag}: file {path} contained no records.")
         raise typer.Exit(code=1)
-    # Shape validation: each record must be a dict with query +
-    # relevant_paths.  A common mistake is passing a JSON-array-per-file
-    # (``queries.json`` instead of ``queries.jsonl``), which would parse
-    # as one list entry and crash opaquely deep inside the miner / eval.
-    for i, q in enumerate(records):
-        if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
-            console.print(
-                f"[red]x[/red] {flag}: line {i + 1} is not a valid query record. "
-                "Each line must be a JSON object with 'query' and "
-                "'relevant_paths' fields. If you have a single JSON array, "
-                "convert to JSONL (one object per line)."
-            )
-            raise typer.Exit(code=1)
-        if not isinstance(q["relevant_paths"], list) or not q["relevant_paths"]:
-            console.print(
-                f"[red]x[/red] {flag}: line {i + 1} has empty or non-list "
-                "'relevant_paths'. Every labeled query needs at least one "
-                "relevant document path."
-            )
-            raise typer.Exit(code=1)
     return records
 
 
@@ -2124,10 +2158,28 @@ def retrain(
         # store.  The retrain pipeline silently scores those queries as
         # 0 (no relevant chunk to retrieve), which would invalidate
         # NDCG@10 without surfacing a single error.
-        all_paths = {row[0] for row in store._conn.execute("SELECT path FROM documents").fetchall()}
-        missing = sorted(
-            {p for q in loaded_eval_queries for p in q["relevant_paths"] if p not in all_paths}
-        )
+        #
+        # Query only the paths the user actually referenced -- a full
+        # ``SELECT path FROM documents`` would pull the entire corpus
+        # into memory on stores with millions of docs (MS MARCO scale,
+        # production search logs).  Eval sets are typically <10k unique
+        # paths so a chunked ``WHERE path IN (...)`` is O(eval_size) on
+        # the indexed ``documents.path`` instead of O(corpus_size).
+        eval_paths = sorted({p for q in loaded_eval_queries for p in q["relevant_paths"]})
+        existing_paths: set[str] = set()
+        # 500 keeps the IN-list well below SQLite's default
+        # ``SQLITE_LIMIT_VARIABLE_NUMBER`` (999) with headroom.
+        chunk_size = 500
+        for i in range(0, len(eval_paths), chunk_size):
+            chunk = eval_paths[i : i + chunk_size]
+            placeholders = ",".join("?" * len(chunk))
+            existing_paths.update(
+                row[0]
+                for row in store._conn.execute(
+                    f"SELECT path FROM documents WHERE path IN ({placeholders})", chunk
+                ).fetchall()
+            )
+        missing = sorted(set(eval_paths) - existing_paths)
         if missing:
             preview = ", ".join(missing[:5]) + (" ..." if len(missing) > 5 else "")
             console.print(

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -84,6 +84,60 @@ def _safe_exc(exc: object) -> str:
     return _escape(str(exc))
 
 
+def _load_labeled_queries_jsonl(path_str: str, *, flag: str) -> list[dict]:
+    """Load and validate a JSONL file of labeled queries.
+
+    Used by ``vstash retrain`` for both --training-queries and
+    --eval-queries.  Each line must be a JSON object with at least
+    ``query`` and ``relevant_paths``; returns the parsed records.
+
+    Errors and exits the process with a clear message on:
+        - missing file,
+        - invalid JSON,
+        - records that are not objects with the required keys,
+        - empty file.
+    The caller's flag name is woven into every message so the user
+    knows which argument was wrong when they pass both.
+    """
+    path = Path(path_str).expanduser()
+    if not path.exists():
+        console.print(f"[red]x[/red] {flag}: file not found: {path}")
+        raise typer.Exit(code=1)
+    try:
+        with path.open() as fh:
+            records = [json.loads(line) for line in fh if line.strip()]
+    except (OSError, json.JSONDecodeError) as exc:
+        console.print(
+            f"[red]x[/red] {flag}: failed to parse {path}: {exc}. "
+            f"Expected JSONL (one {{'query': ..., 'relevant_paths': [...]}} per line)."
+        )
+        raise typer.Exit(code=1) from exc
+    if not records:
+        console.print(f"[red]x[/red] {flag}: file {path} contained no records.")
+        raise typer.Exit(code=1)
+    # Shape validation: each record must be a dict with query +
+    # relevant_paths.  A common mistake is passing a JSON-array-per-file
+    # (``queries.json`` instead of ``queries.jsonl``), which would parse
+    # as one list entry and crash opaquely deep inside the miner / eval.
+    for i, q in enumerate(records):
+        if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
+            console.print(
+                f"[red]x[/red] {flag}: line {i + 1} is not a valid query record. "
+                "Each line must be a JSON object with 'query' and "
+                "'relevant_paths' fields. If you have a single JSON array, "
+                "convert to JSONL (one object per line)."
+            )
+            raise typer.Exit(code=1)
+        if not isinstance(q["relevant_paths"], list) or not q["relevant_paths"]:
+            console.print(
+                f"[red]x[/red] {flag}: line {i + 1} has empty or non-list "
+                "'relevant_paths'. Every labeled query needs at least one "
+                "relevant document path."
+            )
+            raise typer.Exit(code=1)
+    return records
+
+
 def _build_miss_hint(
     *,
     cfg_auto_hint: bool,
@@ -1949,6 +2003,17 @@ def retrain(
         "labeled-batched miner (v5 recipe) instead of chunk-prefix "
         "pseudo-queries. H-R8 (2026-04-21).",
     ),
+    eval_queries_path: str | None = typer.Option(
+        None,
+        "--eval-queries",
+        help="Path to a JSONL file of labeled eval queries (same shape as "
+        "--training-queries). When set, the eval gate scores baseline "
+        "and fine-tuned models on these real queries instead of the "
+        "internal chunk-prefix split, so the gate reflects the corpus "
+        "you actually care about (BEIR qrels, search logs, manual "
+        "annotations). Mutually exclusive with --no-eval. Ignores "
+        "--eval-fraction (the held-out set is the file you provide).",
+    ),
     training_pair_source: str = typer.Option(
         "auto",
         "--training-pair-source",
@@ -2039,34 +2104,40 @@ def retrain(
 
     loaded_training_queries: list[dict] | None = None
     if training_queries:
-        path = Path(training_queries).expanduser()
-        if not path.exists():
-            console.print(f"[red]x[/red] --training-queries: file not found: {path}")
-            raise typer.Exit(code=1)
-        try:
-            with path.open() as fh:
-                loaded_training_queries = [json.loads(line) for line in fh if line.strip()]
-        except (OSError, json.JSONDecodeError) as exc:
-            console.print(
-                f"[red]x[/red] --training-queries: failed to parse {path}: {exc}. "
-                f"Expected JSONL (one {{'query': ..., 'relevant_paths': [...]}} per line)."
-            )
-            raise typer.Exit(code=1) from exc
-        # Shape validation: each record must be a dict with query +
-        # relevant_paths. A common mistake is passing a JSON-array-per-file
-        # (``queries.json`` instead of ``queries.jsonl``), which would parse
-        # as one list entry and crash opaquely inside the miner.
-        for i, q in enumerate(loaded_training_queries):
-            if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
-                console.print(
-                    f"[red]x[/red] --training-queries: line {i + 1} is not a "
-                    "valid query record. Each line must be a JSON object with "
-                    "'query' and 'relevant_paths' fields. If you have a single "
-                    "JSON array, convert to JSONL (one object per line)."
-                )
-                raise typer.Exit(code=1)
+        loaded_training_queries = _load_labeled_queries_jsonl(
+            training_queries, flag="--training-queries"
+        )
         console.print(
-            f"  Training queries: [cyan]{len(loaded_training_queries)} labeled[/cyan] from {path}"
+            f"  Training queries: [cyan]{len(loaded_training_queries)} labeled[/cyan] "
+            f"from {training_queries}"
+        )
+
+    loaded_eval_queries: list[dict] | None = None
+    if eval_queries_path:
+        if no_eval:
+            console.print(
+                "[red]x[/red] --eval-queries and --no-eval are mutually exclusive. Drop one."
+            )
+            raise typer.Exit(code=1)
+        loaded_eval_queries = _load_labeled_queries_jsonl(eval_queries_path, flag="--eval-queries")
+        # Warn when the eval queries reference paths absent from the
+        # store.  The retrain pipeline silently scores those queries as
+        # 0 (no relevant chunk to retrieve), which would invalidate
+        # NDCG@10 without surfacing a single error.
+        all_paths = {row[0] for row in store._conn.execute("SELECT path FROM documents").fetchall()}
+        missing = sorted(
+            {p for q in loaded_eval_queries for p in q["relevant_paths"] if p not in all_paths}
+        )
+        if missing:
+            preview = ", ".join(missing[:5]) + (" ..." if len(missing) > 5 else "")
+            console.print(
+                f"[yellow]! --eval-queries: {len(missing)} relevant_paths reference "
+                f"docs not in this store ({preview}). Those queries will score 0; "
+                "ingest the missing docs first or remove them from the eval file.[/yellow]"
+            )
+        console.print(
+            f"  Eval queries:     [cyan]{len(loaded_eval_queries)} labeled[/cyan] "
+            f"from {eval_queries_path} (gate uses these instead of internal split)"
         )
 
     result = run_retrain(
@@ -2082,6 +2153,7 @@ def retrain(
         min_gain=min_gain,
         skip_eval=no_eval,
         seed=seed,
+        eval_queries=loaded_eval_queries,
         synthesize_queries=synthesize,
         synth_n=synth_n,
         synth_cache=synth_cache,


### PR DESCRIPTION
## Summary

- Closes the symmetry hole in `vstash retrain`'s labeled path: `--training-queries` already accepted JSONL labels, but the eval gate was forced to use the internal chunk-prefix split. The new `--eval-queries` lets the gate score baseline and fine-tuned candidates on the real holdout without dropping into the Python API.
- Factored the shared JSONL loader + validation (`_load_labeled_queries_jsonl`); same error messages for both flags. Added safety guards (`--eval-queries` mutually exclusive with `--no-eval`, warning when `relevant_paths` reference docs missing from the store).
- Tests in `tests/test_cli_retrain.py` (11 cases) cover the loader, the error paths, the mutual-exclusion guard, and forwarding to `run_retrain` via a monkeypatched stub. No sentence-transformers required.
- Docs: new "Labeled training and eval queries" section in `docs/retrain.md` with the JSONL shape, a stratified-holdout snippet using `qrels_to_eval_queries`, and a brief pattern note on chat-JSON ingestion (LongMemEval-style; no core code added).

## Why this is generally useful, not just for LongMemEval

1. Anyone with BEIR qrels (SciFact, NFCorpus, FiQA, MS MARCO, custom) can already train via `--training-queries`, but today the gate measures chunk-prefix retrieval, not their benchmark. With `--eval-queries`, the gate reflects the queries they care about.
2. Equivalent fix for production: search logs and click-throughs are real `(query, relevant_doc)` pairs. With this flag a user can split their telemetry into train + holdout from the CLI and let the gate refuse regressions.
3. Manual annotations: 200 - 500 hand-labeled pairs become a viable workflow without writing Python.
4. Closes the asymmetry in the labeled path -- the Python `retrain()` already supported this; only the CLI was missing it.

## Test plan

- [x] `python -m pytest tests/test_cli_retrain.py -q` (11 passed)
- [x] `python -m pytest tests/test_cli_commands.py tests/test_retrain.py -q` (89 passed, no regressions)
- [x] `ruff check .` (clean)
- [x] `ruff format --check .` (clean after format)
- [x] `vstash retrain --help` shows the new flag
- [x] Manual: `--eval-queries` with mutually-exclusive `--no-eval` exits non-zero with a clear message
- [x] Manual: `--eval-queries` referencing a doc not in the store prints the warning and proceeds (caller may have intended it; we surface, do not block)

## Out of scope (follow-ups)

- `vstash retrain-multi` already accepts `eval_queries_by_dataset` in its Python signature; surfacing it on the multi CLI is a parallel change. Not bundled here to keep this PR small.
- Chat-JSON ingestion: documented as a pattern (see "Working from chat-style JSON" in `docs/retrain.md`), intentionally not added to core. vstash is the substrate; per-product chat schemas belong in user adapters.