### PR TITLE
feat(#303): expose reasoning + usage via chat.ask_full() returning AskResult

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -7,7 +7,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vstash.chat import _build_messages, _build_prompt, _is_retryable, _retry_call, ask, ask_full
+from vstash.chat import (
+    _build_messages,
+    _build_prompt,
+    _is_retryable,
+    _normalize_usage,
+    _retry_call,
+    ask,
+    ask_full,
+)
 from vstash.config import VstashConfig
 from vstash.models import AskResult, SearchResult
 
@@ -157,6 +165,36 @@ class TestRetryLogic:
 # ------------------------------------------------------------------ #
 
 
+class TestNormalizeUsage:
+    """Lock in the contract for the helper that flattens SDK ``usage``
+    objects into a plain dict."""
+
+    def test_none_in_none_out(self) -> None:
+        assert _normalize_usage(None) is None
+
+    def test_dict_passthrough(self) -> None:
+        assert _normalize_usage(
+            {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+        ) == {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}
+
+    def test_object_with_attributes(self) -> None:
+        obj = SimpleNamespace(prompt_tokens=4, completion_tokens=5, total_tokens=9)
+        assert _normalize_usage(obj) == {
+            "prompt_tokens": 4,
+            "completion_tokens": 5,
+            "total_tokens": 9,
+        }
+
+    def test_partial_keys_kept(self) -> None:
+        """Missing fields are simply dropped, not coerced to 0."""
+        assert _normalize_usage({"prompt_tokens": 7}) == {"prompt_tokens": 7}
+
+    def test_empty_dict_collapses_to_none(self) -> None:
+        """No recognised int fields -> None, so consumers can distinguish
+        'no telemetry' from 'all zero counts'."""
+        assert _normalize_usage({"weird_field": "abc"}) is None
+
+
 def _cerebras_response(content: str, *, reasoning: str | None = None, usage: dict | None = None):
     """Mimic the shape ``cerebras.cloud.sdk.Cerebras.chat.completions.create``
     returns: ``response.choices[0].message.{content,reasoning}`` plus
@@ -229,6 +267,21 @@ class TestAskFullCerebras:
             result = ask_full("q", chunks, cfg)
         assert result.reasoning is None
 
+    def test_usage_none_yields_none_not_empty_dict(self) -> None:
+        """Cerebras occasionally omits ``response.usage`` (5xx-then-fallback,
+        streaming retries). AskResult.usage must be None, never ``{}``,
+        so consumers can distinguish 'no telemetry' from 'all-zero counts'."""
+        cfg = _cfg_cerebras("gpt-oss-120b")
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.completions.create.return_value = _cerebras_response(
+            "answer", reasoning="trace", usage=None
+        )
+        with patch("cerebras.cloud.sdk.Cerebras", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.reasoning == "trace"
+        assert result.usage is None
+
 
 class TestAskFullOpenAI:
     """OpenAI / OpenAI-compat. Reasoning channel is non-standard so the
@@ -260,6 +313,30 @@ class TestAskFullOpenAI:
         }
         assert result.backend == "openai"
         assert result.model == "gpt-4o-mini"
+
+    def test_reasoning_content_field_is_recognised(self) -> None:
+        """vLLM, DeepSeek, Together, xAI Grok and OpenAI o1/o3 Chat
+        Completions surface reasoning under ``message.reasoning_content``,
+        not ``message.reasoning``. Both must be accepted."""
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "openai"},
+                "openai": {
+                    "api_key": "k",
+                    "base_url": "http://localhost:8000/v1",
+                    "model": "deepseek-r1",
+                },
+            }
+        )
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        msg = SimpleNamespace(content="final answer", reasoning_content="step 1 ... step 2 ...")
+        choice = SimpleNamespace(message=msg)
+        client.chat.completions.create.return_value = SimpleNamespace(choices=[choice], usage=None)
+        with patch("openai.OpenAI", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.content == "final answer"
+        assert result.reasoning == "step 1 ... step 2 ..."
 
 
 class TestAskFullOllama:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from vstash.chat import _build_messages, _build_prompt, _is_retryable, _retry_call
+from vstash.chat import _build_messages, _build_prompt, _is_retryable, _retry_call, ask, ask_full
 from vstash.config import VstashConfig
-from vstash.models import SearchResult
+from vstash.models import AskResult, SearchResult
 
 
 def _make_chunk(text: str, title: str = "TestDoc") -> SearchResult:
@@ -147,3 +150,178 @@ class TestRetryLogic:
         with pytest.raises(ConnectionError, match="401"):
             _retry_call(auth_error)
         assert call_count == 1
+
+
+# ------------------------------------------------------------------ #
+# ask_full() / AskResult (#303)                                        #
+# ------------------------------------------------------------------ #
+
+
+def _cerebras_response(content: str, *, reasoning: str | None = None, usage: dict | None = None):
+    """Mimic the shape ``cerebras.cloud.sdk.Cerebras.chat.completions.create``
+    returns: ``response.choices[0].message.{content,reasoning}`` plus
+    ``response.usage``."""
+    msg = SimpleNamespace(content=content)
+    if reasoning is not None:
+        msg.reasoning = reasoning
+    choice = SimpleNamespace(message=msg)
+    usage_obj = SimpleNamespace(**usage) if usage else None
+    return SimpleNamespace(choices=[choice], usage=usage_obj)
+
+
+def _cfg_cerebras(model: str = "gpt-oss-120b") -> VstashConfig:
+    return VstashConfig.model_validate(
+        {
+            "inference": {"backend": "cerebras", "model": model},
+            "cerebras": {"api_key": "test-key"},
+        }
+    )
+
+
+class TestAskFullCerebras:
+    """Cerebras is the priority backend (Merken Phase 2 driver)."""
+
+    def test_populates_reasoning_and_usage_when_present(self) -> None:
+        cfg = _cfg_cerebras("gpt-oss-120b")
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.completions.create.return_value = _cerebras_response(
+            "the answer",
+            reasoning="step 1: ... step 2: ...",
+            usage={"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150},
+        )
+        with patch("cerebras.cloud.sdk.Cerebras", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert isinstance(result, AskResult)
+        assert result.content == "the answer"
+        assert result.reasoning == "step 1: ... step 2: ..."
+        assert result.usage == {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        }
+        assert result.backend == "cerebras"
+        assert result.model == "gpt-oss-120b"
+
+    def test_reasoning_none_when_model_omits_it(self) -> None:
+        """llama3.1-8b on Cerebras has no reasoning channel; result.reasoning
+        must be None, not empty string."""
+        cfg = _cfg_cerebras("llama3.1-8b")
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        # No ``reasoning`` attribute on the mocked message at all.
+        client.chat.completions.create.return_value = _cerebras_response("plain answer")
+        with patch("cerebras.cloud.sdk.Cerebras", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.content == "plain answer"
+        assert result.reasoning is None
+        assert result.backend == "cerebras"
+        assert result.model == "llama3.1-8b"
+
+    def test_empty_string_reasoning_collapses_to_none(self) -> None:
+        """``message.reasoning = ""`` (some SDK versions) must collapse to None,
+        not become a valid empty trace."""
+        cfg = _cfg_cerebras("gpt-oss-120b")
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.completions.create.return_value = _cerebras_response("answer", reasoning="")
+        with patch("cerebras.cloud.sdk.Cerebras", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.reasoning is None
+
+
+class TestAskFullOpenAI:
+    """OpenAI / OpenAI-compat. Reasoning channel is non-standard so the
+    common case is ``reasoning=None``; usage is always populated."""
+
+    def test_no_reasoning_for_vanilla_openai(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "openai"},
+                "openai": {"api_key": "k", "model": "gpt-4o-mini"},
+            }
+        )
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        msg = SimpleNamespace(content="hello")
+        choice = SimpleNamespace(message=msg)
+        usage_obj = SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+        client.chat.completions.create.return_value = SimpleNamespace(
+            choices=[choice], usage=usage_obj
+        )
+        with patch("openai.OpenAI", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.content == "hello"
+        assert result.reasoning is None
+        assert result.usage == {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        }
+        assert result.backend == "openai"
+        assert result.model == "gpt-4o-mini"
+
+
+class TestAskFullOllama:
+    """Ollama exposes thinking content for qwen3 thinking-enabled models."""
+
+    def test_with_thinking_and_eval_counts(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama"},
+                "ollama": {"host": "http://localhost:11434", "model": "qwen3:8b"},
+            }
+        )
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.return_value = {
+            "message": {"content": "answer", "thinking": "trace..."},
+            "prompt_eval_count": 30,
+            "eval_count": 12,
+        }
+        with patch("ollama.Client", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.content == "answer"
+        assert result.reasoning == "trace..."
+        assert result.usage == {
+            "prompt_tokens": 30,
+            "completion_tokens": 12,
+            "total_tokens": 42,
+        }
+        assert result.backend == "ollama"
+        assert result.model == "qwen3:8b"
+
+    def test_without_thinking_returns_none(self) -> None:
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama"},
+                "ollama": {"host": "http://localhost:11434", "model": "llama3:8b"},
+            }
+        )
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.return_value = {
+            "message": {"content": "plain answer"},
+            "prompt_eval_count": 5,
+            "eval_count": 3,
+        }
+        with patch("ollama.Client", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.reasoning is None
+        assert result.content == "plain answer"
+
+
+class TestAskBackwardCompat:
+    """``ask()`` keeps its ``-> str`` contract via ``ask_full().content``."""
+
+    def test_ask_returns_plain_string(self) -> None:
+        cfg = _cfg_cerebras("gpt-oss-120b")
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        client.chat.completions.create.return_value = _cerebras_response(
+            "the answer", reasoning="hidden cot"
+        )
+        with patch("cerebras.cloud.sdk.Cerebras", return_value=client):
+            result = ask("q", chunks, cfg)
+        assert isinstance(result, str)
+        assert result == "the answer"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -167,7 +167,7 @@ class TestRetryLogic:
 
 class TestNormalizeUsage:
     """Lock in the contract for the helper that flattens SDK ``usage``
-    objects into a plain dict."""
+    objects into a complete dict (or None)."""
 
     def test_none_in_none_out(self) -> None:
         assert _normalize_usage(None) is None
@@ -185,9 +185,22 @@ class TestNormalizeUsage:
             "total_tokens": 9,
         }
 
-    def test_partial_keys_kept(self) -> None:
-        """Missing fields are simply dropped, not coerced to 0."""
-        assert _normalize_usage({"prompt_tokens": 7}) == {"prompt_tokens": 7}
+    def test_total_derived_when_missing(self) -> None:
+        """If prompt + completion are present but total is missing, we
+        derive total = prompt + completion locally rather than discarding
+        the partial data."""
+        assert _normalize_usage({"prompt_tokens": 4, "completion_tokens": 5}) == {
+            "prompt_tokens": 4,
+            "completion_tokens": 5,
+            "total_tokens": 9,
+        }
+
+    def test_partial_returns_none_not_partial_dict(self) -> None:
+        """Missing prompt OR completion -> None. We never emit a partial
+        usage dict so consumers don't have to defensively probe each key."""
+        assert _normalize_usage({"prompt_tokens": 7}) is None
+        assert _normalize_usage({"completion_tokens": 7}) is None
+        assert _normalize_usage({"total_tokens": 14}) is None
 
     def test_empty_dict_collapses_to_none(self) -> None:
         """No recognised int fields -> None, so consumers can distinguish

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -310,6 +310,32 @@ class TestAskFullOllama:
         assert result.reasoning is None
         assert result.content == "plain answer"
 
+    def test_object_shaped_response_does_not_crash(self) -> None:
+        """Older / pinned ollama-python versions occasionally return a
+        Pydantic-ish response object instead of a dict. Subscript access
+        used to crash with TypeError; the permissive path must accept it."""
+        cfg = VstashConfig.model_validate(
+            {
+                "inference": {"backend": "ollama"},
+                "ollama": {"host": "http://localhost:11434", "model": "qwen3:8b"},
+            }
+        )
+        chunks = [_make_chunk("ctx")]
+        client = MagicMock()
+        # Object-shaped response: message + counts as attributes, not keys.
+        msg = SimpleNamespace(content="answer", thinking="trace")
+        response_obj = SimpleNamespace(message=msg, prompt_eval_count=4, eval_count=2)
+        client.chat.return_value = response_obj
+        with patch("ollama.Client", return_value=client):
+            result = ask_full("q", chunks, cfg)
+        assert result.content == "answer"
+        assert result.reasoning == "trace"
+        assert result.usage == {
+            "prompt_tokens": 4,
+            "completion_tokens": 2,
+            "total_tokens": 6,
+        }
+
 
 class TestAskBackwardCompat:
     """``ask()`` keeps its ``-> str`` contract via ``ask_full().content``."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -732,13 +732,17 @@ class TestMemoryAsk:
 
     @requires_sqlite_vec
     def test_ask_calls_chat(self, tmp_path: Path) -> None:
-        """ask() retrieves chunks and passes them to chat.ask."""
+        """ask() retrieves chunks and dispatches via chat.ask_full,
+        returning .content (post-#303 thin-wrapper shape)."""
+        from vstash.models import AskResult
+
         doc = tmp_path / "askable.md"
         doc.write_text("Python is a high-level language for general purpose programming.")
 
+        fake = AskResult(content="mocked answer", backend="cerebras", model="m")
         with Memory(db=tmp_path / "test.db") as mem:
             mem.add(doc)
-            with patch("vstash.memory._chat_ask", return_value="mocked answer") as mock:
+            with patch("vstash.memory._chat_ask_full", return_value=fake) as mock:
                 answer = mem.ask("what is python?")
                 assert answer == "mocked answer"
                 mock.assert_called_once()
@@ -749,8 +753,9 @@ class TestMemoryAsk:
 
     @requires_sqlite_vec
     def test_ask_full_routes_through_chat_ask_full(self, tmp_path: Path) -> None:
-        """Memory.ask_full() must dispatch to chat.ask_full (#303), not
-        chat.ask. Same retrieval, different LLM call."""
+        """Memory.ask_full() dispatches to chat.ask_full (#303). Memory.ask
+        is now a thin wrapper around it -- both share retrieval + LLM
+        plumbing so there's no risk of drift."""
         from vstash.models import AskResult
 
         doc = tmp_path / "askable.md"
@@ -765,19 +770,44 @@ class TestMemoryAsk:
         )
         with Memory(db=tmp_path / "test.db") as mem:
             mem.add(doc)
-            with (
-                patch("vstash.memory._chat_ask_full", return_value=fake) as mock_full,
-                patch("vstash.memory._chat_ask") as mock_plain,
-            ):
+            with patch("vstash.memory._chat_ask_full", return_value=fake) as mock_full:
                 result = mem.ask_full("what is python?")
-                # Plain ask must NOT have fired -- this is the whole point.
-                mock_plain.assert_not_called()
                 mock_full.assert_called_once()
                 assert mock_full.call_args[0][0] == "what is python?"
                 assert isinstance(mock_full.call_args[0][1], list)
             assert isinstance(result, AskResult)
             assert result.reasoning == "step 1: think"
             assert result.usage["total_tokens"] == 15
+
+    @requires_sqlite_vec
+    def test_ask_forwards_all_kwargs_to_ask_full(self, tmp_path: Path) -> None:
+        """Memory.ask must forward every retrieval kwarg to ask_full so
+        the thin-wrapper refactor doesn't silently drop a knob."""
+        from vstash.models import AskResult
+
+        doc = tmp_path / "askable.md"
+        doc.write_text("body content for forwarding test")
+
+        fake = AskResult(content="answer", backend="cerebras", model="m")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc)
+            with patch.object(mem, "ask_full", return_value=fake) as spy:
+                mem.ask(
+                    "q",
+                    top_k=7,
+                    layer="L",
+                    history=[{"role": "user", "content": "prev"}],
+                    vec_weight=0.6,
+                    fts_weight=0.4,
+                    retrieval_mode="vec_only",
+                )
+            kwargs = spy.call_args.kwargs
+            assert kwargs["top_k"] == 7
+            assert kwargs["layer"] == "L"
+            assert kwargs["history"] == [{"role": "user", "content": "prev"}]
+            assert kwargs["vec_weight"] == 0.6
+            assert kwargs["fts_weight"] == 0.4
+            assert kwargs["retrieval_mode"] == "vec_only"
 
 
 # ------------------------------------------------------------------ #

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -747,6 +747,38 @@ class TestMemoryAsk:
                 # Second arg is the chunks list
                 assert isinstance(mock.call_args[0][1], list)
 
+    @requires_sqlite_vec
+    def test_ask_full_routes_through_chat_ask_full(self, tmp_path: Path) -> None:
+        """Memory.ask_full() must dispatch to chat.ask_full (#303), not
+        chat.ask. Same retrieval, different LLM call."""
+        from vstash.models import AskResult
+
+        doc = tmp_path / "askable.md"
+        doc.write_text("Python is a high-level language for general purpose programming.")
+
+        fake = AskResult(
+            content="mocked answer",
+            reasoning="step 1: think",
+            usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+            backend="cerebras",
+            model="gpt-oss-120b",
+        )
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc)
+            with (
+                patch("vstash.memory._chat_ask_full", return_value=fake) as mock_full,
+                patch("vstash.memory._chat_ask") as mock_plain,
+            ):
+                result = mem.ask_full("what is python?")
+                # Plain ask must NOT have fired -- this is the whole point.
+                mock_plain.assert_not_called()
+                mock_full.assert_called_once()
+                assert mock_full.call_args[0][0] == "what is python?"
+                assert isinstance(mock_full.call_args[0][1], list)
+            assert isinstance(result, AskResult)
+            assert result.reasoning == "step 1: think"
+            assert result.usage["total_tokens"] == 15
+
 
 # ------------------------------------------------------------------ #
 # SDK DB resolution consistency                                        #

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -3,10 +3,19 @@
 __version__ = "0.35.0"
 
 from .memory import Memory
