### PR TITLE
refactor(vectorbackend): introduce VectorBackend Protocol + extract IVFPQ

### DIFF
--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -7,8 +7,8 @@ import pytest
 
 pytest.importorskip("snapvec", reason="snapvec not installed")
 
-from vstash._ivfpq_backend import IVFPQBackend
 from vstash.store import VstashStore
+from vstash.vectorbackend import IVFPQBackend
 
 DIM = 96  # multiple of ivfpq_M so no param juggling is needed
 N = 400  # big enough for the default nlist without overfitting warnings
@@ -168,7 +168,7 @@ class TestVstashStoreIVFPQIntegration:
         """Regression test for #289: the per-backend branch in
         ``VstashStore.search`` must not double-invert ``IVFPQBackend
         .search`` output.  ``IVFPQBackend`` already returns cosine
-        distance in ``[0, 2]`` (see ``_ivfpq_backend.py``), so a same-
+        distance in ``[0, 2]`` (see ``vectorbackend/snapvec_ivfpq.py``), so a same-
         vector query under ``snapvec-ivfpq`` must land in the
         ``"high"`` tier, not the ``"low"`` tier that double-inversion
         would produce.

--- a/tests/test_vectorbackend.py
+++ b/tests/test_vectorbackend.py
@@ -1,0 +1,113 @@
+"""Tests for the vstash.vectorbackend Protocol and registry.
+
+The Protocol is structural; existing classes that already match its
+shape (notably IVFPQBackend, which is the only concrete adapter
+extracted in v0.37) satisfy it without inheritance. These tests
+pin three things:
+
+1. ``vstash.vectorbackend.IVFPQBackend`` is the same class object
+   as ``vstash.vectorbackend.snapvec_ivfpq.IVFPQBackend`` (the
+   re-export contract).
+2. ``vstash._ivfpq_backend`` still re-exports the same class with
+   a DeprecationWarning (compat shim contract for v0.37 -> v0.40).
+3. IVFPQBackend satisfies the runtime-checkable VectorBackend
+   Protocol -- i.e. has all the required methods with the right
+   signatures.
+
+Snapvec is an optional dep; the whole module skips when it is not
+installed.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+pytest.importorskip("snapvec", reason="snapvec not installed")
+
+import numpy as np
+
+from vstash.vectorbackend import IVFPQBackend, VectorBackend
+
+
+class TestPackageExports:
+    """Re-export contract: IVFPQBackend is one class, three import paths."""
+
+    def test_package_exports_ivfpq_backend(self) -> None:
+        from vstash.vectorbackend import IVFPQBackend as Pkg
+        from vstash.vectorbackend.snapvec_ivfpq import IVFPQBackend as Mod
+
+        assert Pkg is Mod, "package re-export drifted from module-level class"
+
+    def test_legacy_shim_warns_and_resolves(self) -> None:
+        # The shim emits a DeprecationWarning on import and resolves
+        # to the same class object as the new path. Tests for the
+        # warning are easier to write at module-import time, but
+        # python caches modules, so we use importlib.reload to force
+        # a fresh import.
+        import importlib
+
+        import vstash._ivfpq_backend
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            importlib.reload(vstash._ivfpq_backend)
+
+        assert any(
+            issubclass(w.category, DeprecationWarning) and "vstash._ivfpq_backend" in str(w.message)
+            for w in captured
+        ), "deprecation warning not emitted from shim"
+
+        from vstash._ivfpq_backend import IVFPQBackend as Shim
+        from vstash.vectorbackend import IVFPQBackend as Pkg
+
+        assert Shim is Pkg, "shim re-export drifted from canonical class"
+
+
+class TestProtocolConformance:
+    """IVFPQBackend satisfies the VectorBackend Protocol."""
+
+    @pytest.fixture
+    def backend(self) -> IVFPQBackend:
+        # M=96 divides dim=384 (the default BGE small dim).
+        return IVFPQBackend(dim=384, nlist=4, M=96, K=64)
+
+    def test_isinstance_check(self, backend: IVFPQBackend) -> None:
+        # runtime_checkable Protocol -- isinstance is the contract
+        # external code uses for defensive type checks.
+        assert isinstance(backend, VectorBackend)
+
+    def test_has_required_attributes(self, backend: IVFPQBackend) -> None:
+        # Every protocol member must exist on the instance.
+        assert hasattr(backend, "dim")
+        assert backend.dim == 384
+
+    def test_len_returns_zero_pre_fit(self, backend: IVFPQBackend) -> None:
+        # Pre-fit IVFPQ reports 0 routable vectors so the store falls
+        # back to sqlite-vec. This is the contract VstashStore.search
+        # depends on at line 2204-ish (`elif self._snap is not None
+        # and len(self._snap) > 0`).
+        assert len(backend) == 0
+
+    def test_search_pre_fit_returns_empty(self, backend: IVFPQBackend) -> None:
+        query = np.random.default_rng(42).standard_normal(384).astype(np.float32)
+        results = backend.search(query, k=5)
+        assert results == []
+
+    def test_add_batch_pre_fit_silently_drops(self, backend: IVFPQBackend) -> None:
+        # The store dual-populates sqlite-vec + snapvec on every
+        # add_document; pre-fit IVFPQ must accept the call without
+        # raising or sqlite-vec writes would be rolled back too.
+        rng = np.random.default_rng(42)
+        ids = list(range(10))
+        vectors = rng.standard_normal((10, 384)).astype(np.float32)
+        # Should not raise.
+        backend.add_batch(ids, vectors)
+        # Still 0 routable vectors because we never fit().
+        assert len(backend) == 0
+
+    def test_delete_pre_fit_returns_false(self, backend: IVFPQBackend) -> None:
+        # Pre-fit deletes are no-ops returning False so the caller
+        # knows the snapvec side did not actually remove anything.
+        assert backend.delete(123) is False

