### PR TITLE
fix(#294): align retrain_synth backend config with current schema

### DIFF
--- a/tests/test_retrain_synth.py
+++ b/tests/test_retrain_synth.py
@@ -12,6 +12,7 @@ import pytest
 from vstash.config import VstashConfig
 from vstash.retrain_synth import (
     _build_prompt,
+    _llm_complete,
     _parse_queries,
     _prompt_hash,
     synthesize_queries,
@@ -98,8 +99,6 @@ class TestLlmCompleteBackendResolution:
 
     @staticmethod
     def _stub_openai_response() -> Any:
-        from vstash.retrain_synth import _llm_complete  # noqa: F401  -- import side effect
-
         resp = MagicMock()
         resp.choices = [MagicMock()]
         resp.choices[0].message.content = '["q1"]'
@@ -120,8 +119,6 @@ class TestLlmCompleteBackendResolution:
         )
         client = self._stub_openai_response()
         with patch("openai.OpenAI", return_value=client) as mk_openai:
-            from vstash.retrain_synth import _llm_complete
-
             _llm_complete(cfg, "p")
         mk_openai.assert_called_once_with(api_key="k", base_url="https://example/v1")
         assert client.chat.completions.create.call_args.kwargs["model"] == "gpt-test"
@@ -135,8 +132,6 @@ class TestLlmCompleteBackendResolution:
         )
         client = self._stub_openai_response()
         with patch("openai.OpenAI", return_value=client) as mk_openai:
-            from vstash.retrain_synth import _llm_complete
-
             _llm_complete(cfg, "p")
         mk_openai.assert_called_once_with(api_key="ollama", base_url="http://localhost:11434/v1")
         assert client.chat.completions.create.call_args.kwargs["model"] == "qwen-test"
@@ -150,8 +145,6 @@ class TestLlmCompleteBackendResolution:
         )
         client = self._stub_openai_response()
         with patch("openai.OpenAI", return_value=client) as mk_openai:
-            from vstash.retrain_synth import _llm_complete
-
             _llm_complete(cfg, "p")
         assert mk_openai.call_args.kwargs["base_url"] == "http://localhost:11434/v1"
 
@@ -164,16 +157,12 @@ class TestLlmCompleteBackendResolution:
         )
         client = self._stub_openai_response()
         with patch("openai.OpenAI", return_value=client) as mk_openai:
-            from vstash.retrain_synth import _llm_complete
-
             _llm_complete(cfg, "p")
         mk_openai.assert_called_once_with(api_key="ck", base_url="https://api.cerebras.ai/v1")
         assert client.chat.completions.create.call_args.kwargs["model"] == "llama-3.3-70b"
 
     def test_local_resolves_to_concrete_backend(self) -> None:
         """``backend='local'`` is normalised through ``_resolve_local_config``."""
-        from vstash.retrain_synth import _llm_complete
-
         cfg_local = VstashConfig.model_validate(
             {
                 "inference": {"backend": "local", "model": "ignored"},
@@ -303,3 +292,53 @@ class TestSynthesizeQueries:
                 on_progress=lambda done, total: calls.append((done, total)),
             )
         assert calls == [(1, 3), (2, 3), (3, 3)]
+
+    def test_cerebras_model_resolution_uses_inference_model(self, tmp_path: Path) -> None:
+        """Regression for #294: synthesize_queries had a second cerebras.model
+        access (separate from _llm_complete) that crashed before any LLM call.
+        """
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "cerebras", "model": "llama-3.3-70b"},
+                "cerebras": {"api_key": "ck"},
+            }
+        )
+        chunks = [{"id": 1, "text": "passage"}]
+        cache_path = tmp_path / "synth.jsonl"
+
+        with patch("vstash.retrain_synth._llm_complete", return_value='["q1"]'):
+            out = synthesize_queries(chunks, cfg, n_per_chunk=1, cache_path=cache_path)
+
+        assert out == {1: ["q1"]}
+        # The resolved model lands in the cache record; assert it was the
+        # inference.model value, not a phantom cerebras.model.
+        record = json.loads(cache_path.read_text().strip())
+        assert record["model"] == "llama-3.3-70b"
+
+    def test_local_resolving_to_cerebras_uses_inference_model(self, tmp_path: Path) -> None:
+        """``backend='local'`` that resolves to cerebras must also pull the
+        model from inference.model (#294)."""
+        cfg_local = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "local", "model": "ignored"},
+                "cerebras": {"api_key": "ck"},
+            }
+        )
+        cfg_resolved = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "cerebras", "model": "llama-3.3-70b"},
+                "cerebras": {"api_key": "ck"},
+            }
+        )
+        chunks = [{"id": 1, "text": "passage"}]
+        cache_path = tmp_path / "synth.jsonl"
+
+        with (
+            patch("vstash.chat._resolve_local_config", return_value=cfg_resolved),
+            patch("vstash.retrain_synth._llm_complete", return_value='["q1"]'),
+        ):
+            out = synthesize_queries(chunks, cfg_local, n_per_chunk=1, cache_path=cache_path)
+
+        assert out == {1: ["q1"]}
+        record = json.loads(cache_path.read_text().strip())
+        assert record["model"] == "llama-3.3-70b"

