### PR TITLE
fix(#297): centralize VstashStore construction in open_store_for_config

### DIFF
--- a/tests/test_cli_get_store_lifecycle.py
+++ b/tests/test_cli_get_store_lifecycle.py
@@ -46,11 +46,15 @@ def _hermetic_config_factory(db_path, *, vector_backend: str = "sqlite-vec"):
 
 def _patch_hermetic_config(monkeypatch, db_path, *, vector_backend: str = "sqlite-vec"):
     """Apply all monkeypatches needed for a hermetic _get_store call."""
+    import vstash._store_open as store_open_mod
+
     monkeypatch.setenv("VSTASH_DB_PATH", str(db_path))
     monkeypatch.setattr(
         cli_mod, "load_config", _hermetic_config_factory(db_path, vector_backend=vector_backend)
     )
-    monkeypatch.setattr(cli_mod, "get_embedding_dim", lambda _model: DIM)
+    # _get_store now delegates to ``open_store_for_config``, which looks
+    # up ``get_embedding_dim`` from the ``_store_open`` module (#297).
+    monkeypatch.setattr(store_open_mod, "get_embedding_dim", lambda _model: DIM)
 
 
 class TestGetStoreAtexit:

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -350,8 +350,7 @@ class TestMemoryJournal:
         from unittest.mock import patch
 
         with (
-            patch("vstash.memory.get_embedding_dim", return_value=384),
-            patch("vstash.memory.VstashStore"),
+            patch("vstash.memory.open_store_for_config"),
             patch("vstash.memory.load_config"),
         ):
             from vstash.memory import Memory
@@ -374,8 +373,7 @@ class TestMemoryJournal:
         from unittest.mock import patch
 
         with (
-            patch("vstash.memory.get_embedding_dim", return_value=384),
-            patch("vstash.memory.VstashStore"),
+            patch("vstash.memory.open_store_for_config"),
             patch("vstash.memory.load_config"),
         ):
             from vstash.memory import Memory
@@ -395,8 +393,7 @@ class TestMemoryJournal:
         from unittest.mock import patch
 
         with (
-            patch("vstash.memory.get_embedding_dim", return_value=384),
-            patch("vstash.memory.VstashStore"),
+            patch("vstash.memory.open_store_for_config"),
             patch("vstash.memory.load_config"),
         ):
             from vstash.memory import Memory
@@ -418,8 +415,7 @@ class TestMemoryJournal:
         from unittest.mock import patch
 
         with (
-            patch("vstash.memory.get_embedding_dim", return_value=384),
-            patch("vstash.memory.VstashStore"),
+            patch("vstash.memory.open_store_for_config"),
             patch("vstash.memory.load_config"),
         ):
             from vstash.memory import Memory

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -732,33 +732,31 @@ class TestSdkDbResolution:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Memory() without explicit db= delegates to resolve_db_path."""
-        from vstash.profile import resolve_db_path
-
         custom_db = tmp_path / "custom.db"
         monkeypatch.delenv("VSTASH_DB_PATH", raising=False)
         monkeypatch.delenv("VSTASH_PROFILE", raising=False)
         monkeypatch.chdir(tmp_path)
 
-        expected = str(resolve_db_path(config_db_path=str(custom_db)))
-
-        with patch("vstash.memory.VstashStore") as mock_store:
-            mock_store.return_value.close = lambda: None
+        with patch("vstash.memory.open_store_for_config") as mock_open:
+            mock_open.return_value.close = lambda: None
             cfg = VstashConfig()
             # Simulate custom storage.db_path
             storage_cfg = cfg.storage.model_copy(update={"db_path": str(custom_db)})
             custom_cfg = cfg.model_copy(update={"storage": storage_cfg})
             with patch("vstash.memory._load_config_from", return_value=custom_cfg):
                 mem = Memory()
-                assert mock_store.call_args[0][0] == expected
+                # db_path=None lets the helper run resolve_db_path against
+                # the config-provided storage.db_path.
+                assert mock_open.call_args.kwargs["db_path"] is None
                 mem.close()
 
     def test_sdk_explicit_db_overrides_all(self, tmp_path: Path) -> None:
         """Memory(db=...) always uses that path, regardless of config."""
         explicit = str(tmp_path / "explicit.db")
-        with patch("vstash.memory.VstashStore") as mock_store:
-            mock_store.return_value.close = lambda: None
+        with patch("vstash.memory.open_store_for_config") as mock_open:
+            mock_open.return_value.close = lambda: None
             mem = Memory(db=explicit)
-            assert mock_store.call_args[0][0] == explicit
+            assert mock_open.call_args.kwargs["db_path"] == explicit
             mem.close()
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from vstash.config import VstashConfig
 from vstash.profile import (
     PROFILES_DIR,
     active_profile_info,
@@ -338,7 +339,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=[0.15] * dim,
             query_text="machine learning",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=5,
         )
 
@@ -359,7 +360,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=[0.1] * 384,
             query_text="test",
-            embedding_dim=384,
+            cfg=VstashConfig(),
         )
         assert results == []
 
@@ -386,7 +387,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=[0.5] * dim,
             query_text="solo content",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
         )
         assert len(results) == 1
         assert results[0][0] == "default"
@@ -423,7 +424,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=embedding,
             query_text="shared",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=5,
         )
 
@@ -458,7 +459,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=[0.5] * dim,
             query_text="content",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
         )
         assert len(results) == 1
         # Score should be the RRF score, not the original store score
@@ -510,7 +511,7 @@ class TestFederatedSearch:
         results = federated_search(
             query_embedding=embedding,
             query_text="tail content",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=5,
         )
 
@@ -642,17 +643,17 @@ class TestMemoryProfile:
         db_file = tmp_path / "custom.db"
         db_file.touch()
 
-        # Mock the store and config to avoid real embedding initialization
+        # Mock the store opener and config to avoid real embedding initialization
         with (
-            patch("vstash.memory.get_embedding_dim", return_value=384),
-            patch("vstash.memory.VstashStore") as mock_store,
+            patch("vstash.memory.open_store_for_config") as mock_open,
             patch("vstash.memory.load_config"),
         ):
             from vstash.memory import Memory
 
             mem = Memory(db=str(db_file), profile="ignored")
-            # The store should have been called with the db path, not the profile path
-            assert mock_store.call_args[0][0] == str(db_file)
+            # The opener should have been called with the explicit db path, not
+            # the profile path (db param wins over profile in resolution).
+            assert mock_open.call_args.kwargs["db_path"] == str(db_file)
             mem.close()
 
 
@@ -699,7 +700,7 @@ class TestFederatedContextExpansion:
         results_no_expand = federated_search(
             query_embedding=emb_middle,
             query_text="chapter two",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=1,
             expand_window=0,
         )
@@ -710,7 +711,7 @@ class TestFederatedContextExpansion:
         results_expanded = federated_search(
             query_embedding=emb_middle,
             query_text="chapter two",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=1,
             expand_window=1,
         )
@@ -748,7 +749,7 @@ class TestFederatedContextExpansion:
         results = federated_search(
             query_embedding=[0.9] * dim,
             query_text="target",
-            embedding_dim=dim,
+            cfg=VstashConfig(),
             top_k=1,
             expand_window=0,
         )

--- a/tests/test_store_open.py
+++ b/tests/test_store_open.py
@@ -1,0 +1,242 @@
+"""Tests for ``open_store_for_config`` and the surfaces that use it.
+
+Issue #297 closed: every public surface (CLI, MCP, web, SDK, journal,
+federated search) used to duplicate the ``StorageConfig -> VstashStore``
+wiring, and several silently dropped the IVFPQ tuning fields. Adding a
+new ``StorageConfig`` knob meant touching 7+ files; missing one meant a
+config that worked under the CLI did nothing under the SDK.
+
+These tests:
+
+1. Lock in that ``open_store_for_config`` forwards every storage knob
+   plus observability/limits/cache.
+2. Lock in that each surface routes through it (so a future knob added
+   only to the helper reaches every entry point automatically).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from vstash._store_open import open_store_for_config
+from vstash.config import (
+    CacheConfig,
+    LimitsConfig,
+    ObservabilityConfig,
+    StorageConfig,
+    VstashConfig,
+)
+
+
+# ------------------------------------------------------------------ #
+# Helper construction                                                  #
+# ------------------------------------------------------------------ #
+
+
+def _ivfpq_config(db_path: str) -> VstashConfig:
+    """Build a config with non-default IVFPQ + obs/limits/cache values.
+
+    M=24 divides 384 (BGE dim), so the IVFPQ backend would actually
+    accept this if a caller fit it -- but we only construct the store
+    with vector_backend=sqlite-vec, so the IVFPQ knobs are stored on
+    the instance without triggering a fit. That's the point: the
+    fields must be wired all the way through even when the backend
+    doesn't consume them.
+    """
+    return VstashConfig(
+        storage=StorageConfig(
+            db_path=db_path,
+            vector_backend="sqlite-vec",
+            snapvec_bits=3,
+            ivfpq_nlist=16,
+            ivfpq_M=24,
+            ivfpq_K=128,
+            ivfpq_rerank_candidates=32,
+            ivfpq_nprobe=4,
+        ),
+        observability=ObservabilityConfig(slow_query_ms=42.0, auto_miss_hint=False),
+        limits=LimitsConfig(max_top_k=42),
+        cache=CacheConfig(query_cache_size=128),
+    )
+
+
+# ------------------------------------------------------------------ #
+# 1. Helper forwards every field                                       #
+# ------------------------------------------------------------------ #
+
+
+class TestOpenStoreForConfig:
+    def test_forwards_every_storage_knob(self, tmp_path: Path) -> None:
+        cfg = _ivfpq_config(str(tmp_path / "store.db"))
+        store = open_store_for_config(cfg)
+        try:
+            # Storage / IVFPQ
+            assert store._vector_backend == "sqlite-vec"
+            assert store._snapvec_bits == 3
+            assert store._ivfpq_nlist == 16
+            assert store._ivfpq_M == 24
+            assert store._ivfpq_K == 128
+            assert store._ivfpq_rerank_candidates == 32
+            assert store._ivfpq_nprobe == 4
+            # Observability / limits / cache
+            assert store._observability.slow_query_ms == 42.0
+            assert store._observability.auto_miss_hint is False
+            assert store._limits.max_top_k == 42
+            assert store._cache_config.query_cache_size == 128
+        finally:
+            store.close()
+
+    def test_db_path_override_wins_over_resolve_chain(self, tmp_path: Path) -> None:
+        cfg_db = tmp_path / "from_cfg.db"
+        explicit = tmp_path / "explicit.db"
+        cfg = _ivfpq_config(str(cfg_db))
+        store = open_store_for_config(cfg, db_path=str(explicit))
+        try:
+            assert Path(store.db_path) == explicit
+        finally:
+            store.close()
+
+    def test_embedding_dim_override(self, tmp_path: Path) -> None:
+        """Reindex passes the *old* model's dim while migrating to a new one."""
+        cfg = _ivfpq_config(str(tmp_path / "dim.db"))
+        store = open_store_for_config(cfg, embedding_dim=128)
+        try:
+            assert store.embedding_dim == 128
+        finally:
+            store.close()
+
+
+# ------------------------------------------------------------------ #
+# 2. Every surface routes through the helper                          #
+# ------------------------------------------------------------------ #
+
+
+class TestSurfacesRouteThroughHelper:
+    """Each surface must call ``open_store_for_config`` exactly once.
+
+    Using the helper as a sentinel proves the surface has not gone back
+    to bespoke ``VstashStore(...)`` wiring with a partial kwargs list.
+    """
+
+    def test_cli_get_store_uses_helper(self, monkeypatch, tmp_path: Path) -> None:
+        import vstash.cli as cli_mod
+
+        cfg = _ivfpq_config(str(tmp_path / "cli.db"))
+        monkeypatch.setattr(cli_mod, "load_config", lambda: cfg)
+        monkeypatch.setenv("VSTASH_DB_PATH", str(tmp_path / "cli.db"))
+        monkeypatch.setattr(cli_mod.atexit, "register", lambda _cb: None)
+
+        with patch("vstash.cli.open_store_for_config", wraps=open_store_for_config) as spy:
+            _cfg, store = cli_mod._get_store()
+            try:
+                assert spy.call_count == 1
+                assert spy.call_args.args[0] is cfg
+            finally:
+                store.close()
+
+    def test_memory_uses_helper(self, tmp_path: Path) -> None:
+        from vstash.memory import Memory
+
+        with patch("vstash.memory.open_store_for_config", wraps=open_store_for_config) as spy:
+            mem = Memory(db=str(tmp_path / "sdk.db"))
+            try:
+                assert spy.call_count == 1
+                assert spy.call_args.kwargs["db_path"] == str(tmp_path / "sdk.db")
+            finally:
+                mem.close()
+
+    def test_journal_uses_helper(self, monkeypatch, tmp_path: Path) -> None:
+        import vstash.journal as journal_mod
+
+        monkeypatch.setattr(journal_mod, "PROFILES_DIR", tmp_path / "profiles")
+        cfg = _ivfpq_config(str(tmp_path / "journal_cfg.db"))
+
+        with patch("vstash.journal.open_store_for_config", wraps=open_store_for_config) as spy:
+            _cfg, store = journal_mod._get_journal_store(cfg)
+            try:
+                assert spy.call_count == 1
+                # journal forces its own per-profile path, not the cfg-resolved one.
+                journal_db = tmp_path / "profiles" / journal_mod.JOURNAL_PROFILE / "memory.db"
+                assert spy.call_args.kwargs["db_path"] == str(journal_db)
+            finally:
+                store.close()
+
+    def test_mcp_uses_helper(self, monkeypatch, tmp_path: Path) -> None:
+        import vstash.mcp as mcp_mod
+
+        cfg = _ivfpq_config(str(tmp_path / "mcp.db"))
+        monkeypatch.setattr(mcp_mod, "_get_config", lambda: cfg)
+        # Clear the lazy singleton so the test exercises a fresh open.
+        monkeypatch.setattr(mcp_mod, "_store", None)
+        monkeypatch.setattr(mcp_mod.atexit, "register", lambda _cb: None)
+
+        with patch("vstash.mcp.open_store_for_config", wraps=open_store_for_config) as spy:
+            store = mcp_mod._get_store()
+            try:
+                assert spy.call_count == 1
+                assert spy.call_args.args[0] is cfg
+            finally:
+                store.close()
+        # Reset the singleton so other tests don't pick up our cfg.
+        mcp_mod._store = None
+
+    def test_web_uses_helper(self, monkeypatch, tmp_path: Path) -> None:
+        pytest.importorskip("starlette")
+        import vstash.web as web_mod
+
+        cfg = _ivfpq_config(str(tmp_path / "web.db"))
+        monkeypatch.setattr(web_mod, "_get_config", lambda: cfg)
+        monkeypatch.setattr(web_mod, "_store", None)
+
+        with patch("vstash.web.open_store_for_config", wraps=open_store_for_config) as spy:
+            store = web_mod._get_store()
+            try:
+                assert spy.call_count == 1
+                assert spy.call_args.args[0] is cfg
+            finally:
+                store.close()
+        web_mod._store = None
+
+    def test_federated_search_uses_helper_per_profile(self, monkeypatch, tmp_path: Path) -> None:
+        """Every per-profile store opened by federated_search must go through
+        the helper -- otherwise IVFPQ tuning silently drops on the federated
+        path even when it works on the primary store. Regression for #297.
+        """
+        from vstash.profile import federated_search
+        from vstash.store import VstashStore
+
+        default_db = tmp_path / "memory.db"
+        profiles_dir = tmp_path / "profiles"
+        monkeypatch.setattr("vstash.profile.DEFAULT_DB", default_db)
+        monkeypatch.setattr("vstash.profile.PROFILES_DIR", profiles_dir)
+        monkeypatch.setattr("vstash.profile._find_local_db", lambda: None)
+
+        # Two profiles with content so federated_search has something to open.
+        for db in [default_db, profiles_dir / "named" / "memory.db"]:
+            db.parent.mkdir(parents=True, exist_ok=True)
+            s = VstashStore(str(db), embedding_dim=384)
+            s.add_document(
+                path=f"/{db.parent.name}.md",
+                title="t",
+                chunks=["body"],
+                embeddings=[[0.1] * 384],
+                source_type="markdown",
+            )
+            s.close()
+
+        cfg = _ivfpq_config(str(default_db))
+
+        with patch("vstash._store_open.open_store_for_config", wraps=open_store_for_config) as spy:
+            results = federated_search(
+                query_embedding=[0.1] * 384,
+                query_text="body",
+                cfg=cfg,
+            )
+            assert results, "federated_search should find at least one result"
+            # One call per profile -- both default and named.
+            assert spy.call_count == 2
+            for call in spy.call_args_list:
+                assert call.args[0] is cfg