-from .models import ChunkInfo, DocumentInfo, ExplainInfo, IngestResult, SearchResult, StoreStats
+from .models import (
+    AskResult,
+    ChunkInfo,
+    DocumentInfo,
+    ExplainInfo,
+    IngestResult,
+    SearchResult,
+    StoreStats,
+)
 
 __all__ = [
     "Memory",
+    "AskResult",
     "ChunkInfo",
     "DocumentInfo",
     "ExplainInfo",

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -105,13 +105,12 @@ def _normalize_usage(raw: object) -> dict[str, int] | None:
     """
     if raw is None:
         return None
-    if isinstance(raw, dict):
-        get = raw.get
-    else:
-        get = lambda k, default=None: getattr(raw, k, default)  # noqa: E731
     out: dict[str, int] = {}
     for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
-        value = get(key)
+        if isinstance(raw, dict):
+            value = raw.get(key)
+        else:
+            value = getattr(raw, key, None)
         if isinstance(value, int):
             out[key] = value
     return out or None
@@ -325,12 +324,25 @@ def _ask_ollama(
             messages=messages,
             options={"temperature": 0.2},
         )
-        message = response["message"]
+        # The ollama python client returns dict-shaped responses on
+        # current versions, but older / pinned releases occasionally
+        # return a Pydantic-ish object.  Stay permissive so an SDK bump
+        # doesn't crash the call site.
+        if isinstance(response, dict):
+            message = response.get("message")
+            prompt = response.get("prompt_eval_count")
+            completion = response.get("eval_count")
+        else:
+            message = getattr(response, "message", None)
+            prompt = getattr(response, "prompt_eval_count", None)
+            completion = getattr(response, "eval_count", None)
         # qwen3 thinking-enabled models surface CoT here; absent otherwise.
-        reasoning = message.get("thinking") if isinstance(message, dict) else None
-        # Ollama exposes prompt_eval_count + eval_count on the response root.
-        prompt = response.get("prompt_eval_count") if hasattr(response, "get") else None
-        completion = response.get("eval_count") if hasattr(response, "get") else None
+        if isinstance(message, dict):
+            content = message.get("content") or ""
+            reasoning = message.get("thinking") or None
+        else:
+            content = getattr(message, "content", "") or ""
+            reasoning = getattr(message, "thinking", None) or None
         usage: dict[str, int] | None = None
         if isinstance(prompt, int) or isinstance(completion, int):
             p = prompt if isinstance(prompt, int) else 0
@@ -341,8 +353,8 @@ def _ask_ollama(
                 "total_tokens": p + c,
             }
         return AskResult(
-            content=message["content"] if isinstance(message, dict) else "",
-            reasoning=reasoning or None,
+            content=content,
+            reasoning=reasoning,
             usage=usage,
             backend="ollama",
             model=model,

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -18,7 +18,7 @@ from collections.abc import Callable, Generator
 from typing import ParamSpec, TypeVar
 
 from .config import VstashConfig
-from .models import SearchResult
+from .models import AskResult, SearchResult
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -96,6 +96,27 @@ Rules:
 - For code questions, provide working code examples from the context."""
 
 
+def _normalize_usage(raw: object) -> dict[str, int] | None:
+    """Coerce an SDK ``usage`` object into ``{prompt, completion, total}_tokens``.
+
+    Cerebras / OpenAI return a Pydantic-ish object; some compat servers
+    return a plain dict; older SDKs may omit it entirely. We accept any
+    of those shapes and keep only int fields we recognise.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        get = raw.get
+    else:
+        get = lambda k, default=None: getattr(raw, k, default)  # noqa: E731
+    out: dict[str, int] = {}
+    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+        value = get(key)
+        if isinstance(value, int):
+            out[key] = value
+    return out or None
+
+
 def _build_prompt(query: str, chunks: list[SearchResult]) -> str:
     """Build user prompt from query and retrieved context chunks.
 
@@ -154,7 +175,7 @@ def _ask_cerebras(
     chunks: list[SearchResult],
     cfg: VstashConfig,
     history: list[dict[str, str]] | None = None,
-) -> str:
+) -> AskResult:
     """Send query to Cerebras API and return the response.
 
     Args:
@@ -164,7 +185,7 @@ def _ask_cerebras(
         history: Prior conversation turns.
 
     Returns:
-        Model response text.
+        AskResult with content + (when present) reasoning + usage.
 
     Raises:
         ValueError: If API key is missing.
@@ -187,15 +208,25 @@ def _ask_cerebras(
 
     client = Cerebras(api_key=api_key)
     messages = _build_messages(query, chunks, history)
+    model = cfg.inference.model
 
     try:
         response = client.chat.completions.create(
-            model=cfg.inference.model,
+            model=model,
             messages=messages,
             max_tokens=2048,
             temperature=0.2,
         )
-        return response.choices[0].message.content  # type: ignore[return-value]
+        message = response.choices[0].message
+        # gpt-oss-* surfaces hidden CoT here; older models / SDKs omit it.
+        reasoning = getattr(message, "reasoning", None) or None
+        return AskResult(
+            content=message.content or "",
+            reasoning=reasoning,
+            usage=_normalize_usage(getattr(response, "usage", None)),
+            backend="cerebras",
+            model=model,
+        )
     except Exception as exc:
         raise ConnectionError(f"Cerebras API error: {exc}") from exc
 
@@ -261,7 +292,7 @@ def _ask_ollama(
     chunks: list[SearchResult],
     cfg: VstashConfig,
     history: list[dict[str, str]] | None = None,
-) -> str:
+) -> AskResult:
     """Send query to Ollama local server and return the response.
 
     Args:
