### PR TITLE
refactor(embed): replace hardcoded if/elif dispatch with built-in registry

### DIFF
--- a/tests/test_builtin_backend_registry.py
+++ b/tests/test_builtin_backend_registry.py
@@ -95,13 +95,54 @@ class TestResolverDispatch:
         hf_idx = names.index("hf_onnx")
         default_idx = names.index("default")
 
-        # Gemma is checked before hf_onnx (specific before general).
-        assert gemma_idx < default_idx
+        # Strict ordering: gemma is the most specific matcher and
+        # must run first; hf_onnx is the next most specific; default
+        # is always last. Loosening any of these ordering relations
+        # would either let a broader matcher steal a gemma name or
+        # break the catch-all guarantee.
+        assert gemma_idx < hf_idx
         assert hf_idx < default_idx
+        assert default_idx == len(names) - 1
 
-        # Sanity: matchers are pure functions of model_name.
+        # Sanity: matchers are pure functions of model_name and are
+        # mutually exclusive on the model names this project ships.
         assert _is_gemma_model("google/embeddinggemma-300m")
         assert not _is_hf_onnx_model("google/embeddinggemma-300m")
+
+    def test_first_match_wins_when_two_matchers_accept(self) -> None:
+        # Direct test of first-match-wins semantics: insert a fake
+        # broad matcher that also accepts a gemma name and verify
+        # the gemma backend still wins because of registration
+        # order. This catches regressions where a future contributor
+        # inserts a broader matcher ahead of a specific one.
+        from vstash.embed import _BUILTIN_BACKENDS as registry, _resolve_builtin_backend
+
+        spy_calls: list[str] = []
+
+        def _spy_matcher(name: str) -> bool:
+            spy_calls.append(name)
+            return True  # would steal everything if placed first
+
+        spy_entry = _BuiltinBackend(
+            name="spy_broad",
+            matches=_spy_matcher,
+            embed_batch=lambda *a, **kw: [],
+            embed_query=lambda *a, **kw: [],
+            warmup=lambda *a, **kw: None,
+        )
+
+        # Insert AFTER gemma -- gemma should still win for a gemma name.
+        registry.insert(1, spy_entry)
+        try:
+            backend = _resolve_builtin_backend("google/embeddinggemma-300m")
+            assert backend.name == "gemma", (
+                "first-match-wins is broken: spy entry stole a gemma name"
+            )
+            # The spy should never have been consulted because gemma
+            # matched first and the loop short-circuited.
+            assert spy_calls == []
+        finally:
+            registry.remove(spy_entry)
 
 
 class TestPublicDispatch:
@@ -166,6 +207,41 @@ class TestPublicDispatch:
         with patch("vstash.embed._resolve_builtin_backend", return_value=fake_backend):
             warmup("any-model", backend="onnx")
         assert warmup_calls == [("any-model", "onnx")]
+
+    def test_warmup_short_circuits_on_custom_resolver(self) -> None:
+        # warmup() must mirror embed_texts/embed_query: if a custom
+        # encoder resolver claims the model name, the built-in
+        # warmup chain must NOT run -- otherwise we warm onnx/mlx
+        # against a name they do not recognise. Regression test for
+        # a bug introduced when warmup migrated to the registry.
+        from vstash.embed import (
+            register_encoder_resolver,
+            unregister_encoder_resolver,
+            warmup,
+        )
+
+        class _FakeEncoder:
+            embedding_dim = 2
+
+            def encode(self, texts):
+                return [[0.0, 0.0] for _ in texts]
+
+        encoder = _FakeEncoder()
+
+        def resolver(name: str):
+            return encoder if name == "custom-warmup-test" else None
+
+        register_encoder_resolver(resolver)
+        try:
+            with patch(
+                "vstash.embed._resolve_builtin_backend",
+                side_effect=AssertionError("built-in warmup should not run for custom name"),
+            ):
+                # Should not raise: the custom resolver short-circuits
+                # before _resolve_builtin_backend is ever called.
+                warmup("custom-warmup-test", backend="onnx")
+        finally:
+            unregister_encoder_resolver(resolver)
 
     def test_custom_encoder_resolver_wins_over_builtins(self) -> None:
         # Ensure the registry change did not regress the public

