### PR TITLE
refactor(cli): migrate vstash ask/chat to services layer

### DIFF
--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -33,6 +33,7 @@ from ._store_open import open_store_for_config
 from .config import VstashConfig, load_config
 from .embed import embed_query, warmup
 from .ingest import ingest, ingest_directory
+from .services import search_with_embedding
 from .store import VstashStore, relevance_tier
 
 from . import __version__
@@ -433,13 +434,14 @@ def ask(
     with store:
         k = top_k or cfg.chunking.top_k
 
-        # Embed query
+        # Embed + search via the services layer for the single-store
+        # path; federated still embeds once up front because
+        # federated_search wants the embedding pre-computed.
         with console.status("[dim]Searching memory...[/dim]", spinner="dots"):
-            q_embedding = embed_query(query, cfg.embeddings.model)
-
             if all_profiles:
                 from .profile import federated_search
 
+                q_embedding = embed_query(query, cfg.embeddings.model)
                 tagged = federated_search(
                     query_embedding=q_embedding,
                     query_text=query,
@@ -452,10 +454,12 @@ def ask(
                 )
                 chunks = [r for _, r in tagged]
             else:
-                chunks = store.search(
-                    q_embedding,
-                    query,
+                chunks = search_with_embedding(
+                    cfg=cfg,
+                    store=store,
+                    query=query,
                     top_k=k,
+                    expand_window=0,
                     collection=collection,
                     project=project,
                     layer=layer,
@@ -951,15 +955,24 @@ def chat(
                     _maybe_dismiss()
                     break
 
-                # Search
-                q_embedding = embed_query(query, cfg.embeddings.model)
-                chunks = store.search(q_embedding, query, top_k=k)
+                # Search via the services layer: embed + validate +
+                # search + expand_context in one call. expand_window=1
+                # gives the LLM adjacent context, same as before.
+                chunks = search_with_embedding(
+                    cfg=cfg,
+                    store=store,
+                    query=query,
+                    top_k=k,
+                    expand_window=1,
+                )
 
                 if not chunks:
                     console.print("[yellow]No relevant context found.[/yellow]")
                     continue
 
-                # Tiered relevance signal
+                # Tiered relevance signal (post-expand, mirroring the
+                # MCP migration pattern -- semantically identical to
+                # the old pre-expand placement).
                 tier = relevance_tier(store.last_best_distance)
                 last_event_id = store.record_search_event(
                     query=query,
@@ -972,9 +985,6 @@ def chat(
                     console.print("[dim]⚠ Low relevance — context may not match well.[/dim]")
                 elif tier == "medium":
                     console.print("[dim]? Uncertain relevance — results may be tangential.[/dim]")
-
-                # Expand context with adjacent chunks
-                chunks = store.expand_context(chunks, window=1)
 
                 source_list = list({c.title for c in chunks})
                 console.print(f"[dim]Sources: {', '.join(source_list)}[/dim]\n")


### PR DESCRIPTION
## Summary

Sprint 2 follow-up mirroring #334 (MCP migration). The CLI had ~6 inline embed+search sites per the audit. This PR migrates the two clean ones (\`vstash ask\` and \`vstash chat\` REPL) to the services layer. The other four sites have shape issues that are intentionally out of scope.

## Migrated

- **\`vstash ask\` non-federated branch (was line 438-462)**: replace \`embed_query + store.search\` with \`search_with_embedding(expand_window=0)\`. The downstream \`store.expand_context(chunks, window=1)\` call at line 512 stays; passing \`expand_window=0\` lets the telemetry/relevance block at lines 487-503 run between search and expand exactly as before.
- **\`vstash chat\` REPL (was line 955)**: the simple full-flow case. Replace inline triplet with \`search_with_embedding(expand_window=1)\`. Telemetry placement moves to AFTER expand for parity with #334.

## Not migrated (out of scope, documented in commit)

- **\`vstash search\` (line 697)**: uses \`explain=explain\` which makes \`store.search\` return \`list[ExplainInfo]\` rather than \`list[SearchResult]\`. Service is typed for the latter only.
- **\`vstash why\` miss-analysis paths (lines 634, 1728)**: \`miss_analysis\` is not a search-triplet shape -- same reasoning as \`vstash_miss_analysis\` in #334.
- **Federated branches in \`ask\` / \`search\`**: use \`federated_search()\` which takes a pre-computed embedding and iterates multiple stores. Different abstraction.

## LimitError flow

The CLI already has \`except ValueError as exc:\` handlers downstream of search calls. \`LimitError\` is a \`ValueError\` subclass, so the validation now happening in the service layer surfaces with the same handling -- no new except branches needed.

## Test plan

- [x] \`pytest tests/test_cli_commands.py tests/test_cli_retrain.py\` -- 64 / 64 pass.
- [x] \`pytest test_cli + test_services + test_mcp + test_store + test_memory\` -- 271 / 271 pass in 31s.
- [x] \`ruff check vstash/cli.py\` clean.

## Risk

Low. Two handlers behave identically (validation now fires up front; result shape and error path unchanged). Federated and explain branches stay on their original code paths.

## Follow-up

Two of six original embed+search sites are now service-routed. Four remain by design (explain shape, miss-analysis shape, federated shape). \`memory.py::search\` / \`Memory.ask_full\` could also delegate to services -- that would close the SDK side of the DRY gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal search and context expansion logic for improved performance and maintainability in the `ask()` function and chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->