@@ -271,7 +302,7 @@ def _ask_ollama(
         history: Prior conversation turns.
 
     Returns:
-        Model response text.
+        AskResult with content + (qwen3 thinking-mode) reasoning + usage.
 
     Raises:
         ConnectionError: If Ollama server is unreachable.
@@ -286,14 +317,36 @@ def _ask_ollama(
 
     client = ollama.Client(host=cfg.ollama.host)
     messages = _build_messages(query, chunks, history)
+    model = cfg.ollama.model
 
     try:
         response = client.chat(
-            model=cfg.ollama.model,
+            model=model,
             messages=messages,
             options={"temperature": 0.2},
         )
-        return response["message"]["content"]  # type: ignore[index]
+        message = response["message"]
+        # qwen3 thinking-enabled models surface CoT here; absent otherwise.
+        reasoning = message.get("thinking") if isinstance(message, dict) else None
+        # Ollama exposes prompt_eval_count + eval_count on the response root.
+        prompt = response.get("prompt_eval_count") if hasattr(response, "get") else None
+        completion = response.get("eval_count") if hasattr(response, "get") else None
+        usage: dict[str, int] | None = None
+        if isinstance(prompt, int) or isinstance(completion, int):
+            p = prompt if isinstance(prompt, int) else 0
+            c = completion if isinstance(completion, int) else 0
+            usage = {
+                "prompt_tokens": p,
+                "completion_tokens": c,
+                "total_tokens": p + c,
+            }
+        return AskResult(
+            content=message["content"] if isinstance(message, dict) else "",
+            reasoning=reasoning or None,
+            usage=usage,
+            backend="ollama",
+            model=model,
+        )
     except Exception as exc:
         raise ConnectionError(f"Ollama error: {exc}") from exc
 
@@ -353,7 +406,7 @@ def _ask_openai(
     chunks: list[SearchResult],
     cfg: VstashConfig,
     history: list[dict[str, str]] | None = None,
-) -> str:
+) -> AskResult:
     """Send query to OpenAI API (or compatible endpoint) and return the response.
 
     Args:
@@ -363,7 +416,9 @@ def _ask_openai(
         history: Prior conversation turns.
 
     Returns:
-        Model response text.
+        AskResult. ``reasoning`` is populated only when the underlying
+        endpoint surfaces a non-standard reasoning channel (some
+        OpenAI-compatible servers do; vanilla GPT-4 does not).
 
     Raises:
         ValueError: If API key is missing.
@@ -396,7 +451,15 @@ def _ask_openai(
             temperature=0.2,
             extra_body=cfg.openai.extra_body,
         )
-        return response.choices[0].message.content or ""
+        message = response.choices[0].message
+        reasoning = getattr(message, "reasoning", None) or None
+        return AskResult(
+            content=message.content or "",
+            reasoning=reasoning,
+            usage=_normalize_usage(getattr(response, "usage", None)),
+            backend="openai",
+            model=model,
+        )
     except Exception as exc:
         raise ConnectionError(f"OpenAI API error: {exc}") from exc
 
@@ -575,13 +638,18 @@ def _resolve_local_config(cfg: VstashConfig) -> VstashConfig:
         )
 
 
-def ask(
+def ask_full(
     query: str,
     chunks: list[SearchResult],
     cfg: VstashConfig,
     history: list[dict[str, str]] | None = None,
-) -> str:
-    """Send query + context chunks to the configured inference backend.
+) -> AskResult:
+    """Like :func:`ask`, but returns the full normalized result.
+
+    Surfaces the reasoning channel and token usage that ``ask()`` drops.
+    Driven by Merken Phase 2 distillation (see issue #303); generally
+    useful for trace-aware logging or evaluation. ``ask()`` is now a
+    thin wrapper that returns ``ask_full(...).content``.
 
     Args:
         query: The user's question.
@@ -590,7 +658,8 @@ def ask(
         history: Prior conversation turns for multi-turn chat.
 
     Returns:
-        Model response text.
+        AskResult with content + (when surfaced) reasoning + usage +
+        resolved backend / model.
 
     Raises:
         ValueError: If the configured backend is unknown.
@@ -610,6 +679,30 @@ def ask(
 
     ask_fn, _ = backend_funcs
     return _retry_call(ask_fn, query, chunks, cfg, history)
+
+
+def ask(
+    query: str,
+    chunks: list[SearchResult],
+    cfg: VstashConfig,
+    history: list[dict[str, str]] | None = None,
+) -> str:
+    """Send query + context chunks to the configured inference backend.
+
+    Args:
+        query: The user's question.
+        chunks: Retrieved context chunks.
+        cfg: Vex configuration.
+        history: Prior conversation turns for multi-turn chat.
+
+    Returns:
+        Model response text. Use :func:`ask_full` if you also need the
+        reasoning trace and usage counts.
+
+    Raises:
+        ValueError: If the configured backend is unknown.
+    """
+    return ask_full(query, chunks, cfg, history).content
 
 
 def stream(

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -96,6 +96,20 @@ Rules:
 - For code questions, provide working code examples from the context."""
 
 
