### PR TITLE
refactor(services): centralise embed -> search -> expand triplet

### DIFF
--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -178,6 +178,63 @@ class TestSearchService:
             assert kwargs["vec_weight"] is None
             assert kwargs["fts_weight"] is None
 
+    def test_distance_cutoff_pinned_forwards_to_store(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # When the caller pins a cutoff, the service must forward
+        # the same value to store.search rather than letting the
+        # store fall back to its hardcoded default. Pin a value
+        # well inside cfg.limits.max_distance_cutoff so validation
+        # passes.
+        with patch.object(populated_store, "search", wraps=populated_store.search) as spy:
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                distance_cutoff=0.9,
+            )
+            kwargs = spy.call_args.kwargs
+            assert kwargs.get("distance_cutoff") == 0.9
+
+    def test_distance_cutoff_none_does_not_forward(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # When the caller passes None (the default), the service must
+        # NOT forward distance_cutoff to store.search -- the store
+        # should apply its own default. Forwarding None would crash
+        # the store (its parameter is typed `float`, not `float | None`).
+        with patch.object(populated_store, "search", wraps=populated_store.search) as spy:
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+            )
+            kwargs = spy.call_args.kwargs
+            assert "distance_cutoff" not in kwargs
+
+    def test_distance_cutoff_above_limit_raises(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # Caller-pinned cutoff above cfg.limits.max_distance_cutoff
+        # is rejected at the boundary. This is the contract Gemini
+        # asked for: validate the value the caller actually passed,
+        # not the configured ceiling.
+        from vstash.validation import DistanceCutoffOutOfRangeError
+
+        with pytest.raises(DistanceCutoffOutOfRangeError):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                distance_cutoff=sample_config.limits.max_distance_cutoff + 1,
+            )
+        # The validation must fire before embed_query, same as the
+        # other validation tests.
+        patched_embed_query.assert_not_called()
+
 
 class TestAskService:
     """ask_with_context delegates to search service then chat.ask_full."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -235,6 +235,41 @@ class TestSearchService:
         # other validation tests.
         patched_embed_query.assert_not_called()
 
+    @pytest.mark.parametrize("bad_window", [-1, -100, "1", 1.5, True])
+    def test_invalid_expand_window_raises_pre_embed(
+        self, populated_store, sample_config, patched_embed_query, bad_window
+    ):
+        # `expand_window` is a cheap public knob; it should be
+        # rejected before the daemon round-trip just like top_k.
+        # bool is a tricky case because `isinstance(True, int)` is
+        # True in Python; we have to special-case it.
+        with pytest.raises(ValueError, match="expand_window"):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                expand_window=bad_window,
+            )
+        patched_embed_query.assert_not_called()
+
+    @pytest.mark.parametrize("bad_mode", ["fuzzy", "VEC_ONLY", "", "hybrid_only"])
+    def test_invalid_retrieval_mode_raises_pre_embed(
+        self, populated_store, sample_config, patched_embed_query, bad_mode
+    ):
+        # retrieval_mode is the second cheap-to-validate public knob.
+        # The Literal type alias does not enforce at runtime, so the
+        # service has to.
+        with pytest.raises(ValueError, match="retrieval_mode"):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                retrieval_mode=bad_mode,
+            )
+        patched_embed_query.assert_not_called()
+
 
 class TestAskService:
     """ask_with_context delegates to search service then chat.ask_full."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,248 @@
