### PR TITLE
fix(store): apply long-query distance_cutoff in vec_only mode

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1314,6 +1314,82 @@ class TestAdaptiveRRF:
                 "this would break ArguAna BEIR gains"
             )
 
+    def test_long_query_cutoff_relaxation_fires_in_vec_only(
+        self, sample_store: VstashStore
+    ) -> None:
+        """vec_only mode must still relax distance_cutoff for long queries.
+
+        Regression for the latent bug surfaced in the v0.35 vec_only BEIR
+        ablation: ArguAna collapsed to NDCG=0.0013 (1403/1406 zero) because
+        vec_only forces adaptive_rrf=False, which previously skipped the
+        long-query cutoff relaxation owned by _compute_adaptive_rrf_params.
+        With the default 1.3225 cutoff and best_dist ~0.2 (typical for
+        diffuse long-query embeddings under cosine), the threshold ~0.265
+        rejected nearly every candidate past rank 0.
+        """
+        dim = sample_store.embedding_dim
+
+        # Mimic the diffuse long-query regime that motivates the 25.0
+        # cutoff: best_distance is non-trivial (~0.3 in cosine), and the
+        # far doc sits at ~1.0. Under a 1.15x cutoff the far doc is
+        # filtered; under the 25.0 long-query relaxation it survives.
+        query_emb = [0.0] * dim
+        query_emb[0] = 1.0
+        close_emb = [0.0] * dim
+        close_emb[0] = 0.7
+        close_emb[1] = 0.7
+        far_emb = [0.0] * dim
+        far_emb[1] = 1.0
+        sample_store.add_document(
+            path="/test/close.md",
+            title="Close Doc",
+            chunks=["close content about programming"],
+            embeddings=[close_emb],
+            source_type="markdown",
+        )
+        sample_store.add_document(
+            path="/test/far.md",
+            title="Far Doc",
+            chunks=["far content about programming"],
+            embeddings=[far_emb],
+            source_type="markdown",
+        )
+
+        long_query = " ".join(["programming"] * 60)
+        short_query = "programming"
+
+        # Baseline: in vec_only mode, a SHORT query with a tight cutoff
+        # drops the far doc (cutoff is honored, no long-query escape).
+        short_results = sample_store.search(
+            query_emb,
+            short_query,
+            retrieval_mode="vec_only",
+            distance_cutoff=1.15,
+        )
+        short_paths = {r.path for r in short_results}
+        assert "/test/far.md" not in short_paths, (
+            "Test setup is wrong: tight cutoff did not drop the far doc "
+            "for a short query, so the long-query relaxation effect is "
+            "untestable."
+        )
+
+        # A LONG query in vec_only must trigger the same 25.0 cutoff
+        # relaxation that hybrid mode gets via _compute_adaptive_rrf_params,
+        # recovering the far doc despite the same explicit tight cutoff.
+        long_results = sample_store.search(
+            query_emb,
+            long_query,
+            retrieval_mode="vec_only",
+            distance_cutoff=1.15,
+        )
+        long_paths = {r.path for r in long_results}
+        assert "/test/far.md" in long_paths, (
+            "vec_only with a >50-word query dropped the far document. "
+            "The long-query distance_cutoff relaxation (25.0) is not "
+            "being applied in vec_only mode -- ArguAna-style ablations "
+            "will collapse to ~0 NDCG."
+        )
+
     def test_idf_weighting_shifts_fts_weight(self, populated_store: VstashStore) -> None:
         """IDF weighting must produce measurably different weights for rare vs common
         terms, and these weights must flow through to search results via explain.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1390,6 +1390,24 @@ class TestAdaptiveRRF:
             "will collapse to ~0 NDCG."
         )
 
+        # Opt-out parity with hybrid: an explicit adaptive_rrf=False from
+        # the caller must disable the relaxation, so the far doc gets
+        # filtered again. Without this gate, vec_only would silently
+        # ignore the user's adaptive_rrf=False.
+        opt_out_results = sample_store.search(
+            query_emb,
+            long_query,
+            retrieval_mode="vec_only",
+            distance_cutoff=1.15,
+            adaptive_rrf=False,
+        )
+        opt_out_paths = {r.path for r in opt_out_results}
+        assert "/test/far.md" not in opt_out_paths, (
+            "vec_only applied the long-query relaxation even though the "
+            "caller passed adaptive_rrf=False. Opt-out must mirror the "
+            "hybrid path semantics."
+        )
+
     def test_idf_weighting_shifts_fts_weight(self, populated_store: VstashStore) -> None:
         """IDF weighting must produce measurably different weights for rare vs common
         terms, and these weights must flow through to search results via explain.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -2195,6 +2195,17 @@ class VstashStore:
                 vec_weight = 1.0
                 fts_weight = 0.0
                 adaptive_rrf = False
+                # Long-query cutoff relaxation must still fire here.
+                # _compute_adaptive_rrf_params owns the 25.0 cosine cutoff
+                # for >50-word queries, but it's gated on adaptive_rrf
+                # which we just turned off. Without this, ArguAna-style
+                # long queries collapse to ~0 NDCG in vec_only mode
+                # (best_dist ~0.2 in cosine, default cutoff 1.3225 yields
+                # threshold ~0.265, rejecting nearly every candidate
+                # past rank 0). Mirror the hybrid long-query relaxation
+                # so vec_only ablations are honest.
+                if len(query_text.split()) > _ADAPTIVE_RRF_LONG_QUERY:
+                    distance_cutoff = 25.0
 
             # Adaptive RRF: compute weights from query characteristics (IDF + length)
             # Skip if caller provided explicit weights

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -272,6 +272,12 @@ RRF_K = 60
 # typically semantic paraphrases where keywords add noise.
 _ADAPTIVE_RRF_LONG_QUERY = 50
 