+def _extract_reasoning(message: object) -> str | None:
+    """Pull the reasoning trace from a chat-completions ``message`` object.
+
+    Different OpenAI-compatible servers expose it under different field
+    names: Cerebras and the original anthropic-flavoured proposals use
+    ``message.reasoning``; vLLM, DeepSeek, Together, xAI Grok and OpenAI
+    o1/o3 Chat Completions all use ``message.reasoning_content``.  We
+    accept either and collapse empty strings to ``None`` so a present-
+    but-empty channel doesn't masquerade as a real trace.
+    """
+    candidate = getattr(message, "reasoning", None) or getattr(message, "reasoning_content", None)
+    return candidate or None
+
+
 def _normalize_usage(raw: object) -> dict[str, int] | None:
     """Coerce an SDK ``usage`` object into ``{prompt, completion, total}_tokens``.
 
@@ -217,11 +231,12 @@ def _ask_cerebras(
             temperature=0.2,
         )
         message = response.choices[0].message
-        # gpt-oss-* surfaces hidden CoT here; older models / SDKs omit it.
-        reasoning = getattr(message, "reasoning", None) or None
+        # gpt-oss-* surfaces hidden CoT under ``reasoning``; future
+        # Cerebras builds may follow the broader ``reasoning_content``
+        # convention -- accept either.
         return AskResult(
             content=message.content or "",
-            reasoning=reasoning,
+            reasoning=_extract_reasoning(message),
             usage=_normalize_usage(getattr(response, "usage", None)),
             backend="cerebras",
             model=model,
@@ -464,10 +479,12 @@ def _ask_openai(
             extra_body=cfg.openai.extra_body,
         )
         message = response.choices[0].message
-        reasoning = getattr(message, "reasoning", None) or None
+        # OpenAI o1/o3 Chat Completions, vLLM, DeepSeek, Together, and
+        # xAI Grok all surface reasoning under ``reasoning_content``;
+        # accept ``reasoning`` too for older / Cerebras-aligned servers.
         return AskResult(
             content=message.content or "",
-            reasoning=reasoning,
+            reasoning=_extract_reasoning(message),
             usage=_normalize_usage(getattr(response, "usage", None)),
             backend="openai",
             model=model,

--- a/vstash/chat.py
+++ b/vstash/chat.py
@@ -111,23 +111,40 @@ def _extract_reasoning(message: object) -> str | None:
 
 
 def _normalize_usage(raw: object) -> dict[str, int] | None:
-    """Coerce an SDK ``usage`` object into ``{prompt, completion, total}_tokens``.
+    """Coerce an SDK ``usage`` object into a complete ``{prompt,
+    completion, total}_tokens`` triple, or ``None`` if we can't.
 
     Cerebras / OpenAI return a Pydantic-ish object; some compat servers
-    return a plain dict; older SDKs may omit it entirely. We accept any
-    of those shapes and keep only int fields we recognise.
+    return a plain dict; older SDKs may omit ``usage`` entirely or skip
+    individual fields.  We refuse to return a partial dict so consumers
+    don't have to defensively probe each key; ``None`` always means
+    "no usage telemetry available".
+
+    If ``prompt_tokens`` and ``completion_tokens`` are both present but
+    ``total_tokens`` is missing, we derive the total locally rather
+    than discarding the data.
     """
     if raw is None:
         return None
