### PR TITLE
fix(#329): IVFPQ load detects stale .snpi vs vec_chunks and downgrades

### DIFF
--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -352,3 +352,95 @@ class TestVstashStoreIVFPQIntegration:
         results = store3.search(v1[0].tolist(), "c0", top_k=3)
         assert len(results) > 0
         store3.close()
+
+    def test_stale_ivfpq_index_downgrades_after_delete_too(self, tmp_path, caplog):
+        """Issue #329 (CR follow-up): asymmetric mismatch must also fire.
+
+        The reverse case of test_stale_ivfpq_index_downgrades_to_unfitted:
+        if a crash leaves ``.snpi`` LARGER than ``vec_chunks`` (delete
+        happened, .snpi flush did not), the index still carries
+        tombstoned ids. Those consume ANN candidate slots and reduce
+        recall because hits get filtered out at the path-resolution
+        stage. CodeRabbit caught this asymmetry on PR #332. The init
+        path must treat ``sqlite_n != snap_n`` as stale, not just
+        ``sqlite_n > snap_n``.
+
+        Repro:
+
+        1. Open, ingest 2 batches, fit, close (.snpi has N + 50).
+        2. Reopen, delete one batch's rows from vec_chunks via SQL
+           (mimicking a delete that did not yet reach the snap save).
+        3. Drop snap + close conn without store.close().
+        4. Reopen. .snpi has N+50 entries; vec_chunks has N. The
+           init path must downgrade.
+        """
+        import logging
+
+        db_path = str(tmp_path / "stale_delete.db")
+
+        store1 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        rng = np.random.default_rng(11)
+        v1 = _unit_vectors(rng, N, DIM)
+        v2 = _unit_vectors(rng, 50, DIM)
+        store1.add_document(
+            path="/t/keep.md",
+            title="keep",
+            chunks=[f"k{i}" for i in range(N)],
+            embeddings=v1.tolist(),
+            source_type="text",
+        )
+        store1.add_document(
+            path="/t/extra.md",
+            title="extra",
+            chunks=[f"e{i}" for i in range(50)],
+            embeddings=v2.tolist(),
+            source_type="text",
+        )
+        store1.fit_ivfpq(training_sample=N + 50)
+        store1.close()  # .snpi has N + 50.
+
+        # 2. Reopen and delete the "extra" doc via the public API,
+        # but skip the snap-save flush by dropping the reference and
+        # closing the conn directly.
+        store2 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        assert store2._snap.fitted
+        assert len(store2._snap) == N + 50
+        # Delete the extra doc -- vec_chunks loses 50 rows.
+        store2.delete_document("/t/extra.md")
+        # .snpi still claims N + 50 because we never flushed.
+        # Drop snap + close conn without calling store.close().
+        store2._snap = None
+        store2._conn.close()
+
+        # 3. Reopen. With the asymmetric fix, this must fire.
+        with caplog.at_level(logging.WARNING, logger="vstash.store"):
+            store3 = VstashStore(
+                db_path,
+                embedding_dim=DIM,
+                vector_backend="snapvec-ivfpq",
+                ivfpq_M=24,
+                ivfpq_K=32,
+                ivfpq_nlist=16,
+            )
+
+        assert any("stale" in r.message.lower() for r in caplog.records), (
+            f"staleness warning not emitted on delete-then-crash; got: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        assert not store3._snap.fitted
+        assert len(store3._snap) == 0
+        store3.close()

--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -257,3 +257,98 @@ class TestVstashStoreIVFPQIntegration:
         assert store2._snap.fitted
         assert len(store2._snap) == N
         store2.close()
+
+    def test_stale_ivfpq_index_downgrades_to_unfitted(self, tmp_path, caplog):
+        """Issue #329: a crash post-fit can leave .snpi behind vec_chunks.
+
+        Reopen must detect that staleness and downgrade the backend to
+        its unfitted state so search falls back to sqlite-vec instead of
+        silently missing the rows ingested in the last write burst. The
+        repro shape:
+
+        1. Open store, ingest + fit, close (so .snpi flushes).
+        2. Reopen, ingest more rows. These land in vec_chunks AND in
+           the in-memory IVFPQ index, but .snpi is NOT flushed.
+        3. Force-close the second store WITHOUT calling close() to
+           simulate a process crash. Use the underlying ``_conn.close``
+           and drop the snap reference -- this leaves .snpi at its
+           v1 size while vec_chunks has the new rows.
+        4. Reopen a third time. The init path must:
+           - log a warning about the staleness,
+           - leave ``self._snap.fitted == False``,
+           - leave ``len(self._snap) == 0`` so the search code path
+             falls back to sqlite-vec via the ``len(self._snap) > 0``
+             gate in VstashStore.search.
+        """
+        import logging
+
+        db_path = str(tmp_path / "stale.db")
+
+        # 1. Initial fit + save.
+        store1 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        rng = np.random.default_rng(7)
+        v1 = _unit_vectors(rng, N, DIM)
+        store1.add_document(
+            path="/t/initial.md",
+            title="initial",
+            chunks=[f"c{i}" for i in range(N)],
+            embeddings=v1.tolist(),
+            source_type="text",
+        )
+        store1.fit_ivfpq(training_sample=N)
+        store1.close()  # .snpi now has N rows.
+
+        # 2. Reopen and add more rows; do NOT close (crash sim).
+        store2 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        assert store2._snap.fitted
+        assert len(store2._snap) == N
+        v2 = _unit_vectors(rng, 50, DIM)
+        store2.add_document(
+            path="/t/burst.md",
+            title="burst",
+            chunks=[f"burst_c{i}" for i in range(50)],
+            embeddings=v2.tolist(),
+            source_type="text",
+        )
+        # vec_chunks now has N+50 rows; .snpi is still at N because
+        # _save_snapvec writes only on close()/checkpoint and we are
+        # simulating a crash. Drop the snap reference + close conn
+        # without calling store.close() to avoid the flush.
+        store2._snap = None
+        store2._conn.close()
+
+        # 3. Reopen. Staleness detection must fire.
+        with caplog.at_level(logging.WARNING, logger="vstash.store"):
+            store3 = VstashStore(
+                db_path,
+                embedding_dim=DIM,
+                vector_backend="snapvec-ivfpq",
+                ivfpq_M=24,
+                ivfpq_K=32,
+                ivfpq_nlist=16,
+            )
+
+        assert any("stale" in r.message.lower() for r in caplog.records), (
+            f"staleness warning not emitted; got: {[r.message for r in caplog.records]}"
+        )
+        # The downgrade contract: unfitted -> search falls back to sqlite-vec.
+        assert not store3._snap.fitted
+        assert len(store3._snap) == 0
+        # Sanity: search still works (via sqlite-vec fallback).
+        results = store3.search(v1[0].tolist(), "c0", top_k=3)
+        assert len(results) > 0
+        store3.close()

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -387,6 +387,20 @@ class VstashStore:
         The backend starts unfit; sqlite-vec remains authoritative until
         ``fit_ivfpq()`` trains on the corpus. After that, searches prefer
         the IVFPQ path and new adds append directly.
+
+        Crash recovery (issue #329): the on-disk ``.snpi`` is only flushed
+        on ``close()`` / ``_checkpoint_snapvec``. A crash between an
+        ``add_document`` (which updates the in-memory IVFPQ index)
+        and ``close()`` can leave ``.snpi`` with fewer rows than
+        ``vec_chunks``. On reopen, this method detects that staleness
+        (``len(loaded_index) < COUNT(vec_chunks)``) and downgrades the
+        backend to its unfitted state so ``VstashStore.search`` falls
+        back to sqlite-vec rather than silently missing the rows
+        ingested in the last write burst. The user is told via
+        ``logger.warning`` to rerun ``vstash snapvec fit`` when
+        convenient. We do not auto-refit because IVFPQ fitting is a
+        ~50s operation that would block every reopen after a crash;
+        sqlite-vec retrieval is correct in the interim.
         """
         if not _HAS_SNAPVEC:
             logger.warning(
@@ -423,6 +437,32 @@ class VstashStore:
                 exc_info=True,
             )
             self._snap = IVFPQBackend(**kwargs)
+            return
+
+        # Staleness check (issue #329): mirrors the FLAT precedent at
+        # _init_snapvec. If the on-disk index reports fewer routable
+        # vectors than vec_chunks, downgrade to unfitted so search
+        # falls back to sqlite-vec. Skip when the index is unfitted
+        # (len == 0 by contract) or the file did not exist (load
+        # returns an unfitted instance in that case too).
+        if self._snap.fitted:
+            try:
+                sqlite_n = int(self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0])
+            except sqlite3.Error:
+                sqlite_n = 0
+            snap_n = len(self._snap)
+            if sqlite_n > snap_n:
+                logger.warning(
+                    "IVFPQ index at %s is stale: %d routable vectors vs %d in "
+                    "vec_chunks (likely a crash between add_document and "
+                    "close()). Downgrading to unfitted; search will fall back "
+                    "to sqlite-vec until you run 'vstash snapvec fit' to "
+                    "rebuild from current vec_chunks.",
+                    self._ivfpq_path,
+                    snap_n,
+                    sqlite_n,
+                )
+                self._snap = IVFPQBackend(**kwargs)
 
     @staticmethod
     def _nlist_for(n: int) -> int:

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -440,9 +440,22 @@ class VstashStore:
             return
 
         # Staleness check (issue #329): mirrors the FLAT precedent at
-        # _init_snapvec. If the on-disk index reports fewer routable
-        # vectors than vec_chunks, downgrade to unfitted so search
-        # falls back to sqlite-vec. Skip when the index is unfitted
+        # _init_snapvec. ANY count mismatch is stale, in either
+        # direction:
+        #
+        # - sqlite_n > snap_n: the canonical add_document case. Crash
+        #   after writing to vec_chunks but before .snpi flush; the
+        #   index is missing the last write burst.
+        # - sqlite_n < snap_n: the delete case. Crash after
+        #   delete_document removed rows from vec_chunks but before
+        #   .snpi flush; the index still carries the deleted ids,
+        #   which then consume ANN candidate slots and reduce recall
+        #   (search returns hits for tombstoned chunk_ids that the
+        #   path map filters out, so top-K is partial).
+        #
+        # In both cases the right answer is to downgrade to unfitted
+        # and let sqlite-vec answer until the user runs `vstash
+        # snapvec fit` to rebuild. Skip when the index is unfitted
         # (len == 0 by contract) or the file did not exist (load
         # returns an unfitted instance in that case too).
         if self._snap.fitted:
@@ -451,10 +464,10 @@ class VstashStore:
             except sqlite3.Error:
                 sqlite_n = 0
             snap_n = len(self._snap)
-            if sqlite_n > snap_n:
+            if sqlite_n != snap_n:
                 logger.warning(
                     "IVFPQ index at %s is stale: %d routable vectors vs %d in "
-                    "vec_chunks (likely a crash between add_document and "
+                    "vec_chunks (likely a crash between add_document/delete and "
                     "close()). Downgrading to unfitted; search will fall back "
                     "to sqlite-vec until you run 'vstash snapvec fit' to "
                     "rebuild from current vec_chunks.",


### PR DESCRIPTION
## Summary

Closes #329 (filed during PR #328 review). IVFPQBackend.load() previously marked any existing \`.snpi\` as authoritative -- a crash between \`add_document\` (which updates the in-memory index) and \`close()\` (which flushes \`.snpi\`) would leave reopen with a stale \`.snpi\`, taking the ANN path and silently missing the rows ingested in the last write burst.

## Fix

Mirror the FLAT precedent already in \`_init_snapvec\` (lines 562-579): after \`IVFPQBackend.load()\` succeeds and reports a fitted index, compare \`len(self._snap)\` against \`COUNT(*) FROM vec_chunks\`. If SQLite is ahead, the on-disk index is stale -- log a warning naming both counts and downgrade the backend to its unfitted state by replacing \`self._snap\` with a fresh \`IVFPQBackend(**kwargs)\`. The unfitted contract (\`len == 0\`, search returns \`[]\`) makes \`VstashStore.search\` fall back to sqlite-vec via the existing \`len(self._snap) > 0\` gate.

## Why downgrade rather than auto-refit

IVFPQ fitting is a ~50s operation. Auto-fitting on every reopen after a crash would be a brutal UX hit. Downgrading is correct (sqlite-vec retrieval is authoritative) and lets the user run \`vstash snapvec fit\` when convenient. The log warning names the exact remediation.

## Test

\`tests/test_snapvec_ivfpq_backend.py::test_stale_ivfpq_index_downgrades_to_unfitted\` (new). Repro:

1. Open store, ingest N rows, fit + close (\`.snpi\` flushes with N).
2. Reopen, ingest 50 more rows. \`vec_chunks\` has N+50; \`.snpi\` still has N.
3. Drop the snap reference + close the connection without \`store.close()\` -- simulates a crash before the flush.
4. Reopen. Assert: \"stale\" warning emitted, \`self._snap.fitted == False\`, \`len(self._snap) == 0\`, search still works (sqlite-vec fallback).

Smoke: 123 / 123 in \`test_snapvec_ivfpq_backend + test_vectorbackend + test_store\` pass in 1.87s. \`ruff check\` clean.

## Risk

Low. The new staleness check is purely additive on the load path: if the index is in sync (the common case), nothing changes. If it is stale, the user gets a clear warning + sqlite-vec fallback instead of silent missing rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved crash-recovery detection for stale snap indexes. The system now automatically identifies and handles stale snap data on reopen, downgrades to a safe search mode, and ensures no results are silently missed when querying after an unexpected shutdown.

* **Tests**
  * Added integration test for crash-recovery scenario with stale snap indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->