--- a/tests/test_builtin_backend_registry.py
+++ b/tests/test_builtin_backend_registry.py
@@ -1,0 +1,234 @@
+"""Tests for the built-in backend registry in :mod:`vstash.embed`.
+
+The registry was introduced in v0.37 to replace the hardcoded
+if/elif chain in ``embed_texts`` / ``embed_query`` / ``warmup``.
+These tests pin the contract:
+
+- The registry is a non-empty list of ``_BuiltinBackend`` entries.
+- The fallback (``name == "default"``) is always last and its
+  matcher returns ``True`` for any model name.
+- ``_resolve_builtin_backend`` walks the list in order and returns
+  the first match.
+- ``embed_texts`` / ``embed_query`` / ``warmup`` all dispatch through
+  the registry rather than re-implementing the if/elif chain.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from vstash.embed import (
+    _BUILTIN_BACKENDS,
+    _BuiltinBackend,
+    _resolve_builtin_backend,
+)
+
+
+class TestRegistryShape:
+    """The registry is the contract; pin its structural invariants."""
+
+    def test_registry_is_non_empty(self) -> None:
+        assert len(_BUILTIN_BACKENDS) > 0
+
+    def test_every_entry_is_builtin_backend(self) -> None:
+        for entry in _BUILTIN_BACKENDS:
+            assert isinstance(entry, _BuiltinBackend)
+
+    def test_fallback_is_last_and_always_matches(self) -> None:
+        # The fallback contract is what makes _resolve_builtin_backend
+        # never raise. If the fallback is ever moved out of last
+        # position, dispatch becomes order-dependent in a way that
+        # breaks the catch-all guarantee.
+        last = _BUILTIN_BACKENDS[-1]
+        assert last.name == "default"
+        assert last.matches("anything")
+        assert last.matches("")
+        assert last.matches("BAAI/bge-small-en-v1.5")
+        assert last.matches("google/embeddinggemma-300m")
+
+    def test_no_duplicate_names(self) -> None:
+        # Names are used in tests and could be used as registry keys
+        # in a future version. Duplicates would be a bug regardless.
+        names = [b.name for b in _BUILTIN_BACKENDS]
+        assert len(names) == len(set(names))
+
+    def test_every_entry_exposes_three_callables(self) -> None:
+        # Every backend must implement all three dispatch surfaces
+        # so the registry walker never needs to None-check.
+        for entry in _BUILTIN_BACKENDS:
+            assert callable(entry.matches)
+            assert callable(entry.embed_batch)
+            assert callable(entry.embed_query)
+            assert callable(entry.warmup)
+
+
+class TestResolverDispatch:
+    """`_resolve_builtin_backend` returns the first matching entry."""
+
+    def test_gemma_model_routes_to_gemma_backend(self) -> None:
+        backend = _resolve_builtin_backend("google/embeddinggemma-300m")
+        assert backend.name == "gemma"
+
+    def test_unknown_model_routes_to_default(self) -> None:
+        # Anything that does not match a specific matcher must fall
+        # through to the catch-all rather than raise.
+        backend = _resolve_builtin_backend("not-a-real-model-name")
+        assert backend.name == "default"
+
+    def test_empty_string_routes_to_default(self) -> None:
+        # Defensive: the matchers should not crash on empty string.
+        # Empty matches no specific backend but must hit the fallback.
+        backend = _resolve_builtin_backend("")
+        assert backend.name == "default"
+
+    def test_dispatch_order_first_match_wins(self) -> None:
+        # If two matchers would both accept a name (currently they do
+        # not, but the contract should hold), the first registered
+        # entry wins. We verify by inspecting the iteration order.
+        from vstash.embed import _is_gemma_model, _is_hf_onnx_model
+
+        # Find each named entry's index.
+        names = [b.name for b in _BUILTIN_BACKENDS]
+        gemma_idx = names.index("gemma")
+        hf_idx = names.index("hf_onnx")
+        default_idx = names.index("default")
+
+        # Gemma is checked before hf_onnx (specific before general).
+        assert gemma_idx < default_idx
+        assert hf_idx < default_idx
+
+        # Sanity: matchers are pure functions of model_name.
+        assert _is_gemma_model("google/embeddinggemma-300m")
+        assert not _is_hf_onnx_model("google/embeddinggemma-300m")
+
+
+class TestPublicDispatch:
+    """`embed_texts` / `embed_query` / `warmup` all walk the registry."""
+
+    def test_embed_texts_dispatches_through_registry(self) -> None:
+        # Patch the resolver and assert embed_texts calls it. The
+        # body returns whatever the matched backend's embed_batch
+        # returns -- here a sentinel list.
+        from vstash.embed import embed_texts
+
+        sentinel = [[1.0, 2.0]]
+        fake_backend = _BuiltinBackend(
+            name="test",
+            matches=lambda _: True,
+            embed_batch=lambda *a, **kw: sentinel,
+            embed_query=lambda *a, **kw: [0.0],
+            warmup=lambda *a, **kw: None,
+        )
+        with (
+            patch("vstash.embed._resolve_builtin_backend", return_value=fake_backend),
+            patch("vstash.embed._resolve_custom_encoder", return_value=None),
+            patch("vstash.embed._check_daemon", return_value=None),
+        ):
+            result = embed_texts(["hello"], "any-model")
+        assert result is sentinel
+
+    def test_embed_query_dispatches_through_registry(self) -> None:
+        from vstash.embed import embed_query
+
+        sentinel = [3.14, 2.71]
+        fake_backend = _BuiltinBackend(
+            name="test",
+            matches=lambda _: True,
+            embed_batch=lambda *a, **kw: [[0.0]],
+            embed_query=lambda *a, **kw: sentinel,
+            warmup=lambda *a, **kw: None,
+        )
+        with (
+            patch("vstash.embed._resolve_builtin_backend", return_value=fake_backend),
+            patch("vstash.embed._resolve_custom_encoder", return_value=None),
+            patch("vstash.embed._check_daemon", return_value=None),
+        ):
+            result = embed_query("hello", "any-model")
+        assert result is sentinel
+
+    def test_warmup_dispatches_through_registry(self) -> None:
+        from vstash.embed import warmup
+
+        warmup_calls: list[tuple] = []
+
+        def _fake_warmup(name: str, backend: str) -> None:
+            warmup_calls.append((name, backend))
+
+        fake_backend = _BuiltinBackend(
+            name="test",
+            matches=lambda _: True,
+            embed_batch=lambda *a, **kw: [[0.0]],
+            embed_query=lambda *a, **kw: [0.0],
+            warmup=_fake_warmup,
+        )
+        with patch("vstash.embed._resolve_builtin_backend", return_value=fake_backend):
+            warmup("any-model", backend="onnx")
+        assert warmup_calls == [("any-model", "onnx")]
+
+    def test_custom_encoder_resolver_wins_over_builtins(self) -> None:
+        # Ensure the registry change did not regress the public
+        # extension hook: a registered custom resolver still runs
+        # before any built-in dispatch happens.
+        from vstash.embed import (
+            embed_texts,
+            register_encoder_resolver,
+            unregister_encoder_resolver,
+        )
+
+        class _FakeEncoder:
+            embedding_dim = 2
+
+            def encode(self, texts):
+                return [[1.0, 2.0] for _ in texts]
+
+        encoder = _FakeEncoder()
+
+        def resolver(name: str):
+            return encoder if name == "claimed-by-custom" else None
+
+        register_encoder_resolver(resolver)
+        try:
+            with (
+                patch(
+                    "vstash.embed._resolve_builtin_backend",
+                    side_effect=AssertionError("built-in dispatch should not run"),
+                ),
+                patch("vstash.embed._check_daemon", return_value=None),
+            ):
+                result = embed_texts(["x", "y"], "claimed-by-custom")
+            assert result == [[1.0, 2.0], [1.0, 2.0]]
+        finally:
+            unregister_encoder_resolver(resolver)
+
+
+class TestRegressionsAgainstOldDispatch:
+    """The new dispatch must produce the same routing as the old chain.
+
+    This locks the v0.36 -> v0.37 migration: gemma names go to the
+    gemma backend, the rest go through the onnx/mlx fallback. If a
+    future contributor accidentally swaps the registry order or
+    registers a new backend with too-loose a matcher, these tests
+    catch the regression before BEIR results drift.
+    """
+
+    @pytest.mark.parametrize(
+        ("model_name", "expected_name"),
+        [
+            ("google/embeddinggemma-300m", "gemma"),
+            # bge models go through the default (onnx/mlx) backend,
+            # not hf_onnx -- the hf_onnx heuristic is reserved for the
+            # short-lived HF ONNX adapter we shipped in v0.32.
+            ("BAAI/bge-small-en-v1.5", "default"),
+            ("BAAI/bge-base-en-v1.5", "default"),
+            ("nomic-ai/nomic-embed-text-v1.5", "default"),
+            ("Stffens/bge-small-rrf-v3", "default"),
+            ("intfloat/multilingual-e5-small", "default"),
+        ],
+    )
+    def test_known_model_routing(self, model_name: str, expected_name: str) -> None:
+        backend = _resolve_builtin_backend(model_name)
+        assert backend.name == expected_name, (
+            f"{model_name} resolved to {backend.name!r}, expected {expected_name!r}"
+        )

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -900,6 +900,13 @@ def warmup(model_name: str, backend: BackendType = "auto") -> None:
         model_name: Model identifier.
         backend: Backend to use — 'onnx', 'mlx', or 'auto'.
     """