-    out: dict[str, int] = {}
-    for key in ("prompt_tokens", "completion_tokens", "total_tokens"):
+
+    def _read(key: str) -> object:
         if isinstance(raw, dict):
-            value = raw.get(key)
-        else:
-            value = getattr(raw, key, None)
-        if isinstance(value, int):
-            out[key] = value
-    return out or None
+            return raw.get(key)
+        return getattr(raw, key, None)
+
+    prompt = _read("prompt_tokens")
+    completion = _read("completion_tokens")
+    total = _read("total_tokens")
+
+    if not (isinstance(prompt, int) and isinstance(completion, int)):
+        return None
+    if not isinstance(total, int):
+        total = prompt + completion
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    }
 
 
 def _build_prompt(query: str, chunks: list[SearchResult]) -> str:

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -19,7 +19,6 @@ from types import TracebackType
 from typing import Literal
 
 from ._store_open import open_store_for_config
-from .chat import ask as _chat_ask
 from .chat import ask_full as _chat_ask_full
 from .config import VstashConfig, load_config
 from .embed import embed_query
@@ -516,17 +515,17 @@ class Memory:
             ValueError: If no inference backend is configured.
             ConnectionError: If the inference API fails.
         """
-        chunks = self.search(
+        return self.ask_full(
             query,
             top_k=top_k,
             collection=collection,
             project=project,
             layer=layer,
+            history=history,
             vec_weight=vec_weight,
             fts_weight=fts_weight,
             retrieval_mode=retrieval_mode,
-        )
-        return _chat_ask(query, chunks, self._cfg, history)
+        ).content
 
     def ask_full(
         self,

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -20,10 +20,12 @@ from typing import Literal
 
 from ._store_open import open_store_for_config
 from .chat import ask as _chat_ask
+from .chat import ask_full as _chat_ask_full
 from .config import VstashConfig, load_config
 from .embed import embed_query
 from .ingest import ingest
 from .models import (
+    AskResult,
     ChunkInfo,
     DocumentInfo,
     IngestResult,
@@ -525,6 +527,50 @@ class Memory:
             retrieval_mode=retrieval_mode,
         )
         return _chat_ask(query, chunks, self._cfg, history)
+
+    def ask_full(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        collection: object = _UNSET,
+        project: object = _UNSET,
+        layer: str | None = None,
+        history: list[dict[str, str]] | None = None,
+        vec_weight: float | None = None,
+        fts_weight: float | None = None,
+        retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
+    ) -> AskResult:
+        """Like :meth:`ask`, but returns content + reasoning + usage.
+
+        Same retrieval and prompt construction as :meth:`ask`; the only
+        difference is that the LLM call goes through
+        :func:`vstash.chat.ask_full` so the reasoning channel and token
+        counts are preserved (issue #303). Drives Merken Phase 2
+        distillation (``Q -> reasoning_trace -> A`` shape).
+
+        Args:
+            See :meth:`ask` -- arguments are identical.
+
+        Returns:
+            AskResult. ``reasoning`` is populated when the backend
+            surfaces it (Cerebras gpt-oss-*, Ollama qwen3 thinking).
+
+        Raises:
+            ValueError: If no inference backend is configured.
+            ConnectionError: If the inference API fails.
+        """
+        chunks = self.search(
+            query,
+            top_k=top_k,
+            collection=collection,
+            project=project,
+            layer=layer,
+            vec_weight=vec_weight,
+            fts_weight=fts_weight,
+            retrieval_mode=retrieval_mode,
+        )
+        return _chat_ask_full(query, chunks, self._cfg, history)
 
     def remove(self, source: str | Path) -> bool:
         """Remove a document from memory.

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -264,3 +264,39 @@ class MissAnalysis(BaseModel):
         default_factory=list,
         description="Actionable, rule-based suggestions to improve the query",
     )