+"""Tests for the vstash.services layer.
+
+The services package was introduced in v0.37 to centralise the
+embed -> search -> expand triplet that the CLI, MCP, web API, and
+SDK previously inlined separately. These tests pin the new
+contract: search_with_embedding validates inputs, embeds the
+query, runs the hybrid pipeline, and optionally expands context.
+ask_with_context delegates to the search service then sends the
+chunks to chat.ask_full.
+
+The tests use mock embeddings (the populated_store fixture) so
+they run in <2s without depending on the FastEmbed daemon.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from vstash.models import AskResult, SearchResult
+from vstash.services import ask_with_context, search_with_embedding
+from vstash.validation import (
+    LimitError,
+    QueryTooLongError,
+    TopKOutOfRangeError,
+)
+
+
+@pytest.fixture
+def patched_embed_query():
+    """Replace embed_query with a deterministic constant vector.
+
+    The populated_store fixture uses 384-dim mock embeddings; we
+    return a vector that lives in the same space so the SQL search
+    actually returns rows. The vector is the average of the two
+    document clusters in populated_store, which puts vstash's
+    relevance ranking in a determinate state.
+    """
+    with patch("vstash.services.search.embed_query") as mock:
+        mock.return_value = [0.3] * 384
+        yield mock
+
+
+class TestSearchService:
+    """search_with_embedding behaviour."""
+
+    def test_returns_search_results(self, populated_store, sample_config, patched_embed_query):
+        results = search_with_embedding(
+            cfg=sample_config,
+            store=populated_store,
+            query="python programming",
+            top_k=3,
+        )
+        assert isinstance(results, list)
+        assert len(results) > 0
+        assert all(isinstance(r, SearchResult) for r in results)
+
+    def test_calls_embed_query_once(self, populated_store, sample_config, patched_embed_query):
+        search_with_embedding(
+            cfg=sample_config,
+            store=populated_store,
+            query="any question",
+            top_k=3,
+        )
+        # The whole point of the service is to centralise this call.
+        # If a future refactor accidentally embeds twice, this test
+        # catches it before the daemon bill doubles.
+        assert patched_embed_query.call_count == 1
+
+    def test_uses_configured_embedding_model(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        search_with_embedding(
+            cfg=sample_config,
+            store=populated_store,
+            query="anything",
+            top_k=1,
+        )
+        # Second positional arg of embed_query is the model name.
+        called_model = patched_embed_query.call_args[0][1]
+        assert called_model == sample_config.embeddings.model
+
+    def test_expand_window_zero_skips_expansion(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # When window=0 the service must not call expand_context. We
+        # verify by spying on the store's method.
+        with patch.object(
+            populated_store, "expand_context", wraps=populated_store.expand_context
+        ) as spy:
+            results = search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                expand_window=0,
+            )
+            spy.assert_not_called()
+        assert len(results) > 0
+
+    def test_expand_window_default_one_calls_expansion(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        with patch.object(
+            populated_store, "expand_context", wraps=populated_store.expand_context
+        ) as spy:
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+            )
+            spy.assert_called_once()
+            # Default window is 1 per the service signature.
+            assert spy.call_args.kwargs.get("window", 1) == 1
+
+    def test_validates_query_too_long(self, populated_store, sample_config, patched_embed_query):
+        # Build a query that exceeds the configured max_query_chars.
+        too_long = "a" * (sample_config.limits.max_query_chars + 1)
+        with pytest.raises(QueryTooLongError):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query=too_long,
+                top_k=3,
+            )
+        # Validation must fire BEFORE embed_query, otherwise the
+        # daemon does work for nothing and bills the user.
+        patched_embed_query.assert_not_called()
+
+    def test_validates_top_k_out_of_range(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        with pytest.raises(TopKOutOfRangeError):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=sample_config.limits.max_top_k + 1,
+            )
+        patched_embed_query.assert_not_called()
+
+    def test_validation_errors_inherit_limit_error(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # Sanity: callers can write `except LimitError` for any
+        # validation failure. This is the contract the v0.37 errors
+        # refactor pinned, but the services layer is the boundary
+        # where it most commonly fires for end users.
+        with pytest.raises(LimitError):
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="x" * (sample_config.limits.max_query_chars + 1),
+                top_k=3,
+            )
+
+    def test_non_hybrid_mode_drops_caller_weights(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # In vec_only / fts_only the store forces the weights
+        # internally; the service must NOT forward caller weights or
+        # the validator-allowed pair would conflict with the store's
+        # forced (1.0, 0.0) / (0.0, 1.0).
+        with patch.object(populated_store, "search", wraps=populated_store.search) as spy:
+            search_with_embedding(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+                retrieval_mode="vec_only",
+                vec_weight=0.7,
+                fts_weight=0.3,
+            )
+            kwargs = spy.call_args.kwargs
+            assert kwargs["retrieval_mode"] == "vec_only"
+            assert kwargs["vec_weight"] is None
+            assert kwargs["fts_weight"] is None
+
+
+class TestAskService:
+    """ask_with_context delegates to search service then chat.ask_full."""
+
+    def test_returns_ask_result(self, populated_store, sample_config, patched_embed_query):
+        # Mock the LLM call so the test does not need a backend.
+        fake = AskResult(
+            content="42",
+            reasoning=None,
+            usage=None,
+            backend="cerebras",
+            model="gpt-oss-120b",
+        )
+        with patch("vstash.services.ask._chat_ask_full", return_value=fake) as mock_ask:
+            result = ask_with_context(
+                cfg=sample_config,
+                store=populated_store,
+                query="what is the meaning of life",
+                top_k=2,
+            )
+        assert isinstance(result, AskResult)
+        assert result.content == "42"
+        # The service should have called chat.ask_full exactly once,
+        # with the retrieved chunks.
+        assert mock_ask.call_count == 1
+        # Arg shape is (query, chunks, cfg, history).
+        args = mock_ask.call_args[0]
+        assert args[0] == "what is the meaning of life"
+        assert isinstance(args[1], list)  # chunks
+        assert args[2] is sample_config
+
+    def test_uses_search_service_for_retrieval(
+        self, populated_store, sample_config, patched_embed_query
+    ):
+        # Confirm that ask delegates to the SAME search service, not
+        # a copy-paste of its body. If a future refactor splits them,
+        # this test forces a second mock to keep them in sync.
+        fake = AskResult(content="ok", backend="cerebras", model="x")
+        with (
+            patch("vstash.services.ask._chat_ask_full", return_value=fake),
+            patch(
+                "vstash.services.ask.search_with_embedding",
+                wraps=__import__(
+                    "vstash.services.search", fromlist=["search_with_embedding"]
+                ).search_with_embedding,
+            ) as spy_search,
+        ):
+            ask_with_context(
+                cfg=sample_config,
+                store=populated_store,
+                query="anything",
+                top_k=2,
+            )
+            spy_search.assert_called_once()
+
+    def test_propagates_validation_error(self, populated_store, sample_config, patched_embed_query):
+        # Validation lives in the search service; ask must not
+        # swallow it (otherwise an over-long query would silently
+        # become a chat call with no context).
+        with patch("vstash.services.ask._chat_ask_full") as mock_ask:
+            with pytest.raises(QueryTooLongError):
+                ask_with_context(
+                    cfg=sample_config,
+                    store=populated_store,
+                    query="x" * (sample_config.limits.max_query_chars + 1),
+                    top_k=2,
+                )
+            mock_ask.assert_not_called()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -243,7 +243,12 @@ class TestSearchService:
         # rejected before the daemon round-trip just like top_k.
         # bool is a tricky case because `isinstance(True, int)` is
         # True in Python; we have to special-case it.
-        with pytest.raises(ValueError, match="expand_window"):
+        # The error must be LimitError (not bare ValueError) so it
+        # honours the function's documented Raises: contract and is
+        # caught by the LimitError -> HTTP 400 mapping in web.py.
+        # LimitError is itself a ValueError subclass, so consumers
+        # that catch ValueError keep working.
+        with pytest.raises(LimitError, match="expand_window"):
             search_with_embedding(
                 cfg=sample_config,
                 store=populated_store,
@@ -259,8 +264,9 @@ class TestSearchService:
     ):
         # retrieval_mode is the second cheap-to-validate public knob.
         # The Literal type alias does not enforce at runtime, so the
-        # service has to.
-        with pytest.raises(ValueError, match="retrieval_mode"):
+        # service has to. LimitError (not ValueError) so it honours
+        # the documented Raises: contract.
+        with pytest.raises(LimitError, match="retrieval_mode"):
             search_with_embedding(
                 cfg=sample_config,
                 store=populated_store,

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -154,6 +154,20 @@ class TestApiSearch:
         assert resp.status_code == 200
         mock_search.assert_called_once_with("foo", 3, 0.0)
 
+    def test_limit_error_maps_to_400(self, client: TestClient) -> None:
+        # Validation now lives in the services layer (search_with_embedding);
+        # api_search must catch LimitError and return 400 instead of letting
+        # it bubble up as an unhandled 500.
+        from vstash.validation import QueryTooLongError
+
+        with patch("vstash.web._do_search") as mock_search:
+            mock_search.side_effect = QueryTooLongError("query too long: 200001 chars")
+            resp = client.post("/api/search", json={"query": "x", "top_k": 3})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "query too long" in body["error"]
+        assert body["kind"] == "QueryTooLongError"
+
 
 # ------------------------------------------------------------------ #
 # /api/chat and /api/chat/reset                                        #
@@ -190,6 +204,20 @@ class TestApiChat:
         assert resp.status_code == 200
         assert resp.json() == {"status": "ok"}
         assert web_mod._chat_history == []
+
+    def test_chat_limit_error_maps_to_400(self, client: TestClient) -> None:
+        # Same regression-guard as test_search_limit_error_maps_to_400:
+        # _do_chat_retrieve goes through search_with_embedding and can
+        # raise LimitError. api_chat must surface that as 400.
+        from vstash.validation import TopKOutOfRangeError
+
+        with patch("vstash.web._do_chat_retrieve") as mock_retrieve:
+            mock_retrieve.side_effect = TopKOutOfRangeError("top_k 9999 exceeds limit 100")
+            resp = client.post("/api/chat", json={"query": "what?", "top_k": 9999})
+        assert resp.status_code == 400
+        body = resp.json()
+        assert "top_k" in body["error"]
+        assert body["kind"] == "TopKOutOfRangeError"
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/services/__init__.py
+++ b/vstash/services/__init__.py
@@ -1,0 +1,41 @@
+"""vstash.services -- shared business-logic helpers for adapters.
+
+The CLI, MCP server, HTTP API, and SDK all need to perform the same
+high-level operations (embed query + search + expand context, then
+optionally feed the chunks to an LLM). Historically each adapter
+re-implemented this triplet inline (mcp.py:546, web.py:98,
+cli.py:438, etc.) and the implementations drifted from each other
+in subtle ways: one passed ``window=1`` to ``expand_context``, the
+next passed ``window=2``; one applied ``recency_boost`` from config,
+another forced it to 0; one validated inputs, the next didn't.
+
+This package centralises the shared steps as pure functions that
+take ``(cfg, store, ...)`` explicitly. They:
+
+- validate user input via :mod:`vstash.validation` (single source of
+  truth for limits)
+- embed the query via :func:`vstash.embed.embed_query`
+- call ``store.search`` / ``store.miss_analysis`` / ``chat.ask_full``
+- optionally expand context via ``store.expand_context``
+
+Adapters (``mcp.py``, ``web.py``, ``cli.py``, ``memory.py``) become
+thin presentation layers that handle their protocol-specific
+concerns (MCP tool result shape, HTTP response format, Rich CLI
+output, SDK return types) and delegate the actual retrieval logic
+here.
+
+These functions are stateless: they do not hold a store, a config,
+or any session state. The caller passes whatever ``VstashStore``
+and ``VstashConfig`` they already have. This keeps the services
+testable in isolation and re-usable across the four adapters.
+"""
+
+from __future__ import annotations
+
+from .ask import ask_with_context
+from .search import search_with_embedding
+
+__all__ = [
+    "ask_with_context",
+    "search_with_embedding",
+]

--- a/vstash/services/ask.py
+++ b/vstash/services/ask.py
@@ -34,9 +34,16 @@ def ask_with_context(
     collection: str | None = None,
     project: str | None = None,
     layer: str | None = None,
+    recency_boost: float = 0.0,
+    added_after: str | None = None,
+    added_before: str | None = None,
+    mmr_lambda: float = 0.5,
     vec_weight: float | None = None,
     fts_weight: float | None = None,
     retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
+    distance_cutoff: float | None = None,
+    exact_match: str | None = None,
+    exact_match_case_sensitive: bool = False,
 ) -> AskResult:
     """Retrieve context for ``query`` and send it to the LLM backend.
 
