### PR TITLE
refactor(memory): migrate Memory.search to services layer

### DIFF
--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -32,6 +32,7 @@ from .models import (
     SearchResult,
     StoreStats,
 )
+from .services import search_with_embedding
 
 # Sentinel for distinguishing "parameter not provided" from explicit None.
 _UNSET = object()
@@ -342,25 +343,20 @@ class Memory:
         Returns:
             Ranked list of SearchResult ordered by relevance.
         """
-        q_embedding = embed_query(query, self._cfg.embeddings.model)
+        # Resolve the retrieval mode through the store helper first --
+        # it handles legacy aliases (like ``fts_only=True`` bool that
+        # mapped to ``"fts_only"`` pre-v0.33). After that the services
+        # layer takes over: validates inputs, embeds the query, and
+        # runs store.search with the right weights for the resolved
+        # mode. expand_window=0 keeps Memory.search's existing
+        # contract of returning raw chunks (no context expansion).
         _mode = self._store._resolve_retrieval_mode(retrieval_mode)
-        # When a non-hybrid mode is active, drop any caller-supplied
-        # weight arguments before they reach the store's validator.
-        # The store will force the weights to (0.0, 1.0) or (1.0, 0.0)
-        # internally on the short-circuit branch, so forwarding caller
-        # weights would either no-op or raise
-        # ``RRFWeightOutOfRangeError`` for a nonsensical value the
-        # caller did not intend us to validate.
-        if _mode != "hybrid":
-            vec_weight = None
-            fts_weight = None
-        return self._store.search(
-            query_embedding=q_embedding,
-            query_text=query,
+        return search_with_embedding(
+            cfg=self._cfg,
+            store=self._store,
+            query=query,
             top_k=top_k,
-            vec_weight=vec_weight,
-            fts_weight=fts_weight,
-            retrieval_mode=_mode,
+            expand_window=0,
             collection=self._resolve_collection(collection),
             project=self._resolve_project(project),
             layer=layer,
@@ -368,6 +364,9 @@ class Memory:
             added_after=added_after,
             added_before=added_before,
             mmr_lambda=mmr_lambda,
+            vec_weight=vec_weight,
+            fts_weight=fts_weight,
+            retrieval_mode=_mode,
             exact_match=exact_match,
             exact_match_case_sensitive=exact_match_case_sensitive,
         )

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -113,6 +113,18 @@ def search_with_embedding(
             f"{sorted(_VALID_RETRIEVAL_MODES)} or None, got {retrieval_mode!r}"
         )
 
+    # Resolve the mode and drop caller weights BEFORE validation when
+    # the mode is non-hybrid. The store forces (1.0, 0.0) or (0.0,
+    # 1.0) on the short-circuit branch, so any caller-supplied
+    # numeric here would either no-op or trip an unrelated validation
+    # error. Memory.search (and the matching MCP / CLI paths) have
+    # always treated `fts_only`/`vec_only` as "ignore weights" --
+    # validating them first would be a behavior change.
+    mode = retrieval_mode or "hybrid"
+    if mode != "hybrid":
+        vec_weight = None
+        fts_weight = None
+
     # If the caller pinned a cutoff, validate THAT value against
     # the configured ceiling; otherwise validate the ceiling against
     # itself (a noop) so the rest of validate_search_input can
@@ -129,14 +141,6 @@ def search_with_embedding(
         vec_weight=vec_weight,
         fts_weight=fts_weight,
     )
-
-    mode = retrieval_mode or "hybrid"
-    # In non-hybrid modes the store forces the weights internally; do
-    # not pass caller weights through, otherwise the validation above
-    # might let a 0.7/0.3 split through that the store would reject.
-    if mode != "hybrid":
-        vec_weight = None
-        fts_weight = None
 
     q_embedding = embed_query(query, cfg.embeddings.model)
 


### PR DESCRIPTION
## Summary

Sprint 2 follow-up. \`Memory.search\` was the last load-bearing inline embed+search site identified by the audit. With this migration the SDK becomes a thin wrapper over the services layer for retrieval:

\`\`\`
Memory.search    -> search_with_embedding(...)
Memory.ask       -> Memory.ask_full -> Memory.search + chat.ask_full
Memory.ask_full  -> Memory.search + chat.ask_full
\`\`\`

A fix to the service is now seen by every adapter (CLI #335, MCP #334, web #327, SDK now). That closes the core DRY gap the services layer was created to address (#327).

## Memory.search changes

- Drop the inline \`embed_query + store.search\` pair.
- Keep \`_resolve_retrieval_mode\` for legacy alias handling (the deprecated \`fts_only=True\` bool from pre-v0.33).
- Forward to \`search_with_embedding(expand_window=0)\` -- preserves Memory.search's existing contract of returning raw chunks. Adapters that want expansion pass \`expand_window=1\`.
- Identifier sentinel resolution stays in Memory (SDK-specific ergonomics).

## Service bug fix uncovered by this migration

The service had \`validate_search_input\` **before** the non-hybrid drop of caller weights. Pre-v0.37 \`Memory.search\` did the opposite: drop weights when non-hybrid, THEN let store validate. The existing test \`test_search_fts_only_overrides_explicit_weights\` exercises this contract -- pass \`mode=\"fts_only\"\` + \`vec_weight=1.5\` (out-of-range), expect the weight to be silently ignored because \`fts_only\` forces (0.0, 1.0) anyway. Migration broke that test.

**Fix**: move the drop-when-non-hybrid block BEFORE \`validate_search_input\`. Validation only sees the weights that will actually reach the store. Restores the pre-migration contract.

## Test plan

- [x] \`pytest tests/test_memory.py tests/test_services.py\` -- 70 / 70 pass in 96s.
- [x] \`ruff check\` + \`ruff format --check\` both clean.
- [x] Existing \`test_non_hybrid_mode_drops_caller_weights\` still passes (mode-resolution semantics unchanged).
- [x] Existing \`test_search_fts_only_overrides_explicit_weights\` passes again after the reorder.

## Risk

Low. Net behaviour change: \`Memory.search\` now runs the boundary validation that used to live inside \`store.search\` -- so an over-long query or out-of-range \`top_k\` raises \`LimitError\` at the SDK boundary rather than deeper in the stack. This is an improvement (validation closer to the caller) and \`LimitError\` is still a \`ValueError\` subclass so \`except ValueError\` callers are unaffected.

## What this closes

Tier 1 plan items 4-6 (mcp / cli / memory) are all in:
- #334 mcp.py -> services
- #335 cli.py -> services
- #336 memory.py -> services (this PR)

Remaining Tier 1 follow-up: formal close of #283 (narrow MCP \`except Exception\`). Tier 2: #280 split \`store.py\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal search functionality architecture by reorganizing how retrieval modes are resolved and weight parameters are handled during validation, ensuring more efficient and consistent processing of search requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->