+
+
+class AskResult(BaseModel):
+    """Normalized result from a chat backend, returned by ``chat.ask_full()``.
+
+    Surfaces the reasoning channel and token usage that ``ask()`` discards.
+    Driven by Merken Phase 2 distillation (gpt-oss-120b -> 7-8B local
+    student in ``Q -> reasoning_trace -> A`` shape) but generally useful
+    for trace-aware logging or evaluation.
+
+    Field semantics:
+      - ``content``: model response text (what ``ask()`` returns).
+      - ``reasoning``: hidden CoT when the backend exposes it (Cerebras
+        ``message.reasoning`` for gpt-oss-*; Ollama ``message.thinking``
+        for qwen3 thinking-mode). ``None`` when absent.
+      - ``usage``: ``{prompt_tokens, completion_tokens, total_tokens}``
+        when the SDK surfaces it. ``None`` otherwise.
+      - ``backend``: resolved concrete backend (``cerebras`` / ``ollama``
+        / ``openai``) post local-resolve.
+      - ``model``: resolved model name actually called.
+    """
+
+    content: str = Field(description="Model response text")
+    reasoning: str | None = Field(
+        default=None,
+        description="Hidden chain-of-thought when the backend surfaces it",
+    )
+    usage: dict[str, int] | None = Field(
+        default=None,
+        description="Token counts (prompt_tokens, completion_tokens, total_tokens)",
+    )
+    backend: str | None = Field(
+        default=None,
+        description="Resolved backend ('cerebras' | 'ollama' | 'openai')",
+    )
+    model: str | None = Field(default=None, description="Resolved model name")