@@ -47,6 +54,13 @@ def ask_with_context(
     :func:`vstash.services.search.search_with_embedding`, then runs
     :func:`vstash.chat.ask_full` against the resolved backend
     (Cerebras, Ollama, OpenAI, or auto-detected local).
+
+    Exposes the full search-side knob set (recency, date filters,
+    MMR diversity, RRF weights, distance cutoff, exact-match) so
+    callers do not have to choose between "use the service" and
+    "use the adapter". A user who wants recency-boosted retrieval
+    in their LLM answer should not have to re-implement the
+    triplet just to pass one parameter.
 
     Args:
         cfg: Active vstash config.
@@ -59,10 +73,21 @@ def ask_with_context(
         collection: Optional collection filter for retrieval.
         project: Optional project filter for retrieval.
         layer: Optional layer filter for retrieval.
+        recency_boost: Temporal decay multiplier on retrieval (0.0
+            = off).
+        added_after: ISO date filter on document add timestamp.
+        added_before: ISO date filter on document add timestamp.
+        mmr_lambda: MMR diversity coefficient applied to context
+            chunks before they reach the LLM.
         vec_weight: Pin RRF vector weight on the retrieval call.
         fts_weight: Pin RRF FTS weight on the retrieval call.
         retrieval_mode: ``"hybrid"`` (default), ``"vec_only"``, or
             ``"fts_only"``.
+        distance_cutoff: Override the store's default distance
+            cutoff for the retrieval call.
+        exact_match: Literal substring required in retrieval results.
+        exact_match_case_sensitive: Whether ``exact_match`` is
+            case-sensitive.
 
     Returns:
         ``AskResult`` carrying content + (when the backend surfaces
@@ -82,8 +107,15 @@ def ask_with_context(
         collection=collection,
         project=project,
         layer=layer,
+        recency_boost=recency_boost,
+        added_after=added_after,
+        added_before=added_before,
+        mmr_lambda=mmr_lambda,
         vec_weight=vec_weight,
         fts_weight=fts_weight,
         retrieval_mode=retrieval_mode,
+        distance_cutoff=distance_cutoff,
+        exact_match=exact_match,
+        exact_match_case_sensitive=exact_match_case_sensitive,
     )
     return _chat_ask_full(query, chunks, cfg, history)

--- a/vstash/services/ask.py
+++ b/vstash/services/ask.py
@@ -1,0 +1,89 @@
+"""vstash.services.ask -- retrieve context, then send to LLM.
+
+Wraps :func:`vstash.services.search.search_with_embedding` and
+:func:`vstash.chat.ask_full` so adapters do not have to remember to
+do retrieval before generation, or to feed the result chunks into
+the right shape for the LLM call.
+
+Returns :class:`AskResult`, which carries content + reasoning +
+usage + resolved backend / model. Adapters that only need the
+text reply can read ``.content``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from ..chat import ask_full as _chat_ask_full
+from .search import search_with_embedding
+
+if TYPE_CHECKING:
+    from ..config import VstashConfig
+    from ..models import AskResult, SearchResult
+    from ..store import VstashStore
+
+
+def ask_with_context(
+    *,
+    cfg: VstashConfig,
+    store: VstashStore,
+    query: str,
+    top_k: int = 5,
+    expand_window: int = 1,
+    history: list[dict[str, str]] | None = None,
+    collection: str | None = None,
+    project: str | None = None,
+    layer: str | None = None,
+    vec_weight: float | None = None,
+    fts_weight: float | None = None,
+    retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
+) -> AskResult:
+    """Retrieve context for ``query`` and send it to the LLM backend.
+
+    The single replacement for the
+    ``embed_query -> store.search -> store.expand_context -> chat.ask_full``
+    chain that the SDK and the (legacy) adapter handlers used to
+    inline. Validates retrieval inputs via
+    :func:`vstash.services.search.search_with_embedding`, then runs
+    :func:`vstash.chat.ask_full` against the resolved backend
+    (Cerebras, Ollama, OpenAI, or auto-detected local).
+
+    Args:
+        cfg: Active vstash config.
+        store: Open ``VstashStore``.
+        query: User question.
+        top_k: How many context chunks to retrieve.
+        expand_window: Sibling chunks per side to include in
+            context expansion. Pass ``0`` to skip expansion.
+        history: Prior conversation turns (multi-turn chat).
+        collection: Optional collection filter for retrieval.
+        project: Optional project filter for retrieval.
+        layer: Optional layer filter for retrieval.
+        vec_weight: Pin RRF vector weight on the retrieval call.
+        fts_weight: Pin RRF FTS weight on the retrieval call.
+        retrieval_mode: ``"hybrid"`` (default), ``"vec_only"``, or
+            ``"fts_only"``.
+
+    Returns:
+        ``AskResult`` carrying content + (when the backend surfaces
+        it) reasoning + usage + resolved backend / model.
+
+    Raises:
+        LimitError: Retrieval input rejected at the boundary.
+        ValueError: Unknown inference backend in ``cfg.inference``.
+        ConnectionError: Inference API call failed.
+    """
+    chunks: list[SearchResult] = search_with_embedding(
+        cfg=cfg,
+        store=store,
+        query=query,
+        top_k=top_k,
+        expand_window=expand_window,
+        collection=collection,
+        project=project,
+        layer=layer,
+        vec_weight=vec_weight,
+        fts_weight=fts_weight,
+        retrieval_mode=retrieval_mode,
+    )
+    return _chat_ask_full(query, chunks, cfg, history)

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -44,6 +44,7 @@ def search_with_embedding(
     vec_weight: float | None = None,
     fts_weight: float | None = None,
     retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
+    distance_cutoff: float | None = None,
     exact_match: str | None = None,
     exact_match_case_sensitive: bool = False,
 ) -> list[SearchResult]:
@@ -77,6 +78,10 @@ def search_with_embedding(
         fts_weight: Pin RRF FTS weight; None keeps adaptive RRF.
         retrieval_mode: ``"hybrid"`` (default), ``"vec_only"``, or
             ``"fts_only"``. None resolves to ``"hybrid"``.
+        distance_cutoff: Override the store's default distance cutoff
+            for this call. ``None`` (default) lets the store apply
+            its built-in default. Validated against
+            ``cfg.limits.max_distance_cutoff`` when provided.
         exact_match: Literal substring required in the result text.
         exact_match_case_sensitive: Whether ``exact_match`` is
             case-sensitive.
@@ -87,13 +92,17 @@ def search_with_embedding(
     Raises:
         LimitError: Any input exceeded the configured limit.
     """
-    # The store defaults distance_cutoff to 1.3225 internally; we
-    # validate against the configured ceiling so callers get a clear
-    # LimitError if they ever pass a custom value via kwargs.
+    # If the caller pinned a cutoff, validate THAT value against
+    # the configured ceiling; otherwise validate the ceiling against
+    # itself (a noop) so the rest of validate_search_input can
+    # still run with a populated arg.
+    effective_cutoff = (
+        distance_cutoff if distance_cutoff is not None else cfg.limits.max_distance_cutoff
+    )
     validate_search_input(
         query_text=query,
         top_k=top_k,
-        distance_cutoff=cfg.limits.max_distance_cutoff,
+        distance_cutoff=effective_cutoff,
         recency_boost=recency_boost,
         limits=cfg.limits,
         vec_weight=vec_weight,
@@ -109,6 +118,13 @@ def search_with_embedding(
         fts_weight = None
 
     q_embedding = embed_query(query, cfg.embeddings.model)
+
+    # Only forward distance_cutoff when the caller pinned one;
+    # otherwise let store.search apply its own default. Avoids
+    # hardcoding the store's default value here (currently 1.3225).
+    extra_kwargs: dict = {}
+    if distance_cutoff is not None:
+        extra_kwargs["distance_cutoff"] = distance_cutoff
 
     results = store.search(
         query_embedding=q_embedding,
@@ -126,6 +142,7 @@ def search_with_embedding(
         mmr_lambda=mmr_lambda,
         exact_match=exact_match,
         exact_match_case_sensitive=exact_match_case_sensitive,
+        **extra_kwargs,
     )
 
     if expand_window > 0 and results:

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 
 from ..embed import embed_query
-from ..validation import validate_search_input
+from ..validation import LimitError, validate_search_input
 
 if TYPE_CHECKING:
     from ..config import VstashConfig
@@ -100,10 +100,15 @@ def search_with_embedding(
     # Validate the cheap-to-check public knobs BEFORE embed_query so
     # an invalid expand_window or retrieval_mode does not pay for a
     # daemon round-trip just to crash inside store.search later.
+    # These raise LimitError (not ValueError) so they honour the
+    # function's documented "Raises: LimitError" contract and so
+    # web/MCP handlers that catch LimitError specifically (api_search,
+    # api_chat) map them to HTTP 400 / MCP error rather than letting
+    # them propagate as 500 / unhandled exception.
     if not isinstance(expand_window, int) or isinstance(expand_window, bool) or expand_window < 0:
-        raise ValueError(f"expand_window must be a non-negative int, got {expand_window!r}")
+        raise LimitError(f"expand_window must be a non-negative int, got {expand_window!r}")
     if retrieval_mode is not None and retrieval_mode not in _VALID_RETRIEVAL_MODES:
-        raise ValueError(
+        raise LimitError(
             f"retrieval_mode must be one of "
             f"{sorted(_VALID_RETRIEVAL_MODES)} or None, got {retrieval_mode!r}"
         )

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -26,6 +26,11 @@ if TYPE_CHECKING:
     from ..models import SearchResult
     from ..store import VstashStore
 
+# The literal Protocol of valid retrieval modes. Kept as a module
+# constant so the runtime check in `search_with_embedding` does not
+# have to maintain a parallel list to the Literal type alias above.
+_VALID_RETRIEVAL_MODES: frozenset[str] = frozenset({"hybrid", "vec_only", "fts_only"})
+
 
 def search_with_embedding(
     *,
@@ -92,6 +97,17 @@ def search_with_embedding(
     Raises:
         LimitError: Any input exceeded the configured limit.
     """
+    # Validate the cheap-to-check public knobs BEFORE embed_query so
+    # an invalid expand_window or retrieval_mode does not pay for a
+    # daemon round-trip just to crash inside store.search later.
+    if not isinstance(expand_window, int) or isinstance(expand_window, bool) or expand_window < 0:
+        raise ValueError(f"expand_window must be a non-negative int, got {expand_window!r}")
+    if retrieval_mode is not None and retrieval_mode not in _VALID_RETRIEVAL_MODES:
+        raise ValueError(
+            f"retrieval_mode must be one of "
+            f"{sorted(_VALID_RETRIEVAL_MODES)} or None, got {retrieval_mode!r}"
+        )
+
     # If the caller pinned a cutoff, validate THAT value against
     # the configured ceiling; otherwise validate the ceiling against
     # itself (a noop) so the rest of validate_search_input can

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -1,0 +1,134 @@
+"""vstash.services.search -- the embed -> search -> expand triplet.
+
+A pure function that the adapters (CLI, MCP, web, SDK) all call to
+turn a user query into a list of relevant chunks. Replaces the
+hand-rolled triplet that was duplicated 13+ times across the
+codebase before v0.37.
+
+The function validates first (so adapters cannot bypass
+:func:`vstash.validation.validate_search_input`), then embeds the
+query, then runs the hybrid retrieval pipeline, then optionally
+expands the context window. The split ``expand_window=0`` exists
+because the miss-analysis path wants raw search results without
+context expansion, and one of the daemon endpoints used to take
+the window from config.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from ..embed import embed_query
+from ..validation import validate_search_input
+
+if TYPE_CHECKING:
+    from ..config import VstashConfig
+    from ..models import SearchResult
+    from ..store import VstashStore
+
+
+def search_with_embedding(
+    *,
+    cfg: VstashConfig,
+    store: VstashStore,
+    query: str,
+    top_k: int = 5,
+    expand_window: int = 1,
+    collection: str | None = None,
+    project: str | None = None,
+    layer: str | None = None,
+    recency_boost: float = 0.0,
+    added_after: str | None = None,
+    added_before: str | None = None,
+    mmr_lambda: float = 0.5,
+    vec_weight: float | None = None,
+    fts_weight: float | None = None,
+    retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
+    exact_match: str | None = None,
+    exact_match_case_sensitive: bool = False,
+) -> list[SearchResult]:
+    """Embed ``query`` then hybrid-search ``store`` then expand context.
+
+    The single replacement for the
+    ``embed_query -> store.search -> store.expand_context`` triplet
+    that adapters used to inline. Validates the public inputs against
+    the configured limits before doing any work, so a 200_000-char
+    query or a ``top_k`` of 9999 is rejected at the boundary instead
+    of crashing inside SQLite.
+
+    Args:
+        cfg: Active vstash config (used for the embedding model and
+            the validation limits).
+        store: Open ``VstashStore``. Caller owns its lifecycle.
+        query: Natural language search query.
+        top_k: Maximum results to return.
+        expand_window: How many sibling chunks per side to include in
+            context expansion. ``0`` skips expansion (returns the raw
+            search results, useful for miss analysis where the
+            unexpanded chunk is what the caller is debugging).
+        collection: Optional collection filter.
+        project: Optional project filter.
+        layer: Optional layer filter.
+        recency_boost: Temporal decay multiplier (0.0 = off).
+        added_after: ISO date filter on document add timestamp.
+        added_before: ISO date filter on document add timestamp.
+        mmr_lambda: MMR diversity coefficient (0.0 to 1.0).
+        vec_weight: Pin RRF vector weight; None keeps adaptive RRF.
+        fts_weight: Pin RRF FTS weight; None keeps adaptive RRF.
+        retrieval_mode: ``"hybrid"`` (default), ``"vec_only"``, or
+            ``"fts_only"``. None resolves to ``"hybrid"``.
+        exact_match: Literal substring required in the result text.
+        exact_match_case_sensitive: Whether ``exact_match`` is
+            case-sensitive.
+
+    Returns:
+        List of ``SearchResult`` ranked by relevance. May be empty.
+
+    Raises:
+        LimitError: Any input exceeded the configured limit.
+    """
+    # The store defaults distance_cutoff to 1.3225 internally; we
+    # validate against the configured ceiling so callers get a clear
+    # LimitError if they ever pass a custom value via kwargs.
+    validate_search_input(
+        query_text=query,
+        top_k=top_k,
+        distance_cutoff=cfg.limits.max_distance_cutoff,
+        recency_boost=recency_boost,
+        limits=cfg.limits,
+        vec_weight=vec_weight,
+        fts_weight=fts_weight,
+    )
+
+    mode = retrieval_mode or "hybrid"
+    # In non-hybrid modes the store forces the weights internally; do
+    # not pass caller weights through, otherwise the validation above
+    # might let a 0.7/0.3 split through that the store would reject.
+    if mode != "hybrid":
+        vec_weight = None
+        fts_weight = None
+
+    q_embedding = embed_query(query, cfg.embeddings.model)
+
+    results = store.search(
+        query_embedding=q_embedding,
+        query_text=query,
+        top_k=top_k,
+        vec_weight=vec_weight,
+        fts_weight=fts_weight,
+        retrieval_mode=mode,
+        collection=collection,
+        project=project,
+        layer=layer,
+        recency_boost=recency_boost,
+        added_after=added_after,
+        added_before=added_before,
+        mmr_lambda=mmr_lambda,
+        exact_match=exact_match,
+        exact_match_case_sensitive=exact_match_case_sensitive,
+    )
+
+    if expand_window > 0 and results:
+        results = store.expand_context(results, window=expand_window)
+
+    return results

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -32,6 +32,7 @@ from .config import VstashConfig, load_config
 from .embed import embed_query
 from .ingest import ingest
 from .models import SearchResult
+from .services import search_with_embedding
 from .store import VstashStore, relevance_tier
 
 logger = logging.getLogger(__name__)
@@ -95,14 +96,14 @@ _chat_history: list[dict[str, str]] = []
 def _do_search(query: str, top_k: int, recency_boost: float) -> dict:
     cfg = _get_config()
     store = _get_store()
-    q_emb = embed_query(query, cfg.embeddings.model)
-    results = store.search(
-        query_embedding=q_emb,
-        query_text=query,
+    results = search_with_embedding(
+        cfg=cfg,
+        store=store,
+        query=query,
         top_k=top_k,
         recency_boost=recency_boost,
+        expand_window=1,
     )
-    results = store.expand_context(results, window=1)
     best_distance = store.last_best_distance
     relevance = relevance_tier(best_distance)
     return {
@@ -170,9 +171,13 @@ def _do_upload(file_bytes: bytes, suffix: str, original_name: str | None = None)
 def _do_chat_retrieve(query: str, top_k: int) -> tuple[list[SearchResult], list[dict]]:
     cfg = _get_config()
     store = _get_store()
-    q_emb = embed_query(query, cfg.embeddings.model)
-    chunks = store.search(query_embedding=q_emb, query_text=query, top_k=top_k)
-    chunks = store.expand_context(chunks, window=1)
+    chunks = search_with_embedding(
+        cfg=cfg,
+        store=store,
+        query=query,
+        top_k=top_k,
+        expand_window=1,
+    )
     sources = list({c.path: {"title": c.title, "path": c.path} for c in chunks}.values())
     return chunks, sources
 

--- a/vstash/web.py
+++ b/vstash/web.py
@@ -34,6 +34,7 @@ from .ingest import ingest
 from .models import SearchResult
 from .services import search_with_embedding
 from .store import VstashStore, relevance_tier
+from .validation import LimitError
 
 logger = logging.getLogger(__name__)
 
@@ -285,7 +286,12 @@ async def api_search(request: Request) -> JSONResponse:
     if not query.strip():
         return _json({"error": "query is required"}, 400)
 
-    data = await _run_sync(_do_search, query, top_k, recency_boost)
+    try:
+        data = await _run_sync(_do_search, query, top_k, recency_boost)
+    except LimitError as exc:
+        # Validation now lives in the services layer; surface the
+        # rejection as 400 instead of letting it bubble up as 500.
+        return _json({"error": str(exc), "kind": type(exc).__name__}, 400)
     return _json(data)
 
 
@@ -298,7 +304,10 @@ async def api_chat(request: Request) -> Any:
     if not query.strip():
         return _json({"error": "query is required"}, 400)
 
-    chunks, sources = await _run_sync(_do_chat_retrieve, query, top_k)
+    try:
+        chunks, sources = await _run_sync(_do_chat_retrieve, query, top_k)
+    except LimitError as exc:
+        return _json({"error": str(exc), "kind": type(exc).__name__}, 400)
 
     if not chunks:
 


### PR DESCRIPTION
## Summary

Sprint 2 step 2. The audit flagged that the \`embed_query -> store.search -> store.expand_context\` triplet was inlined **13+ times** across the codebase: 3 sites in \`mcp.py\`, 4 in \`web.py\`, 6+ in \`cli.py\`. Implementations had drifted: validation was applied unevenly, \`recency_boost\` was forced to 0 in some paths, \`expand_context\` window varied between 1 and 2.

This PR introduces \`vstash/services/\` as the single source of truth and migrates the smallest adapter (\`web.py\`) as proof of design. \`mcp.py\` and \`cli.py\` migrations land as follow-up PRs (mechanical once the service exists).

## What's new

- \`vstash/services/search.py::search_with_embedding\` -- validates inputs (raises \`LimitError\` BEFORE \`embed_query\` is called, saving a daemon round-trip on rejected queries), embeds, calls \`store.search\` with the full parameter set, optionally expands context. \`expand_window=0\` skips expansion (used by miss-analysis paths).
- \`vstash/services/ask.py::ask_with_context\` -- delegates to \`search_with_embedding\`, then \`chat.ask_full\`. Returns \`AskResult\` so adapters can surface reasoning + usage when the backend provides them (Cerebras \`gpt-oss-120b\`, Ollama qwen3 thinking) without a second round-trip.
- \`vstash/services/__init__.py\` -- re-exports both as the documented import surface.

## Migrated in this PR

\`vstash/web.py\`: \`_do_search\` and \`_do_chat_retrieve\` now call \`search_with_embedding\` instead of inlining the triplet. Net diff: +13 / -8.

## Test plan

\`tests/test_services.py\` (12 tests, 1.16s):

- [x] \`search_with_embedding\` returns \`list[SearchResult]\`, calls \`embed_query\` exactly once, uses the configured model, drops caller weights in non-hybrid modes.
- [x] \`expand_window=0\` skips \`store.expand_context\`; \`expand_window=1\` (default) calls it with \`window=1\`.
- [x] **Validation fires BEFORE the embed call** (mock asserts \`embed_query\` never invoked on rejected input).
- [x] \`ask_with_context\` returns \`AskResult\`, delegates to \`search_with_embedding\` (not a copy-paste), propagates \`LimitError\` instead of sending a no-context query to the LLM.
- [x] Validation errors still inherit from \`LimitError\` (compat with v0.37 errors hierarchy).

Broader smoke: \`pytest test_services + test_web + test_validation + test_store\` -> 206 / 206 in 6.39s. \`ruff check .\` + \`ruff format --check .\` both clean.

## Risk

Low. The services package is purely additive; only \`web.py\` adopts it, and behavior is preserved (services compose the same store calls, just with input validation added). Existing \`Memory.search\` / \`Memory.ask\` paths are untouched.

## Follow-ups (separate PRs)

- Migrate \`vstash/mcp.py\` (3 sites at lines 546, 697, 802) -- closes part of #283.
- Migrate \`vstash/cli.py\` (6+ sites at lines 438, 634, 697, 955, 1728).
- Migrate \`vstash/memory.py::search\` and \`Memory.ask_full\` to delegate to the services so Memory becomes a thin wrapper rather than a parallel implementation.

Stacks behind PR #326 (\`refactor/errors-hierarchy\`); after #326 lands, a quick rebase swaps \`from vstash.validation\` to \`from vstash.errors\` in the test file. Test outcomes are identical either way (re-export keeps both paths working).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified search and ask service endpoints for end-to-end retrieval + QA with configurable retrieval modes, filters, distance-cutoff handling, and optional context expansion.

* **Tests**
  * Added deterministic, comprehensive service tests covering input validation, embedding/search flow, expansion behavior, weight/parameter forwarding, and error propagation.

* **Refactor**
  * Centralized embedding → search → expansion wiring into shared service helpers.

* **Bug Fixes**
  * Web API now returns consistent HTTP 400 responses for validation/limit errors (includes error kind).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->