### PR TITLE
fix(#295): persist web uploads under ~/.vstash/uploads with stable names

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -244,6 +244,96 @@ class TestApiUpload:
         assert resp.json()["title"] == "uploaded"
         assert resp.json()["status"] == "ok"
 
+    def test_upload_forwards_original_filename_to_do_upload(self, client: TestClient) -> None:
+        """The Starlette handler must pass ``upload.filename`` along so
+        ``_do_upload`` can preserve it in the persisted source path (#295).
+        """
+        with patch("vstash.web._do_upload") as mock_upload:
+            mock_upload.return_value = IngestResult(status="ok", source="/x", title="x", chunks=1)
+            files = {"file": ("report.md", io.BytesIO(b"body"), "text/markdown")}
+            client.post("/api/upload", files=files)
+        args, kwargs = mock_upload.call_args
+        # _do_upload(file_bytes, suffix, original_name)
+        assert args[0] == b"body"
+        assert args[1] == ".md"
+        assert args[2] == "report.md"
+
+
+class TestDoUploadPersistence:
+    """``_do_upload`` must persist the bytes and pass a real path to ingest (#295).
+
+    Before #295 the path passed to ``ingest()`` was a NamedTemporaryFile
+    that got unlinked in the ``finally`` block, leaving documents
+    pointing at deleted ``/var/folders/.../tmpXXX`` files with
+    ``tmpXXX`` as the title.
+    """
+
+    def test_persists_under_uploads_dir_with_safe_name(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        from pathlib import Path
+
+        import vstash.web as web_mod
+
+        uploads_dir = tmp_path / "uploads"
+        monkeypatch.setattr(web_mod, "_UPLOADS_DIR", uploads_dir)
+        monkeypatch.setattr(web_mod, "_get_config", lambda: MagicMock())
+        monkeypatch.setattr(web_mod, "_get_store", lambda: MagicMock())
+
+        seen: dict = {}
+
+        def _capture_ingest(path, *_args, **_kwargs):
+            p = Path(path)
+            seen["path"] = p
+            seen["exists_at_ingest"] = p.exists()
+            seen["bytes"] = p.read_bytes()
+            return IngestResult(status="ok", source=str(p), title=p.stem, chunks=1)
+
+        monkeypatch.setattr(web_mod, "ingest", _capture_ingest)
+
+        result = web_mod._do_upload(b"body", ".md", "weird name!@#.md")
+
+        assert result.status == "ok"
+        # File still exists after ingest -- not a temp that got unlinked.
+        assert seen["path"].exists()
+        # Lives under our uploads dir.
+        assert uploads_dir in seen["path"].parents
+        # Original-ish name is preserved (sanitised) in the basename.
+        assert "weird_name___.md" in seen["path"].name
+        # Suffix is honoured even when sanitisation drops it.
+        assert seen["path"].suffix == ".md"
+        # The bytes ingest sees match the upload.
+        assert seen["bytes"] == b"body"
+
+    def test_falls_back_to_default_basename_when_original_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        import vstash.web as web_mod
+
+        uploads_dir = tmp_path / "uploads"
+        monkeypatch.setattr(web_mod, "_UPLOADS_DIR", uploads_dir)
+        monkeypatch.setattr(web_mod, "_get_config", lambda: MagicMock())
+        monkeypatch.setattr(web_mod, "_get_store", lambda: MagicMock())
+
+        captured: list = []
+        monkeypatch.setattr(
+            web_mod,
+            "ingest",
+            lambda path, *_a, **_kw: (
+                captured.append(path) or IngestResult(status="ok", source=path, title="t", chunks=1)
+            ),
+        )
+
+        web_mod._do_upload(b"body", ".txt", None)
+
+        from pathlib import Path
+
+        path = Path(captured[0])
+        assert path.exists()
+        assert path.suffix == ".txt"
+        # Falls back to "upload" when no filename was provided.
+        assert "upload" in path.name
+
 
 # ------------------------------------------------------------------ #
 # HTML index + observability                                           #

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -405,6 +405,34 @@ class TestDoUploadPersistence:
         assert len(path.name) < 200
         assert path.suffix == ".md"
 
+    def test_caps_long_suffix_too(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """A 1KB suffix must not survive the cap intact -- the basename
+        budget covers safe_name + suffix together (CodeRabbit on #309)."""
+        import vstash.web as web_mod
+
+        uploads_dir = tmp_path / "uploads"
+        monkeypatch.setattr(web_mod, "_UPLOADS_DIR", uploads_dir)
+        monkeypatch.setattr(web_mod, "_get_config", lambda: MagicMock())
+        monkeypatch.setattr(web_mod, "_get_store", lambda: MagicMock())
+        captured: list = []
+        monkeypatch.setattr(
+            web_mod,
+            "ingest",
+            lambda path, *_a, **_kw: (
+                captured.append(path) or IngestResult(status="ok", source=path, title="t", chunks=1)
+            ),
+        )
+
+        adversarial_suffix = "." + ("a" * 1024)
+        web_mod._do_upload(b"body", adversarial_suffix, "ok.md")
+
+        from pathlib import Path
+
+        path = Path(captured[0])
+        # Final basename stays under the OS limit even when the suffix
+        # itself is pathological.
+        assert len(path.name) < 200
+
 
 # ------------------------------------------------------------------ #
 # HTML index + observability                                           #

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -334,6 +334,77 @@ class TestDoUploadPersistence:
         # Falls back to "upload" when no filename was provided.
         assert "upload" in path.name
 
+    @pytest.mark.parametrize(
+        "client_name",
+        [
+            "subdir/leaked.md",
+            "/etc/passwd",
+            "C:\\Users\\jay\\secret.md",
+            "..\\..\\sneaky.md",
+        ],
+    )
+    def test_strips_client_path_fragments_to_basename(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        client_name: str,
+    ) -> None:
+        """Filenames with path separators must be reduced to their basename
+        before sanitization, so client path fragments never reach the
+        persisted name (CodeRabbit on #309)."""
+        import vstash.web as web_mod
+
+        uploads_dir = tmp_path / "uploads"
+        monkeypatch.setattr(web_mod, "_UPLOADS_DIR", uploads_dir)
+        monkeypatch.setattr(web_mod, "_get_config", lambda: MagicMock())
+        monkeypatch.setattr(web_mod, "_get_store", lambda: MagicMock())
+        captured: list = []
+        monkeypatch.setattr(
+            web_mod,
+            "ingest",
+            lambda path, *_a, **_kw: (
+                captured.append(path) or IngestResult(status="ok", source=path, title="t", chunks=1)
+            ),
+        )
+
+        web_mod._do_upload(b"body", ".md", client_name)
+
+        from pathlib import Path
+
+        path = Path(captured[0])
+        # No directory separators (raw or sanitised) survive in the basename.
+        assert "/" not in path.name and "\\" not in path.name
+        # Path fragments must not be flattened into underscores either.
+        assert "subdir" not in path.name
+        assert "etc" not in path.name
+        assert "Users" not in path.name
+
+    def test_caps_extremely_long_filenames(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+        """A 1KB adversarial filename must not blow past ENAMETOOLONG."""
+        import vstash.web as web_mod
+
+        uploads_dir = tmp_path / "uploads"
+        monkeypatch.setattr(web_mod, "_UPLOADS_DIR", uploads_dir)
+        monkeypatch.setattr(web_mod, "_get_config", lambda: MagicMock())
+        monkeypatch.setattr(web_mod, "_get_store", lambda: MagicMock())
+        captured: list = []
+        monkeypatch.setattr(
+            web_mod,
+            "ingest",
+            lambda path, *_a, **_kw: (
+                captured.append(path) or IngestResult(status="ok", source=path, title="t", chunks=1)
+            ),
+        )
+
+        web_mod._do_upload(b"body", ".md", "a" * 1024 + ".md")
+
+        from pathlib import Path
+
+        path = Path(captured[0])
+        # 12-char uuid prefix + dash + capped basename + suffix < 255.
+        assert len(path.name) < 200
+        assert path.suffix == ".md"
+
 
 # ------------------------------------------------------------------ #
 # HTML index + observability                                           #

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import tempfile
 import threading
+import uuid
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
@@ -120,16 +120,29 @@ def _do_stats() -> Any:
     return _get_store().stats()
 
 
-def _do_upload(file_bytes: bytes, suffix: str) -> Any:
+_UPLOADS_DIR = Path("~/.vstash/uploads").expanduser()
+
+
+def _do_upload(file_bytes: bytes, suffix: str, original_name: str | None = None) -> Any:
+    """Persist an uploaded blob and ingest it.
+
+    The earlier implementation wrote to ``tempfile.NamedTemporaryFile``
+    and ``unlink``ed the path right after ``ingest()`` returned. The
+    document then pointed at a deleted ``/var/folders/.../tmpXXX``
+    path with the temp basename as title (#295). Persisting under
+    ``~/.vstash/uploads/<uuid>-<safe-name>`` gives the stored document
+    a stable source the user can later re-open or re-ingest.
+    """
     cfg = _get_config()
     store = _get_store()
-    fd = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-    try:
-        fd.write(file_bytes)
-        fd.close()
-        return ingest(fd.name, cfg, store, force=True)
-    finally:
-        Path(fd.name).unlink(missing_ok=True)
+    _UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
+    src_name = original_name or "upload"
+    safe_name = "".join(c if c.isalnum() or c in "._-" else "_" for c in src_name)
+    if not safe_name.endswith(suffix):
+        safe_name += suffix
+    target = _UPLOADS_DIR / f"{uuid.uuid4().hex[:12]}-{safe_name}"
+    target.write_bytes(file_bytes)
+    return ingest(str(target), cfg, store, force=True)
 
 
 def _do_chat_retrieve(query: str, top_k: int) -> tuple[list[SearchResult], list[dict]]:
@@ -338,7 +351,7 @@ async def api_upload(request: Request) -> JSONResponse:
 
     suffix = Path(upload.filename).suffix if upload.filename else ".txt"
     content = await upload.read()
-    result = await _run_sync(_do_upload, content, suffix)
+    result = await _run_sync(_do_upload, content, suffix, upload.filename)
     return _json(result)
 
 

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -136,8 +136,16 @@ def _do_upload(file_bytes: bytes, suffix: str, original_name: str | None = None)
     cfg = _get_config()
     store = _get_store()
     _UPLOADS_DIR.mkdir(parents=True, exist_ok=True)
-    src_name = original_name or "upload"
+    # Strip any path fragments a client may have included (POSIX or
+    # Windows separators) before sanitization so we never persist
+    # ``a/b/leaked.md`` as ``a_b_leaked.md``.
+    raw_name = original_name or "upload"
+    src_name = raw_name.replace("\\", "/").rsplit("/", 1)[-1] or "upload"
     safe_name = "".join(c if c.isalnum() or c in "._-" else "_" for c in src_name)
+    # Cap the basename length so an adversarial filename can't blow
+    # past ENAMETOOLONG (255 on most filesystems). Keep the suffix.
+    if len(safe_name) > 128:
+        safe_name = safe_name[:128]
     if not safe_name.endswith(suffix):
         safe_name += suffix
     target = _UPLOADS_DIR / f"{uuid.uuid4().hex[:12]}-{safe_name}"

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -142,12 +142,26 @@ def _do_upload(file_bytes: bytes, suffix: str, original_name: str | None = None)
     raw_name = original_name or "upload"
     src_name = raw_name.replace("\\", "/").rsplit("/", 1)[-1] or "upload"
     safe_name = "".join(c if c.isalnum() or c in "._-" else "_" for c in src_name)
-    # Cap the basename length so an adversarial filename can't blow
-    # past ENAMETOOLONG (255 on most filesystems). Keep the suffix.
-    if len(safe_name) > 128:
-        safe_name = safe_name[:128]
-    if not safe_name.endswith(suffix):
-        safe_name += suffix
+    # Cap the FINAL basename (incl. suffix) so an adversarial filename or
+    # suffix can't blow past ENAMETOOLONG (255 on most filesystems). The
+    # uuid12 prefix + dash add 13 chars to the on-disk name; keep margin.
+    _MAX_BASENAME = 128
+    safe_suffix = "".join(c if c.isalnum() or c in "._-" else "_" for c in (suffix or ""))
+    if safe_suffix and not safe_suffix.startswith("."):
+        safe_suffix = "." + safe_suffix
+    # If the suffix alone exceeds the cap, truncate it; never let it eat
+    # the whole budget.
+    if len(safe_suffix) >= _MAX_BASENAME:
+        safe_suffix = safe_suffix[: _MAX_BASENAME - 1]
+    # Strip an existing copy of the suffix so we always re-append it
+    # exactly once at the cap boundary.
+    if safe_suffix and safe_name.endswith(safe_suffix):
+        safe_name = safe_name[: -len(safe_suffix)]
+    if safe_suffix:
+        keep = max(1, _MAX_BASENAME - len(safe_suffix))
+        safe_name = safe_name[:keep] + safe_suffix
+    elif len(safe_name) > _MAX_BASENAME:
+        safe_name = safe_name[:_MAX_BASENAME]
     target = _UPLOADS_DIR / f"{uuid.uuid4().hex[:12]}-{safe_name}"
     target.write_bytes(file_bytes)
     return ingest(str(target), cfg, store, force=True)


### PR DESCRIPTION
## Summary
- `POST /api/upload` wrote the body to `NamedTemporaryFile`, ingested that path, and `unlink`ed it in the `finally` block. Documents ended up pointing at `/var/folders/.../tmpXXX` with `tmpXXX` as the title, breaking the web UI document list, delete/forget flows, and source links.
- `_do_upload` now persists uploads to `~/.vstash/uploads/<uuid12>-<safe-name>`, preserving the original filename (sanitised) and the requested suffix.
- `api_upload` forwards `upload.filename` so the persisted basename matches what the user uploaded.
- Drop the `tempfile` import; `uuid` replaces it.

## Test plan
- [x] `pytest tests/test_web.py` (39 passed)
- [x] `ruff check` + `ruff format --check` clean
- [x] New: `test_upload_forwards_original_filename_to_do_upload`
- [x] New: `test_persists_under_uploads_dir_with_safe_name` -- file still exists after ingest, lives under uploads dir, suffix preserved
- [x] New: `test_falls_back_to_default_basename_when_original_missing`

Closes #295.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uploaded files are now stored persistently in a dedicated uploads directory; original filenames are preserved after sanitization, path fragments are stripped, very long names/suffixes are capped, and a default "upload" basename is used when missing.

* **Tests**
  * Added end-to-end tests covering upload handling, filename preservation/sanitization, length limits, path-fragment stripping, and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->