### PR TITLE
ci(coverage): add coverage gate + Codecov upload + badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[all,dev]"
-      - run: pytest --tb=short -q
+      - name: Run tests with coverage
+        run: pytest --tb=short -q --cov=vstash --cov-report=xml --cov-report=term
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![PyPI](https://img.shields.io/pypi/v/vstash)](https://pypi.org/project/vstash/)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![python](https://img.shields.io/badge/python-3.10+-blue)]()
-[![CI](https://github.com/stffns/vstash/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/stffns/vstash/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/stffns/vstash/branch/develop/graph/badge.svg)](https://codecov.io/gh/stffns/vstash)
+[![CI](https://github.com/stffns/vstash/actions/workflows/ci.yml/badge.svg)](https://github.com/stffns/vstash/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/stffns/vstash/graph/badge.svg)](https://codecov.io/gh/stffns/vstash)
 
 **Local document memory with hybrid retrieval.** Single SQLite file. Zero cloud dependencies for search. Beats ColBERTv2 on **5/5 [BEIR](https://github.com/beir-cellar/beir) datasets** with the tuned [`bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) model. Under 60 ms p50 at 50K chunks on an Apple Silicon laptop.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![PyPI](https://img.shields.io/pypi/v/vstash)](https://pypi.org/project/vstash/)
 [![license](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![python](https://img.shields.io/badge/python-3.10+-blue)]()
-[![tests](https://img.shields.io/badge/tests-900+_passing-brightgreen)]()
+[![CI](https://github.com/stffns/vstash/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/stffns/vstash/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/stffns/vstash/branch/develop/graph/badge.svg)](https://codecov.io/gh/stffns/vstash)
 
 **Local document memory with hybrid retrieval.** Single SQLite file. Zero cloud dependencies for search. Beats ColBERTv2 on **5/5 [BEIR](https://github.com/beir-cellar/beir) datasets** with the tuned [`bge-small-rrf-v3`](https://huggingface.co/Stffens/bge-small-rrf-v3) model. Under 60 ms p50 at 50K chunks on an Apple Silicon laptop.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,3 +123,35 @@ filterwarnings = [
     "ignore:builtin type SwigPyObject has no __module__ attribute:DeprecationWarning",
     "ignore:builtin type swigvarlink has no __module__ attribute:DeprecationWarning",
 ]
+
+[tool.coverage.run]
+source = ["vstash"]
+branch = true
+parallel = true
+# Skip the auto-generated CLI entry shim and the optional sub-backends
+# whose code paths are exercised by integration tests gated off the
+# default CI run (snapvec backends require the `snapvec` package and
+# fitted index files; treesitter requires the language pack).
+omit = [
+    "vstash/__main__.py",
+    "vstash/_ivfpq_backend.py",
+]
+
+[tool.coverage.report]
+# 75% is the floor we land on; raise toward 85% as the test suite
+# fills in (audit highlighted thin coverage on cli.py / web.py / embed.py).
+fail_under = 75
+show_missing = true
+skip_covered = false
+precision = 1
+exclude_also = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+    "@overload",
+    "\\.\\.\\.",
+]
+
+[tool.coverage.html]
+directory = "htmlcov"


### PR DESCRIPTION
## Summary

Audit flagged \`900+ tests\` was a meaningless metric without a coverage gate. \`pytest-cov\` was already in \`[dev]\` extras but never wired into CI. Heavy concentration in \`test_store.py\` / \`test_retrain*.py\` / \`test_mcp.py\` masked thin coverage on \`cli.py\` (2882 LOC, 466 LOC tests), \`embed.py\` (977 LOC, 92 LOC tests), and \`web.py\` (876 LOC, 658 LOC mostly upload-focused).

## Changes

- \`pyproject.toml\` -- new \`[tool.coverage.{run,report,html}]\` config:
  - \`source=[\"vstash\"]\`, \`branch=true\`, \`parallel=true\` (matrix-safe).
  - \`omit\` skips \`__main__.py\` and \`_ivfpq_backend.py\` whose paths are gated off the default CI run.
  - \`fail_under=75\` -- realistic starting floor. Bump toward 85% as CLI / web / embed coverage fills in.
- \`.github/workflows/ci.yml\` -- \`pytest --cov=vstash --cov-report=xml --cov-report=term\`, upload to Codecov via \`codecov-action@v4\` on the 3.12 leg only (avoid double-counting). \`fail_ci_if_error=false\` so Codecov outages do not block merges.
- \`README.md\` -- replace the hand-curated \`tests-900+_passing\` badge with the live GitHub Actions CI status badge (develop branch) + Codecov coverage badge.

## Setup needed (one-time)

Repo settings:
1. Sign in to Codecov with the \`stffns/vstash\` repo and either:
   - Enable tokenless OIDC for public repos (recommended), or
   - Add \`CODECOV_TOKEN\` as an Actions secret (private mode).
2. The action reads \`secrets.CODECOV_TOKEN\` if present; tokenless mode works without it.

## Test plan

- [ ] CI run on this PR shows the new \`--cov\` output and uploads coverage.
- [ ] Codecov page populates and the badge resolves.
- [ ] First-time \`fail_under=75\` either passes or gives us a baseline number to lower / raise.