+# Long-query distance_cutoff. 25.0 = 5.0^2: the squared cosine equivalent
+# of the legacy v1 L2 5.0x cutoff (#272). Diffuse long-query embeddings
+# compress distances; without this relaxation the default 1.3225 cutoff
+# rejects nearly every candidate past rank 0.
+_LONG_QUERY_DISTANCE_CUTOFF = 25.0
+
 
 class VstashStore:
     """SQLite-backed vector + FTS5 hybrid store with RRF ranking.
@@ -2194,18 +2200,20 @@ class VstashStore:
             elif _vec_only:
                 vec_weight = 1.0
                 fts_weight = 0.0
-                adaptive_rrf = False
                 # Long-query cutoff relaxation must still fire here.
-                # _compute_adaptive_rrf_params owns the 25.0 cosine cutoff
-                # for >50-word queries, but it's gated on adaptive_rrf
-                # which we just turned off. Without this, ArguAna-style
+                # _compute_adaptive_rrf_params owns the cutoff for
+                # >50-word queries, but it's gated on adaptive_rrf which
+                # we're about to turn off. Without this, ArguAna-style
                 # long queries collapse to ~0 NDCG in vec_only mode
                 # (best_dist ~0.2 in cosine, default cutoff 1.3225 yields
                 # threshold ~0.265, rejecting nearly every candidate
                 # past rank 0). Mirror the hybrid long-query relaxation
-                # so vec_only ablations are honest.
-                if len(query_text.split()) > _ADAPTIVE_RRF_LONG_QUERY:
-                    distance_cutoff = 25.0
+                # so vec_only ablations are honest, and gate it on
+                # adaptive_rrf so an explicit adaptive_rrf=False from
+                # the caller still opts out (parity with hybrid).
+                if adaptive_rrf and len(query_text.split()) > _ADAPTIVE_RRF_LONG_QUERY:
+                    distance_cutoff = _LONG_QUERY_DISTANCE_CUTOFF
+                adaptive_rrf = False
 
             # Adaptive RRF: compute weights from query characteristics (IDF + length)
             # Skip if caller provided explicit weights
@@ -4229,15 +4237,11 @@ class VstashStore:
 
         # Long queries: favor vector + relax distance cutoff
         # (diffuse embeddings from long text compress distance range).
-        # 25.0 = 5.0^2: same squaring relationship as the main
-        # ``default_cutoff`` between v1 L2 space and v2 cosine space
-        # (#272); preserves the ArguAna-class "effectively disabled"
-        # semantics where long-query best_dist was ~0.8 under L2 so
-        # 5*best was always past the L2 ceiling of 2.  Under cosine
-        # best_dist is ~0.2 so we need 25*best to keep the cutoff
-        # from rejecting true positives at rank > 0.
+        # See ``_LONG_QUERY_DISTANCE_CUTOFF`` for the squaring rationale
+        # (#272). The vec_only branch in ``search`` mirrors this same
+        # relaxation; both must use the same constant.
         if n_words > _ADAPTIVE_RRF_LONG_QUERY:
-            return 0.9, 0.1, 25.0
+            return 0.9, 0.1, _LONG_QUERY_DISTANCE_CUTOFF
 
         idf_dict, total_chunks = self._build_idf_cache()
 


### PR DESCRIPTION
## Summary

`vec_only` retrieval mode forces `adaptive_rrf=False`, which previously skipped `_compute_adaptive_rrf_params` and the 25.0 cosine cutoff that function owns for >50-word queries. With the default 1.3225 cutoff and diffuse long-query `best_distance ~0.2`, the threshold ~0.265 rejected almost every candidate past rank 0 -- silent for short queries, catastrophic for ArguAna-style long queries.

## Symptom

v0.35 BEIR `vec_only` ablation on ArguAna: NDCG@10 = **0.0013** (1403/1406 queries returned zero-NDCG). Hybrid mode on the same dataset returned 0.4367, masking the bug because FTS5 carried the load.

## Fix

Mirror the long-query relaxation inside the `_vec_only` branch (`vstash/store.py:2194`) so `distance_cutoff` jumps to 25.0 when `len(query_text.split()) > _ADAPTIVE_RRF_LONG_QUERY`. Three lines plus rationale comment.

After the fix, ArguAna `vec_only` NDCG@10 = **0.4250** (237/1406 zero-NDCG). The ~0.012 gap below hybrid 0.4367 is the honest FTS5 contribution.

## Scope of impact

- **Hybrid mode unaffected** -- adaptive_rrf path still owns the relaxation there. All paper, README, model card, and BEIR bootstrap numbers (which are hybrid) are unchanged.
- **fts_only unaffected** -- no vec rows flow through the cutoff stage.
- **vec_only on long-query corpora** is the only affected mode. Re-run the vec_only sidecars used for substrate ablations.

## Regression test

`TestAdaptiveRRF::test_long_query_cutoff_relaxation_fires_in_vec_only` -- embeddings sized to mimic the diffuse long-query regime (`best_distance ~0.3` cosine). Verified to fail on unfixed code (`/test/far.md` dropped) and pass on fixed code.

## Test plan

- [x] `pytest tests/test_store.py -k "long_query or vec_only"` (3/3 pass)
- [x] `pytest tests/` full suite (1040/1040 pass)
- [x] `ruff check` clean
- [x] Local smoke: `python -m experiments.beir_benchmark --no-chroma --retrieval-mode vec_only --datasets arguana --model BAAI/bge-small-en-v1.5` -> NDCG@10 0.4250 (was 0.0013)