### PR TITLE
chore(license): add LICENSE file + adopt SPDX expression (PEP 639)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jayson Steffens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.18"]
 build-backend = "hatchling.build"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,13 @@ name = "vstash"
 dynamic = ["version"]
 description = "Local document memory with instant semantic search. Drop any file. Ask anything. Get an answer in under a second."
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 keywords = ["embeddings", "semantic-search", "rag", "local", "cerebras", "sqlite-vec", "fastembed", "vector-stash"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

- Add `LICENSE` file (MIT) at repo root. The project declared MIT in `pyproject.toml` but the file did not exist, so the license was unenforceable as written and PyPI's License-File reference was broken.
- Adopt PEP 639 form: `license = \"MIT\"` (SPDX expression) + `license-files = [\"LICENSE\"]`, replacing the deprecated `license = { text = \"MIT\" }` form.
- Drop now-deprecated `\"License :: OSI Approved :: MIT License\"` classifier (PEP 639 supersedes it).

## Verification

Built sdist locally; `PKG-INFO` now contains:

```
License-Expression: MIT
License-File: LICENSE
```

Hatchling >= 1.18 handles PEP 639 natively, so no build-system bump is required.

## Test plan

- [ ] CI green (lint + tests)
- [ ] sdist build inspects clean (no extra warnings about deprecated license form)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an MIT license to the project.
  * Updated project packaging metadata to declare the license and adjust build settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->