### PR TITLE
refactor(errors): introduce VstashError ancestor + centralise hierarchy

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,134 @@
+"""Tests for the unified vstash exception hierarchy (vstash.errors).
+
+The hierarchy was introduced in v0.37 and centralises errors that
+were previously defined in vstash.validation (LimitError tree) and
+vstash.store (SchemaVersionError) under a common VstashError ancestor.
+These tests pin the contract:
+
+- VstashError is an Exception (not a ValueError).
+- LimitError multi-inherits from VstashError + ValueError.
+- SchemaVersionError multi-inherits from VstashError + RuntimeError.
+- BackendError is a direct VstashError subclass.
+- Backwards-compat re-exports keep working: vstash.validation.LimitError
+  is the same class as vstash.errors.LimitError, and vstash.store
+  re-exports SchemaVersionError identically.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vstash import (
+    BackendError,
+    LimitError,
+    SchemaVersionError,
+    VstashError,
+)
+from vstash.errors import (
+    ChunkTooLargeError,
+    EmbeddingMismatchError,
+    PathTooLongError,
+    QueryInvalidError,
+    QueryTooLongError,
+    TopKOutOfRangeError,
+)
+
+
+class TestAncestry:
+    """The class hierarchy is the user-visible contract."""
+
+    def test_vstash_error_is_exception(self) -> None:
+        assert issubclass(VstashError, Exception)
+        # Must NOT be a ValueError or RuntimeError so consumers can
+        # distinguish "vstash failure" from "input bad" / "runtime bad".
+        assert not issubclass(VstashError, ValueError)
+        assert not issubclass(VstashError, RuntimeError)
+
+    def test_limit_error_multi_inherits(self) -> None:
+        assert issubclass(LimitError, VstashError)
+        assert issubclass(LimitError, ValueError)
+
+    def test_schema_version_error_multi_inherits(self) -> None:
+        assert issubclass(SchemaVersionError, VstashError)
+        assert issubclass(SchemaVersionError, RuntimeError)
+
+    def test_backend_error_is_vstash_error_only(self) -> None:
+        assert issubclass(BackendError, VstashError)
+        # No stdlib parallel ancestor; backend failures are vstash-only.
+        assert not issubclass(BackendError, ValueError)
+        assert not issubclass(BackendError, RuntimeError)
+
+    @pytest.mark.parametrize(
+        "subclass",
+        [
+            QueryInvalidError,
+            QueryTooLongError,
+            TopKOutOfRangeError,
+            PathTooLongError,
+            ChunkTooLargeError,
+            EmbeddingMismatchError,
+        ],
+    )
+    def test_validation_subclasses_inherit_chain(self, subclass: type) -> None:
+        # Every LimitError subclass must reach VstashError AND ValueError
+        # transitively. This is what makes ``except VstashError`` and
+        # ``except ValueError`` both correct catch clauses for any
+        # validation failure.
+        assert issubclass(subclass, LimitError)
+        assert issubclass(subclass, VstashError)
+        assert issubclass(subclass, ValueError)
+
+
+class TestBackwardsCompat:
+    """Existing imports must keep resolving to the same class objects."""
+
+    def test_validation_reexports_limit_error(self) -> None:
+        from vstash.validation import LimitError as VLE
+
+        assert VLE is LimitError
+
+    def test_validation_reexports_subclass(self) -> None:
+        from vstash.validation import QueryTooLongError as VQTL
+
+        assert VQTL is QueryTooLongError
+
+    def test_store_reexports_schema_version_error(self) -> None:
+        from vstash.store import SchemaVersionError as SVE
+
+        assert SVE is SchemaVersionError
+
+    def test_value_error_catches_limit_error(self) -> None:
+        # Pre-v0.37 user code does ``except ValueError`` around store
+        # ops. That must keep working.
+        with pytest.raises(ValueError):
+            raise QueryTooLongError("test")
+
+    def test_runtime_error_catches_schema_version_error(self) -> None:
+        with pytest.raises(RuntimeError):
+            raise SchemaVersionError("test")
+
+
+class TestVstashErrorCatchAll:
+    """The headline value of v0.37: one ``except`` for any vstash failure."""
+
+    def test_catches_limit_error(self) -> None:
+        with pytest.raises(VstashError):
+            raise QueryTooLongError("query too long")
+
+    def test_catches_schema_version_error(self) -> None:
+        with pytest.raises(VstashError):
+            raise SchemaVersionError("unknown schema version")
+
+    def test_catches_backend_error(self) -> None:
+        with pytest.raises(VstashError):
+            raise BackendError("snapvec fit failed")
+
+    def test_does_not_catch_unrelated_exceptions(self) -> None:
+        # ``except VstashError`` must not swallow stdlib exceptions
+        # raised from third-party code (e.g. sqlite3.OperationalError,
+        # FileNotFoundError, KeyError) -- those should bubble up.
+        with pytest.raises(KeyError):
+            try:
+                raise KeyError("missing")
+            except VstashError:
+                pytest.fail("VstashError caught a KeyError -- ancestry leak")

--- a/vstash/__init__.py
+++ b/vstash/__init__.py
@@ -1,7 +1,13 @@
-"""vstash — local document memory with instant semantic search."""
+"""vstash -- local document memory with instant semantic search."""
 
 __version__ = "0.36.0"
 
+from .errors import (
+    BackendError,
+    LimitError,
+    SchemaVersionError,
+    VstashError,
+)
 from .memory import Memory
 from .models import (
     AskResult,
@@ -15,11 +21,15 @@ from .models import (
 
 __all__ = [
     "AskResult",
+    "BackendError",
     "ChunkInfo",
     "DocumentInfo",
     "ExplainInfo",
     "IngestResult",
+    "LimitError",
     "Memory",
+    "SchemaVersionError",
     "SearchResult",
     "StoreStats",
+    "VstashError",
 ]

--- a/vstash/errors.py
+++ b/vstash/errors.py
@@ -1,0 +1,152 @@
+"""vstash.errors -- single source of truth for the exception hierarchy.
+
+Every error vstash raises descends from :class:`VstashError`. Catching
+``VstashError`` is the right way to handle any vstash-originated
+failure without also swallowing unrelated exceptions.
+
+Backwards compatibility: the validation errors in this module also
+inherit from :class:`ValueError`, and :class:`SchemaVersionError`
+also inherits from :class:`RuntimeError`. Existing user code that
+catches the stdlib base classes continues to work unchanged.
+
+Re-exports: :mod:`vstash.validation` and :mod:`vstash.store` both
+re-export their respective error classes from here, so existing
+``from vstash.validation import LimitError`` and
+``from vstash.store import SchemaVersionError`` imports keep working.
+"""
+
+from __future__ import annotations
+
+
+class VstashError(Exception):
+    """Base class for all vstash-raised exceptions.
+
+    Catch this to handle any vstash failure mode without also catching
+    unrelated stdlib exceptions. Direct subclasses split the failure
+    space by category:
+
+    - :class:`LimitError` -- input validation rejected at the API
+      boundary (queries too long, top_k out of range, chunks too big).
+    - :class:`SchemaVersionError` -- on-disk database has a schema
+      version this build does not know how to read.
+    - :class:`BackendError` -- a vector backend (sqlite-vec, snapvec,
+      ivfpq) failed to fit, save, or query.
+    """
+
+
+# ------------------------------------------------------------------ #
+# Input validation errors (formerly defined in validation.py)         #
+# ------------------------------------------------------------------ #
+
+
+class LimitError(VstashError, ValueError):
+    """Base class for all vstash input validation errors.
+
+    Multi-inherits from :class:`VstashError` (so ``except VstashError``
+    catches it) and :class:`ValueError` (so existing
+    ``except ValueError`` handlers continue to work). Catch this
+    directly to handle any vstash-imposed limit; catch a specific
+    subclass to react to one category.
+    """
+
+
+class QueryInvalidError(LimitError):
+    """Query text is missing, the wrong type, or otherwise unusable."""
+
+
+class QueryTooLongError(LimitError):
+    """Query text exceeds the configured maximum length."""
+
+
+class TopKOutOfRangeError(LimitError):
+    """``top_k`` is < 1 or above the configured maximum."""
+
+
+class DistanceCutoffOutOfRangeError(LimitError):
+    """``distance_cutoff`` is negative or above the configured maximum."""
+
+
+class RecencyBoostOutOfRangeError(LimitError):
+    """``recency_boost`` is negative or above the configured maximum."""
+
+
+class RRFWeightOutOfRangeError(LimitError):
+    """``vec_weight`` or ``fts_weight`` is outside the ``[0.0, 1.0]`` range."""
+
+
+class PathTooLongError(LimitError):
+    """Document path exceeds the configured maximum length."""
+
+
+class EmptyDocumentError(LimitError):
+    """Document has zero chunks."""
+
+
+class TooManyChunksError(LimitError):
+    """Document has more chunks than the configured maximum."""
+
+
+class ChunkTooLargeError(LimitError):
+    """A single chunk exceeds the configured character limit."""
+
+
+class EmbeddingMismatchError(LimitError):
+    """``chunks`` and ``embeddings`` lists have different lengths."""
+
+
+class InvalidIdentifierError(LimitError):
+    """``project`` / ``collection`` identifier is empty, too long, or contains
+    control characters."""
+
+
+# ------------------------------------------------------------------ #
+# Schema / storage errors                                              #
+# ------------------------------------------------------------------ #
+
+
+class SchemaVersionError(VstashError, RuntimeError):
+    """Raised when an existing DB declares a schema version this build
+    of vstash does not recognize.
+
+    Multi-inherits from :class:`RuntimeError` for backwards
+    compatibility with callers that ``except RuntimeError`` around
+    store construction. The right remedy is to upgrade vstash, restore
+    from backup, or run a future ``vstash migrate`` command (not yet
+    implemented).
+    """
+
+
+# ------------------------------------------------------------------ #
+# Backend errors (used by vector backends, retrieval pipeline)        #
+# ------------------------------------------------------------------ #
+
+
+class BackendError(VstashError):
+    """A vector backend (sqlite-vec, snapvec, snapvec-ivfpq) failed.
+
+    Distinct from :class:`LimitError` (caller-supplied input is bad)
+    and :class:`SchemaVersionError` (database is from a different
+    vstash version). Use this for backend-internal failures such as a
+    snapvec index file failing to load, an IVFPQ fit step receiving
+    too few training vectors, or a sqlite-vec extension load error.
+    """
+
+
+__all__ = [
+    "BackendError",
+    "ChunkTooLargeError",
+    "DistanceCutoffOutOfRangeError",
+    "EmbeddingMismatchError",
+    "EmptyDocumentError",
+    "InvalidIdentifierError",
+    "LimitError",
+    "PathTooLongError",
+    "QueryInvalidError",
+    "QueryTooLongError",
+    "RRFWeightOutOfRangeError",
+    "RecencyBoostOutOfRangeError",
+    "SchemaVersionError",
+    "TooManyChunksError",
+    "TopKOutOfRangeError",
+    "VstashError",
+]

--- a/vstash/errors.py
+++ b/vstash/errors.py
@@ -1,8 +1,22 @@
-"""vstash.errors -- single source of truth for the exception hierarchy.
+"""vstash.errors -- single source of truth for the vstash error hierarchy.
 
-Every error vstash raises descends from :class:`VstashError`. Catching
-``VstashError`` is the right way to handle any vstash-originated
-failure without also swallowing unrelated exceptions.
+This module is the canonical home of vstash's *domain* exception
+tree: input validation (:class:`LimitError`), schema mismatch
+(:class:`SchemaVersionError`), and vector backend failure
+(:class:`BackendError`). Every error in that tree descends from
+:class:`VstashError`, so ``except VstashError`` is the catch-all
+for vstash domain failures.
+
+Scope caveat: not every exception raised from a vstash function is a
+domain error. Some public guard paths still raise plain
+:class:`ValueError` / :class:`RuntimeError` (for example
+``Memory.miss_analysis`` rejects callers that pass neither
+``expected_path`` nor ``expected_chunk_id``), and lower-level
+failures bubble up as their stdlib types (``sqlite3.OperationalError``,
+``FileNotFoundError``, ``KeyError``). Tracking the migration of
+those sites to ``VstashError`` subclasses is a follow-up; until
+that lands, ``except VstashError`` covers the *domain hierarchy*
+defined here, not literally every error vstash can ever raise.
 
 Backwards compatibility: the validation errors in this module also
 inherit from :class:`ValueError`, and :class:`SchemaVersionError`
@@ -19,11 +33,12 @@ from __future__ import annotations
 
 
 class VstashError(Exception):
-    """Base class for all vstash-raised exceptions.
+    """Base class for vstash's domain exception tree.
 
-    Catch this to handle any vstash failure mode without also catching
-    unrelated stdlib exceptions. Direct subclasses split the failure
-    space by category:
+    Catch this to handle any vstash *domain* failure (input
+    validation, schema mismatch, backend failure) without also
+    catching unrelated stdlib exceptions. Direct subclasses split
+    the failure space by category:
 
     - :class:`LimitError` -- input validation rejected at the API
       boundary (queries too long, top_k out of range, chunks too big).
@@ -31,6 +46,11 @@ class VstashError(Exception):
       version this build does not know how to read.
     - :class:`BackendError` -- a vector backend (sqlite-vec, snapvec,
       ivfpq) failed to fit, save, or query.
+
+    Some legacy guard paths still raise plain :class:`ValueError` or
+    :class:`RuntimeError`; migrating those to ``VstashError``
+    subclasses is a follow-up. ``except VstashError`` covers the
+    domain tree above, not every exception vstash can possibly raise.
     """
 
 

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -33,6 +33,7 @@ import sqlite_vec
 from collections import OrderedDict
 
 from .config import CacheConfig, LimitsConfig, ObservabilityConfig
