### PR TITLE
chore(gitignore): ignore macOS iCloud sync collision artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ paper/arxiv/*.blg
 
 # Claude scheduled-task lock
 .claude/scheduled_tasks.lock
+
+# macOS iCloud sync collision artefacts (e.g. "foo 2.py", "foo 2.json").
+# These are auto-generated when iCloud cannot reconcile the same file
+# across devices and never represent real work — the un-suffixed file
+# is canonical.
+* 2.*
+* 2
+* [0-9].*

--- a/.gitignore
+++ b/.gitignore
@@ -67,10 +67,13 @@ paper/arxiv/*.blg
 # Claude scheduled-task lock
 .claude/scheduled_tasks.lock
 
-# macOS iCloud sync collision artefacts (e.g. "foo 2.py", "foo 2.json").
+# macOS iCloud sync collision artefacts (e.g. "foo 2.py", "foo 3.json").
 # These are auto-generated when iCloud cannot reconcile the same file
-# across devices and never represent real work — the un-suffixed file
-# is canonical.
-* 2.*
-* 2
-* [0-9].*
+# across devices and never represent real work; the un-suffixed file
+# is canonical. iCloud starts numbering at 2, so "* 1.*" / "* 0.*"
+# are NOT collision markers and stay tracked (e.g. "Figure 1.png",
+# "version 0.json"). Multi-digit covers the rare 10+ collision case.
+* [2-9].*
+* [2-9]
+* [0-9][0-9].*
+* [0-9][0-9]


### PR DESCRIPTION
## Summary

iCloud Drive auto-creates \`\"<name> 2.<ext>\"\` duplicates whenever it cannot reconcile a file across devices. Over the last few weeks 27+ such entries accumulated in \`git status\` -- the audit caught them as pure noise (the un-suffixed file is always canonical, and none were tracked in git).

- Add 3 \`.gitignore\` patterns under a comment explaining the source: \`* 2.*\`, \`* 2\`, \`* [0-9].*\` (future-proofs against \`* 3.*\` if a third device ever collides).
- Delete the 33 pre-existing collision files from the working tree (20 in \`experiments/\`, 13 stale \`.pyc\` in \`tests/__pycache__/\`). Each had a verified un-suffixed counterpart still in place; nothing was tracked.

## Verification

\`\`\`
\$ find . -name '* 2.*' -not -path './.git/*' -not -path './.venv/*' | wc -l
0
\$ git status --short | grep -c ' 2\\.'
0
\`\`\`

## Test plan

- [ ] CI green
- [ ] \`git status\` on a fresh clone stays clean of iCloud noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules to prevent macOS iCloud sync collision artifacts (numeric-suffixed duplicates) from being committed, keeping the repository cleaner.
  * No other repository or code changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->