### PR TITLE
fix(#296): map collection=None to schema default on writes

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -144,6 +144,34 @@ class TestMemoryAdd:
             [r2] = mem.add(doc, force=True)
             assert r2.status == "ok"
 
+    @requires_sqlite_vec
+    def test_add_collection_none_falls_back_to_default(self, tmp_path: Path) -> None:
+        """``collection=None`` on writes is mapped to the schema default ``'default'``.
+
+        ``documents.collection`` is NOT NULL with default ``'default'``; before
+        #296 the explicit ``None`` reached SQLite and raised
+        ``IntegrityError NOT NULL constraint failed: documents.collection``.
+        """
+        doc = tmp_path / "nullcoll.md"
+        doc.write_text("Body for the null-collection regression test.")
+
+        with Memory(db=tmp_path / "test.db") as mem:
+            [result] = mem.add(doc, collection=None)
+            assert result.status == "ok"
+            assert mem.list(collection="default"), "doc must land in 'default'"
+
+    @requires_sqlite_vec
+    def test_remember_collection_none_falls_back_to_default(self, tmp_path: Path) -> None:
+        """Same #296 guard applies to ``Memory.remember`` (text ingest)."""
+        with Memory(db=tmp_path / "test.db") as mem:
+            result = mem.remember(
+                "Body for the null-collection remember regression test.",
+                title="t",
+                collection=None,
+            )
+            assert result.status == "ok"
+            assert mem.list(collection="default"), "doc must land in 'default'"
+
 
 # ------------------------------------------------------------------ #
 # Memory.search                                                        #

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -154,7 +154,9 @@ class Memory:
         Args:
             source: File path, URL, or directory to ingest.
             force: Re-ingest even if the document already exists.
-            collection: Override the default collection. Pass None for no collection.
+            collection: Override the default collection. ``documents.collection``
+                is NOT NULL with default ``"default"``; passing ``None`` falls back
+                to that schema default rather than storing NULL (#296).
             project: Override the default project tag. Pass None for no project.
             layer: Layer/category tag.
             tags: Comma-separated tags.
@@ -163,6 +165,8 @@ class Memory:
             List of IngestResult (one per file, even for single-file ingestion).
         """
         col = self._collection if collection is _UNSET else collection
+        if col is None:
+            col = "default"
         proj = self._project if project is _UNSET else project
 
         source_str = str(source)
@@ -226,7 +230,9 @@ class Memory:
             text: The content to ingest.
             title: Human-readable title for the document. When *None*,
                 a descriptive title is auto-generated from the text content.
-            collection: Override the default collection. Pass None for no collection.
+            collection: Override the default collection. ``documents.collection``
+                is NOT NULL with default ``"default"``; passing ``None`` falls back
+                to that schema default rather than storing NULL (#296).
             project: Override the default project tag. Pass None for no project.
             layer: Layer/category tag.
             tags: Comma-separated tags.
@@ -242,6 +248,8 @@ class Memory:
         from .ingest import ingest_text
 
         col = self._collection if collection is _UNSET else collection
+        if col is None:
+            col = "default"
         proj = self._project if project is _UNSET else project
 
         return ingest_text(


### PR DESCRIPTION
## Summary
- `Memory.add()` and `Memory.remember()` documented `collection=None` as "no collection", but `documents.collection` is `NOT NULL DEFAULT 'default'`, so the explicit `None` reached SQLite and raised `IntegrityError NOT NULL constraint failed: documents.collection`.
- On the write path, treat `collection=None` as the schema default `"default"` and update the docstrings.
- Read paths (`search`, `list`, `get_document_chunks`) still treat `None` as "no filter".

## Test plan
- [x] `pytest tests/test_memory.py` (44 passed, 130s)
- [x] `ruff check` + `ruff format --check` clean
- [x] New regression: `test_add_collection_none_falls_back_to_default`
- [x] New regression: `test_remember_collection_none_falls_back_to_default`

Closes #296.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `add()` and `remember()` methods now properly handle explicit `collection=None` by defaulting to `"default"` instead of allowing NULL values.

* **Tests**
  * Added regression tests covering write operations when `collection=None` is explicitly passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->