+    # Custom resolvers win over every built-in path (mirrors the
+    # short-circuit in embed_texts / embed_query). A registered custom
+    # encoder is responsible for its own initialization on first
+    # `.encode()` call, so we simply skip built-in warmup rather than
+    # warming the wrong backend with an unrecognised model name.
+    if _resolve_custom_encoder(model_name) is not None:
+        return
     _resolve_builtin_backend(model_name).warmup(model_name, backend)
 
 

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -20,8 +20,9 @@ import os
 import platform
 import threading
 import urllib.request
-from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from fastembed import TextEmbedding
@@ -753,6 +754,145 @@ def _resolve(backend: BackendType = "auto") -> Literal["onnx", "mlx"]:
     return _active_backend
 
 
+# ------------------------------------------------------------------ #
+# Built-in backend registry                                            #
+# ------------------------------------------------------------------ #
+#
+# The model-name -> embedding-impl dispatch used to live as a hardcoded
+# if/elif chain in embed_texts / embed_query / warmup. Adding a new
+# built-in family (e.g. another HF model variant) meant editing all
+# three sites in lock-step and risked drift. The audit (2026-04-30)
+# flagged this as an OCP violation.
+#
+# Now: a single ordered registry of (matcher, embed_batch, embed_query,
+# warmup) tuples. The dispatch loop iterates the registry; the first
+# matcher that returns True wins. The fallback entry has a matcher
+# that always returns True and resolves onnx vs mlx internally; it
+# must stay last in the list.
+#
+# This is internal: the public extension hook for users is still
+# `register_encoder_resolver`. The built-in registry exists so the
+# project's own backends compose by the same pattern (data, not
+# branches) rather than three sites of hand-rolled dispatch.
+
+
+def _gemma_batch(texts: list[str], model_name: str, _backend: BackendType) -> list[list[float]]:
+    return _embed_gemma(texts, model_name)
+
+
+def _gemma_query(text: str, model_name: str, _backend: BackendType) -> list[float]:
+    return _query_gemma(text, model_name)
+
+
+def _gemma_warmup(model_name: str, _backend: BackendType) -> None:
+    _warmup_gemma(model_name)
+
+
+def _hf_onnx_batch(texts: list[str], model_name: str, _backend: BackendType) -> list[list[float]]:
+    return _embed_hf_onnx(texts, model_name)
+
+
+def _hf_onnx_query(text: str, model_name: str, _backend: BackendType) -> list[float]:
+    return _query_hf_onnx(text, model_name)
+
+
+def _hf_onnx_warmup(model_name: str, _backend: BackendType) -> None:
+    _warmup_hf_onnx(model_name)
+
+
+def _default_batch(texts: list[str], model_name: str, backend: BackendType) -> list[list[float]]:
+    """Fallback batch embedder: routes through onnx or mlx based on _resolve()."""
+    resolved = _resolve(backend)
+    if resolved == "mlx":
+        return _embed_mlx(texts, model_name)
+    return _embed_onnx(texts, model_name)
+
+
+def _default_query(text: str, model_name: str, backend: BackendType) -> list[float]:
+    """Fallback single-query embedder: same dispatch as :func:`_default_batch`."""
+    resolved = _resolve(backend)
+    if resolved == "mlx":
+        return _query_mlx(text, model_name)
+    return _query_onnx(text, model_name)
+
+
+def _default_warmup(model_name: str, backend: BackendType) -> None:
+    resolved = _resolve(backend)
+    if resolved == "mlx":
+        _warmup_mlx(model_name)
+    else:
+        _warmup_onnx(model_name)
+
+
+def _matches_default(_model_name: str) -> bool:
+    """Always-true matcher for the fallback entry. Stays last in the list."""
+    return True
+
+
+@dataclass(frozen=True)
+class _BuiltinBackend:
+    """A built-in embedding backend identified by a model-name matcher.
+
+    The dispatch loop in :func:`embed_texts`, :func:`embed_query`, and
+    :func:`warmup` iterates :data:`_BUILTIN_BACKENDS` in order; the
+    first ``matches`` that returns ``True`` wins. Every entry exposes
+    the same three callables so the dispatch loop never branches on
+    which kind of backend it is calling.
+    """
+
+    name: str
+    matches: Callable[[str], bool]
+    embed_batch: Callable[[list[str], str, BackendType], list[list[float]]]
+    embed_query: Callable[[str, str, BackendType], list[float]]
+    warmup: Callable[[str, BackendType], None]
+
+
+#: Built-in backends in dispatch order. The last entry is the
+#: catch-all fallback (onnx vs mlx, resolved per-platform); it must
+#: stay last because its matcher always returns ``True``.
+_BUILTIN_BACKENDS: list[_BuiltinBackend] = [
+    _BuiltinBackend(
+        name="gemma",
+        matches=_is_gemma_model,
+        embed_batch=_gemma_batch,
+        embed_query=_gemma_query,
+        warmup=_gemma_warmup,
+    ),
+    _BuiltinBackend(
+        name="hf_onnx",
+        matches=_is_hf_onnx_model,
+        embed_batch=_hf_onnx_batch,
+        embed_query=_hf_onnx_query,
+        warmup=_hf_onnx_warmup,
+    ),
+    _BuiltinBackend(
+        name="default",
+        matches=_matches_default,
+        embed_batch=_default_batch,
+        embed_query=_default_query,
+        warmup=_default_warmup,
+    ),
+]
+
+
+def _resolve_builtin_backend(model_name: str) -> _BuiltinBackend:
+    """Return the first built-in backend whose matcher accepts ``model_name``.
+
+    The fallback entry (matcher returns ``True`` for any name) is
+    always last in the list, so this function never raises -- it
+    always returns at least the fallback. The explicit ``raise`` at
+    the bottom is a defensive guard against a future edit that
+    accidentally removes the fallback.
+    """
+    for be in _BUILTIN_BACKENDS:
+        if be.matches(model_name):
+            return be
+    raise RuntimeError(
+        f"No built-in backend matched {model_name!r}; the default "
+        "fallback entry is missing from _BUILTIN_BACKENDS."
+    )
+
+
 def warmup(model_name: str, backend: BackendType = "auto") -> None:
     """Pre-load the embedding model to eliminate cold start latency.
 
@@ -760,17 +900,7 @@ def warmup(model_name: str, backend: BackendType = "auto") -> None:
         model_name: Model identifier.
         backend: Backend to use — 'onnx', 'mlx', or 'auto'.
     """