--- a/vstash/_ivfpq_backend.py
+++ b/vstash/_ivfpq_backend.py
@@ -1,193 +1,28 @@
-"""IVFPQ backend adapter for VstashStore.
+"""Compatibility shim. The real module lives at
+:mod:`vstash.vectorbackend.snapvec_ivfpq` since v0.37.
 
-Wraps snapvec.IVFPQSnapIndex so it can slot into the same hot-path that
-the flat SnapIndex uses. The key adaptation is that IVFPQ requires an
-explicit `fit()` call on a training sample before the first `add_batch`;
-the adapter tracks fitted state and forwards a consistent API.
+Importing from here continues to work but is deprecated. New code
+should use::
 
-Lifecycle:
-    1. Store is created with vector_backend="snapvec-ivfpq". The .snpi
-       file does not exist yet, so IVFPQBackend(fitted=False). sqlite-vec
-       receives every chunk as usual (dual-population).
-    2. Search falls back to sqlite-vec while len(backend) == 0 (matches
-       the existing `elif self._snap is not None and len(self._snap) > 0`
-       branch in VstashStore.search).
-    3. User runs `vstash snapvec fit`. The CLI reads all embeddings from
-       vec_chunks, calls backend.fit(sample) + backend.add_batch(all),
-       backend.save(path).
-    4. On next store open, IVFPQBackend.load() reads the .snpi and the
-       presence of the file is authoritative for fitted state.
-    5. Post-fit add_document calls are forwarded to the fitted index.
-    6. Deletes forward through in all states (no-op before fit).
+    from vstash.vectorbackend import IVFPQBackend
+    # or
+    from vstash.vectorbackend.snapvec_ivfpq import IVFPQBackend
+
+This shim will be removed in v0.40.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+import warnings
 
-import numpy as np
+from .vectorbackend.snapvec_ivfpq import IVFPQBackend
 