--- a/tests/test_retrain_synth.py
+++ b/tests/test_retrain_synth.py
@@ -83,6 +83,119 @@ class TestParseQueries:
 
 
 # ------------------------------------------------------------------ #
+# Backend config resolution (#294)                                     #
+# ------------------------------------------------------------------ #
+
+
+class TestLlmCompleteBackendResolution:
+    """Lock in the config field names ``_llm_complete`` reads per backend.
+
+    Before #294 the ollama path read ``cfg.ollama.base_url`` and the
+    cerebras path read ``cfg.cerebras.base_url`` / ``cfg.cerebras.model``
+    -- none of which exist on the Pydantic models, so synthesis raised
+    AttributeError per chunk and silently fell back to prefix queries.
+    """
+
+    @staticmethod
+    def _stub_openai_response() -> Any:
+        from vstash.retrain_synth import _llm_complete  # noqa: F401  -- import side effect
+
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = '["q1"]'
+        client = MagicMock()
+        client.chat.completions.create.return_value = resp
+        return client
+
+    def test_openai_uses_openai_model_and_base_url(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "openai", "model": "ignored"},
+                "openai": {
+                    "api_key": "k",
+                    "model": "gpt-test",
+                    "base_url": "https://example/v1",
+                },
+            }
+        )
+        client = self._stub_openai_response()
+        with patch("openai.OpenAI", return_value=client) as mk_openai:
+            from vstash.retrain_synth import _llm_complete
+
+            _llm_complete(cfg, "p")
+        mk_openai.assert_called_once_with(api_key="k", base_url="https://example/v1")
+        assert client.chat.completions.create.call_args.kwargs["model"] == "gpt-test"
+
+    def test_ollama_uses_host_and_appends_v1(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama", "model": "ignored"},
+                "ollama": {"host": "http://localhost:11434", "model": "qwen-test"},
+            }
+        )
+        client = self._stub_openai_response()
+        with patch("openai.OpenAI", return_value=client) as mk_openai:
+            from vstash.retrain_synth import _llm_complete
+
+            _llm_complete(cfg, "p")
+        mk_openai.assert_called_once_with(api_key="ollama", base_url="http://localhost:11434/v1")
+        assert client.chat.completions.create.call_args.kwargs["model"] == "qwen-test"
+
+    def test_ollama_host_already_v1_is_not_doubled(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama"},
+                "ollama": {"host": "http://localhost:11434/v1", "model": "x"},
+            }
+        )
+        client = self._stub_openai_response()
+        with patch("openai.OpenAI", return_value=client) as mk_openai:
+            from vstash.retrain_synth import _llm_complete
+
+            _llm_complete(cfg, "p")
+        assert mk_openai.call_args.kwargs["base_url"] == "http://localhost:11434/v1"
+
+    def test_cerebras_uses_inference_model_and_hardcoded_base_url(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "cerebras", "model": "llama-3.3-70b"},
+                "cerebras": {"api_key": "ck"},
+            }
+        )
+        client = self._stub_openai_response()
+        with patch("openai.OpenAI", return_value=client) as mk_openai:
+            from vstash.retrain_synth import _llm_complete
+
+            _llm_complete(cfg, "p")
+        mk_openai.assert_called_once_with(api_key="ck", base_url="https://api.cerebras.ai/v1")
+        assert client.chat.completions.create.call_args.kwargs["model"] == "llama-3.3-70b"
+
+    def test_local_resolves_to_concrete_backend(self) -> None:
+        """``backend='local'`` is normalised through ``_resolve_local_config``."""
+        from vstash.retrain_synth import _llm_complete
+
+        cfg_local = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "local", "model": "ignored"},
+                "ollama": {"host": "http://localhost:11434", "model": "x"},
+            }
+        )
+        cfg_resolved = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama"},
+                "ollama": {"host": "http://localhost:11434", "model": "x"},
+            }
+        )
+        client = self._stub_openai_response()
+        with (
+            patch("vstash.chat._resolve_local_config", return_value=cfg_resolved) as mk_resolve,
+            patch("openai.OpenAI", return_value=client),
+        ):
+            _llm_complete(cfg_local, "p")
+        mk_resolve.assert_called_once()
+
+
+# ------------------------------------------------------------------ #
 # End-to-end synthesize_queries with mocked LLM + cache                #
 # ------------------------------------------------------------------ #
 