-    if _is_gemma_model(model_name):
-        _warmup_gemma(model_name)
-        return
-    if _is_hf_onnx_model(model_name):
-        _warmup_hf_onnx(model_name)
-        return
-    resolved = _resolve(backend)
-    if resolved == "mlx":
-        _warmup_mlx(model_name)
-    else:
-        _warmup_onnx(model_name)
+    _resolve_builtin_backend(model_name).warmup(model_name, backend)
 
 
 # ------------------------------------------------------------------ #
@@ -919,14 +1049,7 @@ def embed_texts(
         if result is not None and len(result) == len(texts):
             return result
 
-    if _is_gemma_model(model_name):
-        return _embed_gemma(texts, model_name)
-    if _is_hf_onnx_model(model_name):
-        return _embed_hf_onnx(texts, model_name)
-    resolved = _resolve(backend)
-    if resolved == "mlx":
-        return _embed_mlx(texts, model_name)
-    return _embed_onnx(texts, model_name)
+    return _resolve_builtin_backend(model_name).embed_batch(texts, model_name, backend)
 
 
 def embed_query(
@@ -959,14 +1082,7 @@ def embed_query(
         if result is not None:
             return result
 
-    if _is_gemma_model(model_name):
-        return _query_gemma(text, model_name)
-    if _is_hf_onnx_model(model_name):
-        return _query_hf_onnx(text, model_name)
-    resolved = _resolve(backend)
-    if resolved == "mlx":
-        return _query_mlx(text, model_name)
-    return _query_onnx(text, model_name)
+    return _resolve_builtin_backend(model_name).embed_query(text, model_name, backend)
 
 
 def get_active_backend() -> str:


### PR DESCRIPTION
## Summary

Sprint 2 step 4. The embed-side dispatch was the second OCP violation flagged by the audit (after vector backends). Adding a new built-in family meant editing three sites in lock-step:

\`\`\`
embed_texts:  if _is_gemma_model(...): _embed_gemma(...)
              elif _is_hf_onnx_model(...): _embed_hf_onnx(...)
              else: _embed_mlx / _embed_onnx

embed_query:  same chain, parallel
warmup:       same chain, parallel
\`\`\`

The custom-encoder hook (\`register_encoder_resolver\`, #278/#287) was a step in the right direction, but the project's own backends never composed by the same pattern.

## What changed

Replace the chain with a single ordered registry of frozen \`_BuiltinBackend\` dataclass entries. Each entry exposes \`matches\`, \`embed_batch\`, \`embed_query\`, \`warmup\`. The dispatch loop walks the list; first matcher to return \`True\` wins. Fallback entry has a matcher that unconditionally returns \`True\` and resolves onnx vs mlx internally; it must stay last (a regression test pins this).

- \`embed_texts\` body: 8 lines of if/elif + \`return _embed_*(...)\` -> a single \`return _resolve_builtin_backend(model_name).embed_batch(texts, model_name, backend)\` call.
- \`embed_query\` and \`warmup\` similarly collapse.
- Adding a fourth built-in is now a one-line append to \`_BUILTIN_BACKENDS\` (matcher + 3 thin adapter functions) instead of editing 3 sites.

## Public API unchanged

- \`register_encoder_resolver\` and \`unregister_encoder_resolver\` keep their existing semantics. Custom encoders still win over every built-in path. The new registry is internal to the project's own backends; it does not affect the documented user extension hook.
- \`embed_texts(texts, model_name, backend='auto')\`, \`embed_query(...)\`, \`warmup(...)\` keep their signatures.

## Test plan

\`tests/test_builtin_backend_registry.py\` (new, 19 tests):

- [x] Registry shape: non-empty, every entry is \`_BuiltinBackend\`, fallback is last and always matches, no duplicate names, every entry exposes the three required callables.
- [x] Dispatch: gemma -> gemma backend, unknown -> default, empty string -> default, first-match-wins enforced via index ordering.
- [x] Public dispatch: \`embed_texts\` / \`embed_query\` / \`warmup\` all walk the registry (mock + sentinel return).
- [x] Custom resolver still wins over built-ins (regression guard on the public hook).
- [x] Parametrized regression test pins the v0.36 -> v0.37 routing for known model names: \`google/embeddinggemma\` -> gemma, \`BAAI/bge-*\` / \`nomic\` / \`Stffens\` / \`multilingual-e5\` -> default.

Broader smoke: 199 / 199 in \`test_encoder_resolver + test_embed + test_store + test_services + test_memory\` pass in 2:03. \`ruff check .\` + \`ruff format --check .\` both clean.

## Risk

Low. No semantic change to dispatch routing -- the registry encodes exactly the same matcher logic the old chain had. The parametrized regression test enumerates the public model names the project ships against (BGE, nomic, Stffens, gemma) and asserts each routes to the same backend it routed to before this PR.

## Closes Sprint 2

This is item 4 of the Sprint 2 plan (errors / services / vectorbackend / embed registry). Sprint 2 is now complete. Follow-ups remain in the original audit punch list (split \`store.py\` #280, split \`cli.py\` #284) but those are larger refactors that benefit from having errors / services / vectorbackend / embed-registry seams in place first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite validating backend routing, uniqueness, ordering, first-match short-circuiting, and that public embedding/warmup calls dispatch to the selected backend (with custom encoder resolvers taking precedence).

* **Refactor**
  * Consolidated backend selection into a single ordered registry for consistent matching and fallback; unified embedding and warmup paths to use that registry and respect custom resolvers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->