### PR TITLE
docs(claude): reconcile Publishing section with publish.yml reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,19 +167,24 @@ publication; do not run `twine` manually. End-to-end flow:
 ```bash
 # 1. Bump __version__ on develop (chore/0.X-housekeeping PR usually
 #    bundles version bump + README highlights + CLAUDE.md updates).
-# 2. Create release PR: develop -> main, merge with --merge (not
-#    squash) so individual feature commits stay visible in main's log.
-# 3. From main, publish a GitHub release. This triggers publish.yml,
+# 2. Create release PR develop -> main and merge with --merge (not
+#    squash) so individual feature commits stay visible in main's log:
+gh pr create --base main --head develop --title "release: v<version>"
+gh pr merge --merge
+# 3. From main, publish a GitHub release. --generate-notes auto-fills
+#    the body from merged PR titles. This triggers publish.yml,
 #    which runs `python -m build` and uploads to PyPI via OIDC:
 gh release create v<version> --target main \
-    --title "v<version>" --notes "..."
-# 4. Open a sync PR `sync/main-to-develop-v<version>` to mirror main
-#    back into develop. Merge with --admin if branch protection is
-#    sticky from old commits.
+    --title "v<version>" --generate-notes
+# 4. Sync main back to develop. --admin lets the merge bypass sticky
+#    branch protections that the release commit may carry forward:
+gh pr create --base develop --head main \
+    --title "sync: main to develop v<version>"
+gh pr merge --merge --admin
 ```
 
 The `pypi` environment in `publish.yml` is wired to a PyPI trusted
 publisher; no API tokens are stored in the repo. If you ever need to
 fall back to a manual upload, install `build` + `twine` locally and
-read the password from `~/.pypirc`, but this should be a break-glass
-path.
+ensure credentials are configured in `~/.pypirc`, but this should be
+a break-glass path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,11 +160,26 @@ GitHub Actions: `lint` (ruff check + format) + `test` (pytest on Python 3.10, 3.
 
 ## Publishing
 
+PyPI publication is automated via OIDC trusted publisher in
+`.github/workflows/publish.yml`. The workflow runs on release
+publication; do not run `twine` manually. End-to-end flow:
+
 ```bash
-# 1. Bump version on develop
-# 2. Create PR: develop → main
-# 3. Merge PR, then from main:
-python -m build
-python -m twine upload dist/vstash-<version>*
-gh release create v<version> --title "v<version>" --notes "..."
+# 1. Bump __version__ on develop (chore/0.X-housekeeping PR usually
+#    bundles version bump + README highlights + CLAUDE.md updates).
+# 2. Create release PR: develop -> main, merge with --merge (not
+#    squash) so individual feature commits stay visible in main's log.
+# 3. From main, publish a GitHub release. This triggers publish.yml,
+#    which runs `python -m build` and uploads to PyPI via OIDC:
+gh release create v<version> --target main \
+    --title "v<version>" --notes "..."
+# 4. Open a sync PR `sync/main-to-develop-v<version>` to mirror main
+#    back into develop. Merge with --admin if branch protection is
+#    sticky from old commits.
 ```
+
+The `pypi` environment in `publish.yml` is wired to a PyPI trusted
+publisher; no API tokens are stored in the repo. If you ever need to
+fall back to a manual upload, install `build` + `twine` locally and
+read the password from `~/.pypirc`, but this should be a break-glass
+path.


### PR DESCRIPTION
## Summary

\`CLAUDE.md\` still instructed \`python -m build && twine upload\` manually for releases, but \`.github/workflows/publish.yml\` already uses the PyPI OIDC trusted publisher and runs build + upload automatically on \`release: published\`. Manual \`twine\` invocation against a trusted-publisher project at best no-ops, at worst fails noisily.

## Changes

- Rewrite the \"Publishing\" section to describe the actual end-to-end flow:
  1. Housekeeping PR bumps \`__version__\` on \`develop\`.
  2. Release PR \`develop -> main\` with \`--merge\` (not squash).
  3. \`gh release create --target main\` triggers \`publish.yml\` -> OIDC upload.
  4. Sync PR \`sync/main-to-develop-v<v>\` mirrors main back to develop.
- Document the \`pypi\` environment / OIDC wiring so the next maintainer knows where the auth lives.
- Keep \`twine\` as an explicit break-glass path rather than the default.

No code changes; doc only.

## Test plan

- [ ] CI green
- [ ] Diff renders cleanly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated publishing documentation to reflect the new OIDC trusted-publisher-based PyPI release automation workflow with GitHub Actions integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->