--- a/vstash/retrain_synth.py
+++ b/vstash/retrain_synth.py
@@ -89,15 +89,20 @@ def _llm_complete(cfg: VstashConfig, prompt: str, model: str | None = None) -> s
         use_model = model or cfg.openai.model
         extra_body = cfg.openai.extra_body
     elif backend == "ollama":
-        base_url = cfg.ollama.base_url.rstrip("/")
+        # OllamaConfig exposes ``host`` (matching chat.py); ensure /v1
+        # so the OpenAI client targets Ollama's openai-compat endpoint.
+        base_url = cfg.ollama.host.rstrip("/")
         if not base_url.endswith("/v1"):
             base_url = base_url + "/v1"
         client = OpenAI(api_key="ollama", base_url=base_url)
         use_model = model or cfg.ollama.model
         extra_body = None
     elif backend == "cerebras":
-        client = OpenAI(api_key=cfg.cerebras_api_key, base_url=cfg.cerebras.base_url)
-        use_model = model or cfg.cerebras.model
+        # CerebrasConfig only carries ``api_key``; the model lives at
+        # ``cfg.inference.model`` and Cerebras exposes an OpenAI-compatible
+        # endpoint at api.cerebras.ai/v1 (#294).
+        client = OpenAI(api_key=cfg.cerebras_api_key, base_url="https://api.cerebras.ai/v1")
+        use_model = model or cfg.inference.model
         extra_body = None
     else:
         raise ValueError(

--- a/vstash/retrain_synth.py
+++ b/vstash/retrain_synth.py
@@ -287,13 +287,15 @@ def synthesize_queries(
             elif backend == "ollama":
                 resolved_model = resolved_cfg.ollama.model
             elif backend == "cerebras":
-                resolved_model = resolved_cfg.cerebras.model
+                # CerebrasConfig only carries api_key; model lives at
+                # cfg.inference.model (#294).
+                resolved_model = resolved_cfg.inference.model
         elif backend == "openai":
             resolved_model = cfg.openai.model
         elif backend == "ollama":
             resolved_model = cfg.ollama.model
         elif backend == "cerebras":
-            resolved_model = cfg.cerebras.model
+            resolved_model = cfg.inference.model
     if resolved_model is None:
         resolved_model = "unknown"
 


### PR DESCRIPTION
## Summary
- `_llm_complete()` read `cfg.ollama.base_url`, `cfg.cerebras.base_url` and `cfg.cerebras.model`. None of those fields exist on the Pydantic models, so non-OpenAI backends raised `AttributeError` per chunk and `synthesize_queries()` silently fell back to prefix-derived queries.
- Ollama: use `cfg.ollama.host` (matching `chat.py`) and ensure `/v1` suffix once.
- Cerebras: hardcode the OpenAI-compatible base URL `https://api.cerebras.ai/v1` and resolve the model from `cfg.inference.model`. `CerebrasConfig` only carries `api_key`.
- OpenAI path unchanged. `backend='local'` still routes through `chat._resolve_local_config`.

## Test plan
- [x] `pytest tests/test_retrain_synth.py` (20 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] New `TestLlmCompleteBackendResolution` covers openai, ollama (with/without trailing `/v1`), cerebras, and local resolution. Patches `openai.OpenAI` so no network calls happen.

Closes #294.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backend configuration parsing so the correct model and API base URL are used for each LLM provider.
  * Resolved caching/model-record issues so synthesized queries store and use the intended model, preventing incorrect model lookups.
  * Ensured provider endpoint paths aren’t duplicated when appending the API version.

* **Tests**
  * Added tests validating backend configuration, model selection, endpoint handling, and cache correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->