### PR DESCRIPTION
## Summary
- New `AskResult` Pydantic model surfaces the reasoning channel + token usage that `ask()` discards. Exported from `vstash` top level.
- Cerebras `gpt-oss-120b` populates `message.reasoning` with its hidden CoT; Ollama qwen3 thinking-mode uses `message.thinking`; OpenAI vanilla GPT-4 returns `None`. All three handled via permissive `getattr` / `.get()` so older SDKs do not crash.
- `_ask_cerebras` / `_ask_ollama` / `_ask_openai` now return `AskResult` internally. `ask()` is a thin wrapper returning `.content` -- existing string contract preserved.
- `Memory.ask_full()` passthrough mirrors `Memory.ask()` so SDK callers get the reasoning trace without rewiring retrieval.

## Why
Merken Phase 2 distillation (gpt-oss-120b -> 7-8B local student in `Q -> reasoning_trace -> A` shape) needs the reasoning channel. Bypassing this in Merken would mean duplicating `_build_prompt` / `SYSTEM_PROMPT`, and silent drift the moment vstash's prompt template changed.

## Acceptance criteria from #303
- [x] `from vstash import AskResult` works.
- [x] `ask_full()` populated for cerebras / openai / ollama.
- [x] Cerebras gpt-oss-* populates `result.reasoning`.
- [x] Cerebras llama-3.1-8b returns `result.reasoning is None` (no reasoning channel).
- [x] `ask()` retains `-> str`. Zero-call-site change for existing callers.
- [x] One unit test per backend with mocked client, plus reasoning-absent regressions.
- [x] `usage` populated for cerebras (and best-effort for openai / ollama).

## Test plan
- [x] `pytest tests/` (1120 passed, 6 deselected, 94s)
- [x] `ruff check` + `ruff format --check` clean
- [x] New `TestAskFullCerebras` (3 cases), `TestAskFullOpenAI`, `TestAskFullOllama` (2 cases), `TestAskBackwardCompat`
- [x] New `Memory.test_ask_full_routes_through_chat_ask_full`

Closes #303.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat API now returns structured responses: text content plus optional hidden reasoning, token usage, and resolved backend/model.
  * Memory retrieval can surface reasoning and usage alongside results.
  * Existing simple text-only chat API preserved for backward compatibility.

* **Tests**
  * Added comprehensive tests validating structured responses, reasoning handling, token usage normalization, and memory integration across backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->