+from .errors import SchemaVersionError
 from .validation import validate_document_input, validate_search_input
 from .models import (
     ChunkInfo,
@@ -72,13 +73,9 @@ SCHEMA_VERSION = "2"
 KNOWN_SCHEMA_VERSIONS: frozenset[str] = frozenset({"1", "2"})
 
 
-class SchemaVersionError(RuntimeError):
-    """Raised when an existing DB declares a schema version this build
-    of vstash does not recognize.
-
-    The right remedy is to upgrade vstash, restore from backup, or run
-    a future ``vstash migrate`` command (not yet implemented).
-    """
+# SchemaVersionError moved to vstash.errors in v0.37 (single source of
+# truth for the VstashError hierarchy). Imported at the top of this
+# module; this comment is left as a breadcrumb for code archaeology.
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/validation.py
+++ b/vstash/validation.py
@@ -11,12 +11,14 @@ Validation lives at the **public API boundary** (``VstashStore`` and
 comparisons; if your inputs are reasonable, the cost is unmeasurable.
 
 All validators raise a subclass of :class:`LimitError`, which itself
-extends :class:`ValueError`.  Catching ``ValueError`` continues to work
-for callers who don't care which limit was hit.
+inherits from :class:`vstash.errors.VstashError` and
+:class:`ValueError`.  Catching either continues to work; the
+``VstashError`` ancestor (added in v0.37) is the unified handle for
+any vstash-domain error.
 
 Limits are configured via the ``[limits]`` section in ``vstash.toml``
 (see :class:`vstash.config.LimitsConfig`).  Defaults are intentionally
-generous — they catch pathological inputs without inconveniencing
+generous -- they catch pathological inputs without inconveniencing
 realistic ones.
 """
 
@@ -24,72 +26,46 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+# Re-export the validation error hierarchy from `vstash.errors` so
+# existing `from vstash.validation import LimitError, QueryTooLongError`
+# imports keep working. The single source of truth is `errors.py`.
+from .errors import (
+    ChunkTooLargeError,
+    DistanceCutoffOutOfRangeError,
+    EmbeddingMismatchError,
+    EmptyDocumentError,
+    InvalidIdentifierError,
+    LimitError,
+    PathTooLongError,
+    QueryInvalidError,
+    QueryTooLongError,
+    RecencyBoostOutOfRangeError,
+    RRFWeightOutOfRangeError,
+    TooManyChunksError,
+    TopKOutOfRangeError,
+)
+
 if TYPE_CHECKING:
     from .config import LimitsConfig
 
-
-# ------------------------------------------------------------------ #
-# Exception hierarchy                                                  #
-# ------------------------------------------------------------------ #
-
-
-class LimitError(ValueError):
-    """Base class for all vstash input validation errors.
-
-    Subclasses :class:`ValueError` so existing ``except ValueError``
-    handlers continue to work.  Catch this directly to handle any
-    vstash-imposed limit; catch a specific subclass to react to one
-    category.
-    """
-
-
-class QueryInvalidError(LimitError):
-    """Query text is missing, the wrong type, or otherwise unusable."""
-
-
-class QueryTooLongError(LimitError):
-    """Query text exceeds the configured maximum length."""
-
-
-class TopKOutOfRangeError(LimitError):
-    """``top_k`` is < 1 or above the configured maximum."""
-
-
-class DistanceCutoffOutOfRangeError(LimitError):
-    """``distance_cutoff`` is negative or above the configured maximum."""
-
-
-class RecencyBoostOutOfRangeError(LimitError):
-    """``recency_boost`` is negative or above the configured maximum."""
-
-
-class RRFWeightOutOfRangeError(LimitError):
-    """``vec_weight`` or ``fts_weight`` is outside the ``[0.0, 1.0]`` range."""
-
-
-class PathTooLongError(LimitError):
-    """Document path exceeds the configured maximum length."""
-
-
-class EmptyDocumentError(LimitError):
-    """Document has zero chunks."""
-
-
-class TooManyChunksError(LimitError):
-    """Document has more chunks than the configured maximum."""
-
-
-class ChunkTooLargeError(LimitError):
-    """A single chunk exceeds the configured character limit."""
-
-
-class EmbeddingMismatchError(LimitError):
-    """``chunks`` and ``embeddings`` lists have different lengths."""
-
-
-class InvalidIdentifierError(LimitError):
-    """``project`` / ``collection`` identifier is empty, too long, or contains
-    control characters."""
+__all__ = [
+    "ChunkTooLargeError",
+    "DistanceCutoffOutOfRangeError",
+    "EmbeddingMismatchError",
+    "EmptyDocumentError",
+    "InvalidIdentifierError",
+    "LimitError",
+    "PathTooLongError",
+    "QueryInvalidError",
+    "QueryTooLongError",
+    "RRFWeightOutOfRangeError",
+    "RecencyBoostOutOfRangeError",
+    "TooManyChunksError",
+    "TopKOutOfRangeError",
+    "validate_document_input",
+    "validate_identifier",
+    "validate_search_input",
+]
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary

Sprint 2 step 1: lay the seam every other architectural refactor will touch. Vstash had two disconnected error trees (\`LimitError(ValueError)\` in \`validation.py\`, \`SchemaVersionError(RuntimeError)\` in \`store.py\`); catching \"any vstash failure\" required \`except (LimitError, SchemaVersionError)\`. The upcoming \`vectorbackend/\` refactor would have added a third.

This PR unifies them under a single \`VstashError\` ancestor while keeping every existing import path and \`except\` clause working.

## What changed

- **New** \`vstash/errors.py\` is the single source of truth:
  - \`VstashError(Exception)\` -- base class for all vstash domain errors.
  - \`LimitError(VstashError, ValueError)\` -- moved from \`validation.py\`, plus all 12 subclasses (\`QueryTooLongError\`, \`TopKOutOfRangeError\`, \`ChunkTooLargeError\`, etc.).
  - \`SchemaVersionError(VstashError, RuntimeError)\` -- moved from \`store.py\`.
  - \`BackendError(VstashError)\` -- new, ready for the upcoming \`vectorbackend/\` refactor.
- \`vstash/validation.py\` and \`vstash/store.py\` re-export their respective classes so \`from vstash.validation import LimitError\` and \`from vstash.store import SchemaVersionError\` keep working.
- \`vstash/__init__.py\` exports \`VstashError\`, \`LimitError\`, \`SchemaVersionError\`, \`BackendError\` at package level: \`from vstash import VstashError\`.

## Multi-inheritance preserves backwards compatibility

\`\`\`
LimitError MRO          : LimitError -> VstashError -> ValueError
SchemaVersionError MRO  : SchemaVersionError -> VstashError -> RuntimeError
\`\`\`

Existing \`except ValueError\` and \`except RuntimeError\` clauses keep catching the same things. The only addition is \`except VstashError\` is now a valid catch-all.

## Test plan

- [x] New \`tests/test_errors.py\` (12 tests, 68 assertions) pins:
  - Ancestry shape (subclass relationships).
  - Multi-inheritance (both stdlib bases preserved).
  - Backwards-compat re-exports (\`vstash.validation.LimitError is vstash.errors.LimitError\`).
  - That \`VstashError\` does NOT swallow unrelated stdlib exceptions (KeyError, etc.).
- [x] \`pytest tests/test_store.py tests/test_validation.py tests/test_memory.py tests/test_errors.py\` -- 214 / 214 pass in 1:50.
- [x] \`ruff check .\` clean, \`ruff format --check .\` clean.

## Risk / blast radius

Low. No production code paths changed; only the class definitions moved files. Existing \`raise LimitError(...)\` and \`raise SchemaVersionError(...)\` sites are untouched. The new \`BackendError\` is available but no code raises it yet -- that lands when the \`vectorbackend/\` Protocol PR ships.

## Follow-ups

- \`vstash/services/\` layer (next Sprint 2 PR) will use \`VstashError\` as the wire-out catch in MCP/web/SDK adapters.
- \`vstash/vectorbackend/\` Protocol PR will start raising \`BackendError\` from the snapvec/IVFPQ paths instead of bare \`RuntimeError\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exceptions are now exposed as top-level package symbols for more consistent, discoverable error handling.
  * A unified, centralized error hierarchy standardizes how different error types are surfaced.

* **Tests**
  * Added tests that validate the unified exception hierarchy, confirm backward-compatible imports, and verify expected exception-catching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->