--- a/vstash/_store_open.py
+++ b/vstash/_store_open.py
@@ -1,0 +1,68 @@
+"""Single source of truth for opening a VstashStore from VstashConfig.
+
+Prior to this helper, every public surface (CLI, MCP, web, SDK, journal,
+federated search) duplicated the StorageConfig -> VstashStore wiring.
+Adding a new storage knob meant touching 7+ files, and each new surface
+risked silently dropping IVFPQ / observability / limits / cache fields
+(see issue #297).
+
+``open_store_for_config`` centralizes the wiring. Callers pass a
+``VstashConfig`` plus optional db_path / embedding_dim overrides.
+"""
+
+from __future__ import annotations
+
+from .config import VstashConfig
+from .embed import get_embedding_dim
+from .store import VstashStore
+
+
+def open_store_for_config(
+    cfg: VstashConfig,
+    *,
+    db_path: str | None = None,
+    profile: str | None = None,
+    embedding_dim: int | None = None,
+) -> VstashStore:
+    """Open a VstashStore wired from a VstashConfig.
+
+    Args:
+        cfg: Loaded ``VstashConfig``. Provides every ``StorageConfig``
+            knob plus observability, limits, and cache.
+        db_path: Optional explicit database path. When omitted, resolved
+            via the standard profile chain (``--profile``, env, project-
+            local, default). Used by ``--store path:alias`` overrides
+            and by per-profile stores in federated search.
+        profile: Named profile to resolve. Ignored when ``db_path`` is
+            given.
+        embedding_dim: Optional embedding dimension override. Used by
+            ``vstash reindex`` to open the store with the *current*
+            model's dim while preparing to migrate to a new dim.
+            Defaults to ``get_embedding_dim(cfg.embeddings.model)``.
+
+    Returns:
+        A ``VstashStore`` with every storage knob, observability,
+        limits, and cache forwarded from ``cfg``.
+    """
+    if db_path is None:
+        from .profile import resolve_db_path
+
+        db_path = str(resolve_db_path(profile, config_db_path=cfg.storage.db_path))
+
+    if embedding_dim is None:
+        embedding_dim = get_embedding_dim(cfg.embeddings.model)
+
+    return VstashStore(
+        db_path,
+        embedding_dim=embedding_dim,
+        vector_backend=cfg.storage.vector_backend,
+        snapvec_bits=cfg.storage.snapvec_bits,
+        ivfpq_nlist=cfg.storage.ivfpq_nlist,
+        ivfpq_M=cfg.storage.ivfpq_M,
+        ivfpq_K=cfg.storage.ivfpq_K,
+        ivfpq_rerank_candidates=cfg.storage.ivfpq_rerank_candidates,
+        ivfpq_nprobe=cfg.storage.ivfpq_nprobe,
+        observability=cfg.observability,
+        limits=cfg.limits,
+        cache=cfg.cache,
+    )

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -29,10 +29,10 @@ from rich.panel import Panel
 from rich.table import Table
 
 from . import chat as chat_module