+warnings.warn(
+    "vstash._ivfpq_backend is deprecated; import IVFPQBackend from "
+    "vstash.vectorbackend (or vstash.vectorbackend.snapvec_ivfpq). "
+    "This shim will be removed in v0.40.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-class IVFPQBackend:
-    """Thin adapter around snapvec.IVFPQSnapIndex with pre-fit safe API.
-
-    Attributes mirror SnapIndex where the search hot-path reads them,
-    so VstashStore does not need a type switch on the snap object.
-
-    The underlying IVFPQSnapIndex is built with ``normalized=True``
-    (cosine scoring assumes unit-length inputs), so this adapter
-    L2-normalizes at every entry point — fit, add_batch, and search.
-    """
-
-    def __init__(
-        self,
-        dim: int,
-        *,
-        nlist: int,
-        M: int = 96,
-        K: int = 256,
-        seed: int = 0,
-        keep_full_precision: bool = True,
-        rerank_candidates: int = 100,
-        nprobe: int = 0,
-    ) -> None:
-        from snapvec import IVFPQSnapIndex
-
-        if dim % M != 0:
-            raise ValueError(
-                f"ivfpq_M={M} must divide embedding_dim={dim}. "
-                f"Pick a divisor (e.g. 96 for dim=384, 128 for dim=1024)."
-            )
-        self.dim = dim
-        self._nlist = nlist
-        self._M = M
-        self._K = K
-        self._seed = seed
-        self._keep_full_precision = keep_full_precision
-        self._rerank_candidates = rerank_candidates
-        self._nprobe = nprobe
-        self._index = IVFPQSnapIndex(
-            dim=dim,
-            nlist=nlist,
-            M=M,
-            K=K,
-            seed=seed,
-            normalized=True,
-            use_rht=False,
-            keep_full_precision=keep_full_precision,
-        )
-        self._fitted: bool = False
-
-    # ------------------------------------------------------------------ #
-    # state                                                               #
-    # ------------------------------------------------------------------ #
-
-    @property
-    def fitted(self) -> bool:
-        return self._fitted
-
-    def __len__(self) -> int:
-        # Before fit, the index has no routable vectors — report 0 so the
-        # store's search code falls through to sqlite-vec.
-        return len(self._index) if self._fitted else 0
-
-    # ------------------------------------------------------------------ #
-    # normalization                                                       #
-    # ------------------------------------------------------------------ #
-
-    @staticmethod
-    def _normalize(x: np.ndarray) -> np.ndarray:
-        x = np.asarray(x, dtype=np.float32)
-        if x.ndim == 1:
-            norm = float(np.linalg.norm(x))
-            return x / norm if norm > 1e-9 else x
-        norms = np.linalg.norm(x, axis=1, keepdims=True)
-        return x / np.where(norms > 1e-9, norms, 1.0)
-
-    # ------------------------------------------------------------------ #
-    # training and build                                                  #
-    # ------------------------------------------------------------------ #
-
-    def fit(self, training_vectors: np.ndarray) -> None:
-        if self._fitted:
-            raise RuntimeError("IVFPQBackend already fitted")
-        self._index.fit(self._normalize(training_vectors))
-        self._fitted = True
-
-    def add_batch(self, ids: list[Any], vectors: np.ndarray) -> None:
-        if not self._fitted:
-            # Silently drop pre-fit adds. sqlite-vec is the source of
-            # truth until fit() runs and the CLI repopulates from there.
-            return
-        self._index.add_batch(list(ids), self._normalize(vectors))
-
-    def delete(self, id_: Any) -> bool:
-        if not self._fitted:
-            return False
-        return self._index.delete(id_)
-
-    # ------------------------------------------------------------------ #
-    # search                                                              #
-    # ------------------------------------------------------------------ #
-
-    def search(self, query: np.ndarray, k: int = 10) -> list[tuple[Any, float]]:
-        if not self._fitted:
-            return []
-        kwargs: dict[str, Any] = {}
-        if self._nprobe > 0:
-            kwargs["nprobe"] = self._nprobe
-        if self._rerank_candidates > 0 and self._keep_full_precision:
-            kwargs["rerank_candidates"] = max(self._rerank_candidates, k)
-        results = self._index.search(self._normalize(query), k=k, **kwargs)
-        # IVFPQ returns similarity scores, not cosine distance. Convert
-        # to a pseudo-distance in [0, 2] so downstream relevance_tier()
-        # and ranking heuristics keep working. cosine_dist = 1 - cos_sim.
-        return [(id_, max(0.0, 1.0 - float(score))) for id_, score in results]
-
-    # ------------------------------------------------------------------ #
-    # persistence                                                         #
-    # ------------------------------------------------------------------ #
-
-    def save(self, path: str) -> None:
-        if self._fitted:
-            self._index.save(path)
-
-    @classmethod
-    def load(
-        cls,
-        path: str,
-        *,
-        dim: int,
-        nlist: int,
-        M: int = 96,
-        K: int = 256,
-        seed: int = 0,
-        keep_full_precision: bool = True,
-        rerank_candidates: int = 100,
-        nprobe: int = 0,
-    ) -> IVFPQBackend:
-        """Load a fitted index from disk, or return an unfit backend.
-
-        The presence of the index file is authoritative: if ``path``
-        exists it's treated as a fitted index. This avoids the split
-        between an index file and a sidecar flag getting out of sync
-        after a crash. Constructor validation (dim % M) still runs via
-        the normal ``__init__`` path.
-        """
-        from snapvec import IVFPQSnapIndex
-
-        backend = cls(
-            dim=dim,
-            nlist=nlist,
-            M=M,
-            K=K,
-            seed=seed,
-            keep_full_precision=keep_full_precision,
-            rerank_candidates=rerank_candidates,
-            nprobe=nprobe,
-        )
-        if Path(path).exists():
-            backend._index = IVFPQSnapIndex.load(path)
-            backend._fitted = True
-        return backend
+__all__ = ["IVFPQBackend"]

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -399,7 +399,7 @@ class VstashStore:
             self._vector_backend = "sqlite-vec"
             return
 
-        from ._ivfpq_backend import IVFPQBackend
+        from .vectorbackend.snapvec_ivfpq import IVFPQBackend
 
         nlist = self._ivfpq_nlist or self._derive_nlist()
         kwargs = dict(
@@ -459,7 +459,7 @@ class VstashStore:
 
         import numpy as np
 
-        from ._ivfpq_backend import IVFPQBackend
+        from .vectorbackend.snapvec_ivfpq import IVFPQBackend
 
         # Stream vec_chunks into a pre-allocated float32 matrix so peak
         # memory stays bounded at ~N * dim * 4 bytes (e.g. ~150 MB at
@@ -2285,7 +2285,7 @@ class VstashStore:
                 #   conversion here.
                 # - ``snapvec-ivfpq`` (``IVFPQBackend``) already
                 #   applies ``1 - similarity`` inside its own
-                #   ``search()`` (see ``_ivfpq_backend.py``) and
+                #   ``search()`` (see ``vectorbackend/snapvec_ivfpq.py``) and
                 #   must not be double-inverted.
                 #
                 # ``min / max`` clamps keep the invariant that

--- a/vstash/vectorbackend/__init__.py
+++ b/vstash/vectorbackend/__init__.py
@@ -1,0 +1,39 @@
+"""vstash.vectorbackend -- pluggable ANN backend adapters.
+
+vstash supports three vector index backends today: sqlite-vec
+(default, embedded in :class:`vstash.store.VstashStore` via the
+``vec_chunks`` virtual table), snapvec (flat quantized), and
+snapvec-ivfpq (IVF + product quantization with optional fp16
+rerank). Historically each backend was wired into the store via a
+hand-rolled if/elif chain (``_init_snapvec``, ``_init_ivfpq``,
+``_save_snapvec``, ``_rebuild_snapvec_from_vec_chunks``, etc.),
+which made adding or auditing a backend a per-call-site exercise.
+
+This package defines a single :class:`VectorBackend` Protocol that
+every backend implements: ``add_batch``, ``search``, ``delete``,
+``save``, ``load``, ``__len__``. The store calls into the protocol;
+backend-specific lifecycle (fit, training-sample sizing) lives on
+the concrete adapter and is invoked through the same handle.
+
+Migration is staged across multiple PRs to keep risk bounded:
+
+- v0.37 (this package): Protocol defined; IVFPQ adapter moved here
+  from ``vstash/_ivfpq_backend.py`` (with a deprecated re-export
+  shim). sqlite-vec stays embedded in the store; snapvec flat
+  stays inline. Behaviour is unchanged.
+- v0.38 (follow-up): extract snapvec flat into
+  ``vectorbackend/snapvec_flat.py``.
+- v0.39+ (later): consider extracting sqlite-vec; lower priority
+  because the virtual-table integration is already encapsulated by
+  the existing SQL queries.
+"""
+
+from __future__ import annotations
+
+from .base import VectorBackend
+from .snapvec_ivfpq import IVFPQBackend
+
+__all__ = [
+    "IVFPQBackend",
+    "VectorBackend",
+]

--- a/vstash/vectorbackend/__init__.py
+++ b/vstash/vectorbackend/__init__.py
@@ -11,9 +11,12 @@ which made adding or auditing a backend a per-call-site exercise.
 
 This package defines a single :class:`VectorBackend` Protocol that
 every backend implements: ``add_batch``, ``search``, ``delete``,
-``save``, ``load``, ``__len__``. The store calls into the protocol;
-backend-specific lifecycle (fit, training-sample sizing) lives on
-the concrete adapter and is invoked through the same handle.
+``save``, ``__len__``. The store calls into the protocol; backend-
+specific lifecycle (``fit``, ``load`` factory, training-sample
+sizing) lives on the concrete adapter rather than on the protocol
+because the call patterns differ per backend (sqlite-vec persists
+implicitly via the SQLite file, snapvec backends round-trip a
+binary blob, IVFPQ requires an explicit ``fit`` before adds).
 
 Migration is staged across multiple PRs to keep risk bounded:
 

--- a/vstash/vectorbackend/base.py
+++ b/vstash/vectorbackend/base.py
@@ -29,10 +29,15 @@ Notes on shape:
 - ``__len__`` returns the count of *routable* vectors, which is 0
   before an IVFPQ index has been fit() even though the underlying
   storage may already hold all chunks.
-- ``save`` and ``load`` work with a path string. snapvec backends
-  write a single binary blob; sqlite-vec persists implicitly via
-  the SQLite database file, so its adapter (when extracted) will
-  no-op these methods.
+- ``save`` works with a path string. snapvec backends write a
+  single binary blob; sqlite-vec persists implicitly via the SQLite
+  database file, so its adapter (when extracted) will no-op
+  ``save``. ``load`` is intentionally NOT in the protocol: it is
+  a backend-specific factory (returns a new instance, takes
+  per-backend configuration kwargs) rather than an instance method,
+  so it lives on the concrete adapter class. The store's
+  registry-driven construction calls each adapter's ``load``
+  classmethod directly when reopening from disk.
 """
 
 from __future__ import annotations

--- a/vstash/vectorbackend/base.py
+++ b/vstash/vectorbackend/base.py
@@ -1,0 +1,95 @@
+"""vstash.vectorbackend.base -- the VectorBackend Protocol.
+
+Every concrete vector backend that vstash speaks to (sqlite-vec,
+snapvec flat, snapvec-ivfpq) presents the same shape to the store
+hot path. This Protocol pins that shape so the store does not need
+backend-specific type switches and a future contributor can add a
+new backend by implementing the protocol plus a registration entry
+in :mod:`vstash.vectorbackend`.
+
+The protocol is structural (``Protocol`` from :mod:`typing`), so
+existing classes that already match the shape (such as
+:class:`vstash.vectorbackend.snapvec_ivfpq.IVFPQBackend`) satisfy
+it without inheritance. ``runtime_checkable`` lets adapters that
+want a defensive ``isinstance(b, VectorBackend)`` assert it.
+
+Notes on shape:
+
+- ``add_batch(ids, vectors)`` accepts a list of opaque chunk-id
+  values plus an array of vectors. Vector arrays are typed
+  ``np.ndarray`` rather than ``Sequence[Sequence[float]]`` because
+  every existing implementation does numpy work internally and
+  enforcing the type at the protocol surface saves redundant
+  conversions.
+- ``search(query, k)`` returns ``list[tuple[id, distance]]``.
+  Distance semantics are cosine in [0, 2] for snapvec backends
+  (after the similarity-to-distance conversion in
+  ``IVFPQBackend.search``) and squared cosine for sqlite-vec under
+  schema v2.
+- ``__len__`` returns the count of *routable* vectors, which is 0
+  before an IVFPQ index has been fit() even though the underlying
+  storage may already hold all chunks.
+- ``save`` and ``load`` work with a path string. snapvec backends
+  write a single binary blob; sqlite-vec persists implicitly via
+  the SQLite database file, so its adapter (when extracted) will
+  no-op these methods.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+
+@runtime_checkable
+class VectorBackend(Protocol):
+    """Structural protocol every vector backend implements.
+
+    Concrete implementations:
+
+    - :class:`vstash.vectorbackend.snapvec_ivfpq.IVFPQBackend` --
+      IVF + product quantization with optional fp16 rerank.
+      Requires an explicit ``fit`` call before adds; this is a
+      backend-specific lifecycle that the protocol does not
+      surface (callers that need it know they instantiated an
+      IVFPQ adapter).
+    - snapvec flat (extracted in a follow-up PR).
+    - sqlite-vec (extracted in a later PR if the cost/benefit
+      proves out -- the virtual-table integration in
+      :class:`vstash.store.VstashStore` is already encapsulated
+      by the existing SQL queries, so the win is marginal).
+    """
+
+    dim: int
+
+    def __len__(self) -> int:
+        """Routable vector count.
+
+        Returns 0 for unfit IVFPQ adapters even when chunks exist
+        upstream. This contract lets the store fall back to
+        sqlite-vec while a snapvec index is being trained.
+        """
+        ...
+
+    def add_batch(self, ids: list[Any], vectors: np.ndarray) -> None:
+        """Insert ``len(ids)`` vectors. Pre-fit IVFPQ silently no-ops."""
+        ...
+
+    def delete(self, id_: Any) -> bool:
+        """Remove the vector with key ``id_``. Returns True if found."""
+        ...
+
+    def search(self, query: np.ndarray, k: int = 10) -> list[tuple[Any, float]]:
+        """Return the ``k`` nearest neighbours as ``[(id, distance), ...]``.
+
+        Distance is cosine in [0, 2] for snapvec backends, squared
+        cosine for sqlite-vec under schema v2. Empty list if the
+        backend is not yet ready to answer (pre-fit IVFPQ).
+        """
+        ...
+
+    def save(self, path: str) -> None:
+        """Persist the index to ``path``. No-op for adapters that
+        store their state in the SQLite file."""
+        ...

--- a/vstash/vectorbackend/snapvec_ivfpq.py
+++ b/vstash/vectorbackend/snapvec_ivfpq.py
@@ -1,0 +1,193 @@
+"""IVFPQ backend adapter for VstashStore.
+
+Wraps snapvec.IVFPQSnapIndex so it can slot into the same hot-path that
+the flat SnapIndex uses. The key adaptation is that IVFPQ requires an
+explicit `fit()` call on a training sample before the first `add_batch`;
+the adapter tracks fitted state and forwards a consistent API.
+
+Lifecycle:
+    1. Store is created with vector_backend="snapvec-ivfpq". The .snpi
+       file does not exist yet, so IVFPQBackend(fitted=False). sqlite-vec
+       receives every chunk as usual (dual-population).
+    2. Search falls back to sqlite-vec while len(backend) == 0 (matches
+       the existing `elif self._snap is not None and len(self._snap) > 0`
+       branch in VstashStore.search).
+    3. User runs `vstash snapvec fit`. The CLI reads all embeddings from
+       vec_chunks, calls backend.fit(sample) + backend.add_batch(all),
+       backend.save(path).
+    4. On next store open, IVFPQBackend.load() reads the .snpi and the
+       presence of the file is authoritative for fitted state.
+    5. Post-fit add_document calls are forwarded to the fitted index.
+    6. Deletes forward through in all states (no-op before fit).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+class IVFPQBackend:
+    """Thin adapter around snapvec.IVFPQSnapIndex with pre-fit safe API.
+
+    Attributes mirror SnapIndex where the search hot-path reads them,
+    so VstashStore does not need a type switch on the snap object.
+
+    The underlying IVFPQSnapIndex is built with ``normalized=True``
+    (cosine scoring assumes unit-length inputs), so this adapter
+    L2-normalizes at every entry point — fit, add_batch, and search.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        *,
+        nlist: int,
+        M: int = 96,
+        K: int = 256,
+        seed: int = 0,
+        keep_full_precision: bool = True,
+        rerank_candidates: int = 100,
+        nprobe: int = 0,
+    ) -> None:
+        from snapvec import IVFPQSnapIndex
+
+        if dim % M != 0:
+            raise ValueError(
+                f"ivfpq_M={M} must divide embedding_dim={dim}. "
+                f"Pick a divisor (e.g. 96 for dim=384, 128 for dim=1024)."
+            )
+        self.dim = dim
+        self._nlist = nlist
+        self._M = M
+        self._K = K
+        self._seed = seed
+        self._keep_full_precision = keep_full_precision
+        self._rerank_candidates = rerank_candidates
+        self._nprobe = nprobe
+        self._index = IVFPQSnapIndex(
+            dim=dim,
+            nlist=nlist,
+            M=M,
+            K=K,
+            seed=seed,
+            normalized=True,
+            use_rht=False,
+            keep_full_precision=keep_full_precision,
+        )
+        self._fitted: bool = False
+
+    # ------------------------------------------------------------------ #
+    # state                                                               #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def fitted(self) -> bool:
+        return self._fitted
+
+    def __len__(self) -> int:
+        # Before fit, the index has no routable vectors — report 0 so the
+        # store's search code falls through to sqlite-vec.
+        return len(self._index) if self._fitted else 0
+
+    # ------------------------------------------------------------------ #
+    # normalization                                                       #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _normalize(x: np.ndarray) -> np.ndarray:
+        x = np.asarray(x, dtype=np.float32)
+        if x.ndim == 1:
+            norm = float(np.linalg.norm(x))
+            return x / norm if norm > 1e-9 else x
+        norms = np.linalg.norm(x, axis=1, keepdims=True)
+        return x / np.where(norms > 1e-9, norms, 1.0)
+
+    # ------------------------------------------------------------------ #
+    # training and build                                                  #
+    # ------------------------------------------------------------------ #
+
+    def fit(self, training_vectors: np.ndarray) -> None:
+        if self._fitted:
+            raise RuntimeError("IVFPQBackend already fitted")
+        self._index.fit(self._normalize(training_vectors))
+        self._fitted = True
+
+    def add_batch(self, ids: list[Any], vectors: np.ndarray) -> None:
+        if not self._fitted:
+            # Silently drop pre-fit adds. sqlite-vec is the source of
+            # truth until fit() runs and the CLI repopulates from there.
+            return
+        self._index.add_batch(list(ids), self._normalize(vectors))
+
+    def delete(self, id_: Any) -> bool:
+        if not self._fitted:
+            return False
+        return self._index.delete(id_)
+
+    # ------------------------------------------------------------------ #
+    # search                                                              #
+    # ------------------------------------------------------------------ #
+
+    def search(self, query: np.ndarray, k: int = 10) -> list[tuple[Any, float]]:
+        if not self._fitted:
+            return []
+        kwargs: dict[str, Any] = {}
+        if self._nprobe > 0:
+            kwargs["nprobe"] = self._nprobe
+        if self._rerank_candidates > 0 and self._keep_full_precision:
+            kwargs["rerank_candidates"] = max(self._rerank_candidates, k)
+        results = self._index.search(self._normalize(query), k=k, **kwargs)
+        # IVFPQ returns similarity scores, not cosine distance. Convert
+        # to a pseudo-distance in [0, 2] so downstream relevance_tier()
+        # and ranking heuristics keep working. cosine_dist = 1 - cos_sim.
+        return [(id_, max(0.0, 1.0 - float(score))) for id_, score in results]
+
+    # ------------------------------------------------------------------ #
+    # persistence                                                         #
+    # ------------------------------------------------------------------ #
+
+    def save(self, path: str) -> None:
+        if self._fitted:
+            self._index.save(path)
+
+    @classmethod
+    def load(
+        cls,
+        path: str,
+        *,
+        dim: int,
+        nlist: int,
+        M: int = 96,
+        K: int = 256,
+        seed: int = 0,
+        keep_full_precision: bool = True,
+        rerank_candidates: int = 100,
+        nprobe: int = 0,
+    ) -> IVFPQBackend:
+        """Load a fitted index from disk, or return an unfit backend.
+
+        The presence of the index file is authoritative: if ``path``
+        exists it's treated as a fitted index. This avoids the split
+        between an index file and a sidecar flag getting out of sync
+        after a crash. Constructor validation (dim % M) still runs via
+        the normal ``__init__`` path.
+        """
+        from snapvec import IVFPQSnapIndex
+
+        backend = cls(
+            dim=dim,
+            nlist=nlist,
+            M=M,
+            K=K,
+            seed=seed,
+            keep_full_precision=keep_full_precision,
+            rerank_candidates=rerank_candidates,
+            nprobe=nprobe,
+        )
+        if Path(path).exists():
+            backend._index = IVFPQSnapIndex.load(path)
+            backend._fitted = True
+        return backend


### PR DESCRIPTION
## Summary

Sprint 2 step 3. Audit flagged the hand-rolled vector-backend dispatch in \`store.py\` (sqlite-vec, snapvec flat, snapvec-ivfpq lifecycles wired via per-backend if/elif chains) as a critical OCP violation. Adding a fourth backend would have meant editing the center.

This PR introduces \`vstash/vectorbackend/\` as the seam, staged conservatively: the Protocol is defined and IVFPQ is the first concrete extraction. snapvec flat and sqlite-vec extractions land later (their lifecycles are more deeply coupled to the store's transactional paths and need separate review).

## Changes

- \`vstash/vectorbackend/base.py\` -- runtime-checkable structural \`VectorBackend\` Protocol with six members: \`dim\`, \`__len__\`, \`add_batch\`, \`delete\`, \`search\`, \`save\`. Distance semantics documented at the protocol surface (cosine in [0, 2] for snapvec, squared cosine for sqlite-vec schema v2). \`__len__ == 0 pre-fit\` is the contract \`VstashStore.search\` depends on to fall back to sqlite-vec.
- \`vstash/vectorbackend/snapvec_ivfpq.py\` -- IVFPQ adapter moved here from \`vstash/_ivfpq_backend.py\` via \`git mv\` so file history is preserved. No behavioural changes.
- \`vstash/vectorbackend/__init__.py\` -- re-exports \`VectorBackend\` + \`IVFPQBackend\`. Documented import path: \`from vstash.vectorbackend import IVFPQBackend\`.
- \`vstash/_ivfpq_backend.py\` -- 25-line compat shim with \`DeprecationWarning\`. Slated for removal in v0.40 (two minors of warning deprecation, matching the #281 cadence).
- \`vstash/store.py\` -- two import sites updated to the new path.
- \`tests/test_snapvec_ivfpq_backend.py\` -- import line updated to the new path.

## Tests

\`tests/test_vectorbackend.py\` (new, 7 tests):

- [x] Re-export contract: IVFPQBackend is one class object reachable via three paths (\`vectorbackend\`, \`vectorbackend.snapvec_ivfpq\`, legacy \`_ivfpq_backend\`).
- [x] Legacy shim emits \`DeprecationWarning\` on import (verified via \`importlib.reload\` + \`warnings.catch_warnings\`).
- [x] IVFPQBackend satisfies the \`runtime_checkable\` Protocol (\`isinstance\` check, attribute presence, pre-fit behaviour for each protocol member).

Smoke: \`pytest test_store + test_snapvec_ivfpq_backend + test_vectorbackend + test_snapvec_backend\` -> 144 / 144 pass in 3.52s. \`ruff check .\` + \`ruff format --check .\` both clean.

## Risk

Low. No semantic changes; only file moves and an additional abstraction layer.

## Follow-ups (separate PRs)

- Extract snapvec flat (currently inline in \`store.py\`: \`_init_snapvec\`, \`_save_snapvec\`, \`_rebuild_snapvec_from_vec_chunks\`, \`_reload_snapvec\`). Bigger surgery -- the lifecycle is coupled to the store's write transactions.
- Decide whether sqlite-vec extraction is worth pursuing. The audit flagged it for OCP cleanliness but the virtual-table integration is already isolated; marginal benefit vs risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * IVFPQ backend migrated to new pluggable `vstash.vectorbackend` architecture; old `vstash._ivfpq_backend` import path deprecated
  * New `VectorBackend` protocol established for custom backend implementations

* **Tests**
  * Comprehensive tests added for vector backend compatibility and protocol adherence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->