+from ._store_open import open_store_for_config
 from .config import VstashConfig, load_config
-from .embed import embed_query, get_embedding_dim, warmup
+from .embed import embed_query, warmup
 from .ingest import ingest, ingest_directory
-from .profile import resolve_db_path
 from .store import VstashStore, relevance_tier
 
 from . import __version__
@@ -297,20 +297,7 @@ def _get_store(
         cfg = load_config()
     if warm:
         warmup(cfg.embeddings.model)
-    dim = get_embedding_dim(cfg.embeddings.model)
-    db_path = str(resolve_db_path(profile, config_db_path=cfg.storage.db_path))
-    store = VstashStore(
-        db_path,
-        embedding_dim=dim,
-        vector_backend=cfg.storage.vector_backend,
-        snapvec_bits=cfg.storage.snapvec_bits,
-        ivfpq_nlist=cfg.storage.ivfpq_nlist,
-        ivfpq_M=cfg.storage.ivfpq_M,
-        ivfpq_K=cfg.storage.ivfpq_K,
-        ivfpq_rerank_candidates=cfg.storage.ivfpq_rerank_candidates,
-        ivfpq_nprobe=cfg.storage.ivfpq_nprobe,
-        cache=cfg.cache,
-    )
+    store = open_store_for_config(cfg, profile=profile)
     atexit.register(store.close)
     return cfg, store
 
@@ -456,9 +443,7 @@ def ask(
                 tagged = federated_search(
                     query_embedding=q_embedding,
                     query_text=query,
-                    embedding_dim=get_embedding_dim(cfg.embeddings.model),
-                    vector_backend=cfg.storage.vector_backend,
-                    snapvec_bits=cfg.storage.snapvec_bits,
+                    cfg=cfg,
                     top_k=k,
                     collection=collection,
                     project=project,
@@ -717,9 +702,7 @@ def search(
                 tagged = federated_search(
                     query_embedding=q_embedding,
                     query_text=query,
-                    embedding_dim=get_embedding_dim(cfg.embeddings.model),
-                    vector_backend=cfg.storage.vector_backend,
-                    snapvec_bits=cfg.storage.snapvec_bits,
+                    cfg=cfg,
                     top_k=k,
                     collection=collection,
                     project=project,
@@ -1416,13 +1399,10 @@ def reindex(
 
     # Open store with current dim (to read existing data)
     current_dim = get_embedding_dim(cfg.embeddings.model) if model else new_dim
-    db_path = str(resolve_db_path(_profile_from_ctx(ctx), config_db_path=cfg.storage.db_path))
-    store = VstashStore(
-        db_path,
+    store = open_store_for_config(
+        cfg,
+        profile=_profile_from_ctx(ctx),
         embedding_dim=current_dim,
-        vector_backend=cfg.storage.vector_backend,
-        snapvec_bits=cfg.storage.snapvec_bits,
-        cache=cfg.cache,
     )
 
     with store:
@@ -2474,18 +2454,7 @@ def retrain_multi_cmd(
                     "Each --store must use a unique name."
                 )
                 raise typer.Exit(code=1)
-            extra_store = VstashStore(
-                path,
-                embedding_dim=dim,
-                vector_backend=cfg.storage.vector_backend,
-                snapvec_bits=cfg.storage.snapvec_bits,
-                ivfpq_nlist=cfg.storage.ivfpq_nlist,
-                ivfpq_M=cfg.storage.ivfpq_M,
-                ivfpq_K=cfg.storage.ivfpq_K,
-                ivfpq_rerank_candidates=cfg.storage.ivfpq_rerank_candidates,
-                ivfpq_nprobe=cfg.storage.ivfpq_nprobe,
-                cache=cfg.cache,
-            )
+            extra_store = open_store_for_config(cfg, db_path=path, embedding_dim=dim)
             opened_extra.append(extra_store)
             stores[alias] = extra_store
 

--- a/vstash/journal.py
+++ b/vstash/journal.py
@@ -23,8 +23,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
 
+from ._store_open import open_store_for_config
 from .config import VstashConfig, load_config
-from .embed import embed_query, get_embedding_dim
+from .embed import embed_query
 from .profile import PROFILES_DIR
 from .store import VstashStore
 
@@ -70,14 +71,7 @@ def _get_journal_store(cfg: VstashConfig | None = None) -> tuple[VstashConfig, V
     db_path = PROFILES_DIR / JOURNAL_PROFILE / "memory.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    dim = get_embedding_dim(cfg.embeddings.model)
-    store = VstashStore(
-        str(db_path),
-        embedding_dim=dim,
-        vector_backend=cfg.storage.vector_backend,
-        snapvec_bits=cfg.storage.snapvec_bits,
-        cache=cfg.cache,
-    )
+    store = open_store_for_config(cfg, db_path=str(db_path))
     return cfg, store
 
 

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -28,8 +28,9 @@ except ImportError as _exc:
         "MCP server requires the mcp package. Install it with: pip install vstash[mcp]"
     ) from _exc
 
+from ._store_open import open_store_for_config
 from .config import VstashConfig, load_config
-from .embed import embed_query, get_embedding_dim, warmup
+from .embed import embed_query, warmup
 from .models import DocumentInfo, IngestResult, SearchResult, StoreStats
 from .store import VstashStore, relevance_tier
 
@@ -107,20 +108,8 @@ def _get_store() -> VstashStore:
     if _store is None:
         with _lock:
             if _store is None:
-                from .profile import resolve_db_path
-
                 cfg = _get_config()
-                dim = get_embedding_dim(cfg.embeddings.model)
-                db_path = str(resolve_db_path(config_db_path=cfg.storage.db_path))
-                _store = VstashStore(
-                    db_path,
-                    embedding_dim=dim,
-                    vector_backend=cfg.storage.vector_backend,
-                    snapvec_bits=cfg.storage.snapvec_bits,
-                    observability=cfg.observability,
-                    limits=cfg.limits,
-                    cache=cfg.cache,
-                )
+                _store = open_store_for_config(cfg)
                 # Detect embedding model drift on non-empty stores.
                 if _store.stats().chunks > 0:
                     drift_msg = _store.check_embedding_drift(cfg.embeddings.model)
@@ -285,20 +274,9 @@ def _run_directory_job(
     Opens its own VstashStore connection to avoid sharing SQLite across threads.
     """
     try:
-        from .embed import get_embedding_dim
         from .ingest import ingest_directory
 
-        from .profile import resolve_db_path
-
-        dim = get_embedding_dim(cfg.embeddings.model)
-        db_path = str(resolve_db_path(config_db_path=cfg.storage.db_path))
-        store = VstashStore(
-            db_path,
-            embedding_dim=dim,
-            vector_backend=cfg.storage.vector_backend,
-            snapvec_bits=cfg.storage.snapvec_bits,
-            cache=cfg.cache,
-        )
+        store = open_store_for_config(cfg)
         try:
             results = ingest_directory(
                 directory,

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -18,9 +18,10 @@ from pathlib import Path
 from types import TracebackType
 from typing import Literal
 
+from ._store_open import open_store_for_config
 from .chat import ask as _chat_ask
 from .config import VstashConfig, load_config
-from .embed import embed_query, get_embedding_dim
+from .embed import embed_query
 from .ingest import ingest
 from .models import (
     ChunkInfo,
@@ -30,7 +31,6 @@ from .models import (
     SearchResult,
     StoreStats,
 )
-from .store import VstashStore
 
 # Sentinel for distinguishing "parameter not provided" from explicit None.
 _UNSET = object()
@@ -93,21 +93,10 @@ class Memory:
         self._chunk_overlap = chunk_overlap
 
         # Resolution: explicit db param > unified resolve_db_path chain
-        if db:
-            db_path = str(db)
-        else:
-            from .profile import resolve_db_path
-
-            db_path = str(resolve_db_path(profile, config_db_path=self._cfg.storage.db_path))
-        dim = get_embedding_dim(self._cfg.embeddings.model)
-        self._store = VstashStore(
-            db_path,
-            embedding_dim=dim,
-            vector_backend=self._cfg.storage.vector_backend,
-            snapvec_bits=self._cfg.storage.snapvec_bits,
-            observability=self._cfg.observability,
-            limits=self._cfg.limits,
-            cache=self._cfg.cache,
+        self._store = open_store_for_config(
+            self._cfg,
+            db_path=str(db) if db else None,
+            profile=profile,
         )
         # Silent killer defense: warn if the DB was built with a
         # different embedding model or a fastembed version that changed

--- a/vstash/profile.py
+++ b/vstash/profile.py
@@ -20,8 +20,12 @@ import re
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .models import SearchResult
+
+if TYPE_CHECKING:
+    from .config import VstashConfig
 
 logger = logging.getLogger(__name__)
 
@@ -230,9 +234,7 @@ def federated_search(
     query_embedding: list[float],
     query_text: str,
     *,
-    embedding_dim: int,
-    vector_backend: str = "sqlite-vec",
-    snapvec_bits: int = 4,
+    cfg: VstashConfig,
     top_k: int = 5,
     collection: str | None = None,
     project: str | None = None,
@@ -244,15 +246,17 @@ def federated_search(
     Opens each profile's VstashStore, runs the query, and merges
     results using Reciprocal Rank Fusion (k=60).  When *expand_window*
     is > 0 each store expands its results with adjacent chunks before
-    closing — this is the only opportunity to expand because the stores
+    closing -- this is the only opportunity to expand because the stores
     are closed after the parallel search phase.
 
     Args:
         query_embedding: Pre-computed query embedding.
         query_text: Raw query text for FTS.
-        embedding_dim: Embedding dimension for stores.
-        vector_backend: Vector backend name.
-        snapvec_bits: Quantization bits for snapvec.
+        cfg: Loaded ``VstashConfig``. Provides every per-profile
+            ``VstashStore`` knob (vector backend, IVFPQ tuning,
+            observability, limits, cache) via ``open_store_for_config``,
+            so all profiles search with the same configuration as the
+            primary store (#297).
         top_k: Number of results to return.
         collection: Optional collection filter.
         project: Optional project filter.
@@ -263,7 +267,7 @@ def federated_search(
         List of (profile_name, SearchResult) tuples sorted by merged score.
         Profile name is "default" for the global database.
     """
-    from .store import VstashStore
+    from ._store_open import open_store_for_config
 
     # Collect all profile db paths (deduplicated by resolved path)
     profiles: list[tuple[str, Path]] = []
@@ -293,12 +297,7 @@ def federated_search(
     def _search_one(item: tuple[str, Path]) -> list[tuple[str, SearchResult]]:
         name, db_path = item
         try:
-            store = VstashStore(
-                str(db_path),
-                embedding_dim=embedding_dim,
-                vector_backend=vector_backend,
-                snapvec_bits=snapvec_bits,
-            )
+            store = open_store_for_config(cfg, db_path=str(db_path))
             try:
                 results = store.search(
                     query_embedding=query_embedding,

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -871,6 +871,11 @@ def evaluate_model(
             tmp_parent / f"retrain_eval_{int(time.time() * 1000)}_{random.randint(0, 1 << 30)}.db"
         )
 
+        # Direct construction (not open_store_for_config) on purpose: this
+        # is a throwaway eval-only DB. The retrain pipeline ingests chunks,
+        # runs NDCG@10, then deletes the file. sqlite-vec defaults are
+        # intentional -- IVFPQ / observability / cache add overhead with
+        # no benefit at the small N evaluated here.
         eval_store = VstashStore(str(tmp_db), embedding_dim=dim)
 
         # Group chunks by document path, then batch-ingest all docs in a

--- a/vstash/retrain_batch.py
+++ b/vstash/retrain_batch.py
@@ -548,6 +548,8 @@ def evaluate_model_batched(
             tmp_parent
             / f"retrain_eval_batched_{int(_time.time() * 1000)}_{_random.randint(0, 1 << 30)}.db"
         )
+        # Throwaway eval-only DB; sqlite-vec defaults are intentional.
+        # See vstash/retrain.py for rationale.
         eval_store = VstashStore(str(tmp_db), embedding_dim=dim)
 
         # Ingest so FTS5 is populated. We feed zero-vectors for the

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -26,9 +26,10 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, StreamingResponse
 from starlette.routing import Route
 
+from ._store_open import open_store_for_config
 from .chat import stream as chat_stream
 from .config import VstashConfig, load_config
-from .embed import embed_query, get_embedding_dim
+from .embed import embed_query
 from .ingest import ingest
 from .models import SearchResult
 from .store import VstashStore, relevance_tier
@@ -53,20 +54,8 @@ def _get_config() -> VstashConfig:
 def _get_store() -> VstashStore:
     global _store  # noqa: PLW0603
     if _store is None:
-        from .profile import resolve_db_path
-
         cfg = _get_config()
-        dim = get_embedding_dim(cfg.embeddings.model)
-        db_path = str(resolve_db_path(config_db_path=cfg.storage.db_path))
-        _store = VstashStore(
-            db_path,
-            embedding_dim=dim,
-            vector_backend=cfg.storage.vector_backend,
-            snapvec_bits=cfg.storage.snapvec_bits,
-            observability=cfg.observability,
-            limits=cfg.limits,
-            cache=cfg.cache,
-        )
+        _store = open_store_for_config(cfg)
         # Detect embedding model drift on non-empty stores.
         if _store.stats().chunks > 0:
             drift_msg = _store.check_embedding_drift(cfg.embeddings.model)


### PR DESCRIPTION
## Summary

Closes #297. Every public surface (CLI, MCP, web, SDK, journal, federated search) used to duplicate the `StorageConfig -> VstashStore` wiring. Several silently dropped IVFPQ tuning fields (`ivfpq_M / K / nlist / nprobe / rerank_candidates`), so a non-default config that worked on the CLI behaved differently under SDK or federated search. Adding a new `StorageConfig` knob also meant touching ~7 files.

This PR collapses every surface onto a single helper, `vstash._store_open.open_store_for_config`, which forwards every storage knob plus `observability`, `limits`, and `cache`.

Net diff: **-76 lines on the surfaces, +1 helper module, +1 test module**.

## What changed

| Surface | Before | After |
| --- | --- | --- |
| `cli._get_store` | IVFPQ + cache, no obs/limits | helper (gains obs/limits) |
| `cli.reindex` | no IVFPQ, no obs/limits | helper (full wiring) |
| `cli` `--store path:alias` | IVFPQ + cache, no obs/limits | helper |
| `journal._get_journal_store` | no IVFPQ, no obs/limits | helper |
| `mcp._get_store` | full | helper |
| `mcp` background ingest | IVFPQ + cache, no obs/limits | helper |
| `memory.Memory.__init__` | full | helper |
| `web._get_store` | full | helper |
| `profile.federated_search` | accepted 7 storage kwargs, dropped obs/limits/cache | takes `cfg=VstashConfig`, full wiring per-profile |
| `retrain.py` / `retrain_batch.py` eval temp store | direct ctor | unchanged + comment explaining why |

## Test plan

- [x] `pytest tests/ -q` (1014 passed, 6 deselected)
- [x] `ruff check . && ruff format --check`
- [x] New `tests/test_store_open.py` (9 tests):
  - Helper forwards every storage knob + obs/limits/cache.
  - `db_path` and `embedding_dim` overrides honored.
  - Each surface (CLI, MCP, web, SDK, journal, federated) routes through the helper exactly once -- a future regression that re-introduces a bespoke `VstashStore(...)` call would fail loudly.
- [x] Existing tests adjusted to patch `open_store_for_config` rather than the underlying `VstashStore` + `get_embedding_dim` pair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized store initialization across all modules through a new unified helper function, simplifying database path and configuration resolution
  * Updated federated search API to accept configuration object instead of individual vector parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->