### PR TITLE
docs(claude): refresh project structure and Sprint 2 architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,13 @@ paper/arxiv/*.blg
 # Claude scheduled-task lock
 .claude/scheduled_tasks.lock
 
+# Personal scratch + archived docs (local-only, never committed)
+notes/
+archive/
+
+# Paper v2 draft (work-in-progress; v1 vstash.tex/pdf stays tracked)
+paper/arxiv/vstash-v2.*
+
 # macOS iCloud sync collision artefacts (e.g. "foo 2.py", "foo 3.json").
 # These are auto-generated when iCloud cannot reconcile the same file
 # across devices and never represent real work; the un-suffixed file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ vstash/
   cli.py             # typer CLI: add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile, journal, retrain, serve, check, snapvec, why
   _store_open.py     # open_store_for_config(cfg): single VstashStore construction entry point used by every adapter (CLI/MCP/web/SDK/journal/federated)
   services/          # Adapter-agnostic service layer. All four adapters (web/MCP/CLI/SDK) route through here.
-    search.py        # embed -> validate -> search -> expand triplet shared by every search caller
+    search.py        # validate -> embed -> search -> expand triplet shared by every search caller
     ask.py           # ask/ask_full orchestration with retrieval context
   vectorbackend/     # Vector backend Protocol + concrete impls
     base.py          # VectorBackend Protocol contract (runtime_checkable)
@@ -106,7 +106,7 @@ docs/               # User-facing documentation
 - **`retrieval_mode` enum (v0.33)**: `Literal["hybrid", "vec_only", "fts_only"] = "hybrid"` on `VstashStore.search`, `Memory.search`, `Memory.ask`, MCP tools, and `VstashRetriever`. `vec_only` is the new symmetric branch to `fts_only` (skip FTS5, force `(1.0, 0.0)` weights). Default stays `hybrid` -- paper / README / v3 model numbers all measured against it. Legacy `fts_only=True` bool is deprecated in v0.33.0 with a `DeprecationWarning`.
 - **`chat.ask_full()` returning `AskResult` (v0.36)** (#303/#310): Public API that surfaces the reasoning channel and token usage that `ask()` discards. `_ask_cerebras` / `_ask_ollama` / `_ask_openai` now return `AskResult` internally; `ask()` is a thin wrapper returning `.content` so the existing `-> str` contract is preserved with zero call-site changes. Cerebras `gpt-oss-120b` populates `message.reasoning`; Ollama qwen3 thinking-mode uses `message.thinking`; OpenAI-compat servers (vLLM, DeepSeek, Together, xAI Grok, OpenAI o1/o3) read `message.reasoning_content`. Shared helpers `_extract_reasoning` (accepts both field names) and `_normalize_usage` (returns complete dict or `None`, never partial). `Memory.ask_full()` mirrors `Memory.ask()`; `Memory.ask` itself routes through `ask_full(...).content` so retrieval / LLM plumbing live in a single load-bearing path. Drives Merken Phase 2 distillation (`Q -> reasoning_trace -> A` shape).
 - **Centralized store construction (v0.36)** (#297/#306): `vstash._store_open.open_store_for_config(cfg)` is the single entry point used by CLI, MCP, web, SDK, journal, and `federated_search`. Replaces the previous per-surface `VstashStore(...)` wiring that silently dropped IVFPQ tuning fields on some paths.
-- **Services layer (post-v0.36)** (#327/#334/#335/#336): `vstash/services/{search,ask}.py` centralises the `embed -> validate -> search -> expand` triplet that the four adapters (web, MCP, CLI, SDK) all duplicated. Every adapter now routes through `services/`, so validation runs at the API boundary before the daemon round-trip and there is one load-bearing path for retrieval/LLM plumbing. When changing search behaviour, edit `services/search.py` first; `VstashStore.search` remains the underlying primitive.
+- **Services layer (post-v0.36)** (#327/#334/#335/#336): `vstash/services/{search,ask}.py` centralises the `validate -> embed -> search -> expand` triplet that the four adapters (web, MCP, CLI, SDK) all duplicated. Every adapter now routes through `services/`, so validation runs at the API boundary before the daemon round-trip and there is one load-bearing path for retrieval/LLM plumbing. When changing search behaviour, edit `services/search.py` first; `VstashStore.search` remains the underlying primitive.
 - **Domain error tree (post-v0.36)** (#326): `vstash/errors.py` defines `VstashError` as the ancestor for `LimitError` (boundary validation), `SchemaVersionError`, and friends. Each leaf multi-inherits the historical `ValueError` / `RuntimeError` it used to raise, so existing `except ValueError` callers keep working without changes.
 - **VectorBackend Protocol (post-v0.36)** (#328): `vstash/vectorbackend/base.py` defines the `VectorBackend` `Protocol` (runtime-checkable). `snapvec_ivfpq.py` is the first concrete impl extracted from legacy `_ivfpq_backend.py`; the legacy module is a deprecated re-export shim slated for removal in v0.40. Use the Protocol contract when adding a new backend.
 - **Built-in embed model registry (post-v0.36)** (#330): replaces the if/elif dispatch in `embed_texts` / `embed_query` / `warmup`. New built-in models register themselves in the registry; the custom encoder resolver hook (#278) still wins over built-ins for non-stock models.
@@ -155,7 +155,7 @@ Key sections: `[inference]`, `[cerebras]`, `[ollama]`, `[openai]`, `[embeddings]
 
 - **Add a new CLI command**: Add `@app.command()` function in `cli.py`, update docstring at top of file. (#284 will split this into `vstash/cli/<command>.py`; until merged, cli.py stays monolithic.)
 - **Add a new embedding model**: Register in the built-in registry in `embed.py` (and optionally `_MLX_MODEL_MAP` for MLX). For non-stock fine-tunes, prefer `register_encoder_resolver(fn)` over editing the registry.
-- **Change search behavior**: Edit `vstash/services/search.py` first if it is adapter-shared (validation, embedding, expand). Edit `VstashStore.search()` in `store.py` for the underlying retrieval pipeline: vector search -> FTS search -> RRF merge -> scoring -> MMR dedup -> context expansion.
+- **Change search behavior**: Edit `vstash/services/search.py` first if it is adapter-shared (validation, embedding, context expansion via `store.expand_context()`). Edit `VstashStore.search()` in `store.py` for the underlying retrieval pipeline: vector search -> FTS search -> RRF merge -> scoring -> MMR dedup.
 - **Add a new vector backend**: Implement the `VectorBackend` Protocol in `vstash/vectorbackend/base.py`. See `snapvec_ivfpq.py` as the reference impl. Add a runtime-checkable conformance test mirroring `test_vectorbackend.py`.
 - **Open a `VstashStore` from a new surface**: call `vstash._store_open.open_store_for_config(cfg)`. Never instantiate `VstashStore(...)` directly from an adapter.
 - **Add a config field**: Add to the relevant Pydantic model in `config.py`, update `docs/configuration.md`.
@@ -210,7 +210,10 @@ gh pr merge --merge --admin
 ```
 
 The `pypi` environment in `publish.yml` is wired to a PyPI trusted
-publisher; no API tokens are stored in the repo. If you ever need to
-fall back to a manual upload, install `build` + `twine` locally and
-ensure credentials are configured in `~/.pypirc`, but this should be
-a break-glass path.
+publisher; no API tokens are stored in the repo. **Do not run `twine`
+manually under normal circumstances.** The only sanctioned exception is
+a break-glass scenario where the OIDC workflow is unrecoverable (e.g.
+PyPI trusted-publisher outage); in that case, install `build` + `twine`
+locally, upload from a clean checkout of the tagged commit, and document
+the manual upload in the release notes so the next release does not
+inherit the workaround.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — vstash project guide
+# CLAUDE.md -- vstash project guide
 
 ## What is vstash?
 
@@ -25,46 +25,66 @@ vstash stats
 
 ```
 vstash/
-  __init__.py       # version (__version__ = "0.36.0")
-  cli.py            # typer CLI — add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile, journal, retrain, serve, check, snapvec
-  retrain.py        # Eval-gated self-supervised embedding fine-tuning. Composes split_corpus_for_eval, evaluate_model, generate_triples, train_mnrl. Refuses to save a model that regresses on held-out NDCG@10.
-  retrain_synth.py  # LLM query synthesis for retrain training pairs (OpenAI-compat, Ollama). JSONL cache keyed by (chunk_id, prompt_hash, model).
-  profile.py        # Multi-profile management: resolution chain, CRUD, federated search
-  journal.py        # Cross-session memory: save, recall, log, prune, transcript parsing
-  store.py          # VstashStore — SQLite + sqlite-vec + FTS5, RRF, scoring, MMR dedup, reindex
-  ingest.py         # parse → chunk → embed pipeline
-  code_split.py     # hybrid code splitting: tree-sitter → parso → regex (25+ languages)
-  embed.py          # FastEmbed ONNX + MLX backends, model registry (English + multilingual)
-  config.py         # Pydantic v2 config from vstash.toml, all defaults
-  chat.py           # LLM chat/ask with retrieval context
-  mcp.py            # MCP server for Claude Desktop
-  memory.py         # Python SDK (from vstash import Memory)
-  langchain.py      # VstashRetriever for LangChain
-  models.py         # Pydantic models (SearchResult, DocumentInfo, StoreStats, IngestResult)
-  watch.py          # File watcher for auto-ingestion and deletion handling
+  __init__.py        # version (__version__ = "0.36.0")
+  cli.py             # typer CLI: add, search, ask, chat, list, stats, forget, reindex, watch, config, export, remember, profile, journal, retrain, serve, check, snapvec, why
+  _store_open.py     # open_store_for_config(cfg): single VstashStore construction entry point used by every adapter (CLI/MCP/web/SDK/journal/federated)
+  services/          # Adapter-agnostic service layer. All four adapters (web/MCP/CLI/SDK) route through here.
+    search.py        # embed -> validate -> search -> expand triplet shared by every search caller
+    ask.py           # ask/ask_full orchestration with retrieval context
+  vectorbackend/     # Vector backend Protocol + concrete impls
+    base.py          # VectorBackend Protocol contract (runtime_checkable)
+    snapvec_ivfpq.py # IVFPQ backend extracted from legacy _ivfpq_backend.py
+  _ivfpq_backend.py  # Deprecated re-export shim, scheduled removal v0.40
+  errors.py          # VstashError ancestor + LimitError / SchemaVersionError. Multi-inherits ValueError/RuntimeError so legacy except callers keep working.
+  validation.py      # API-boundary input validation, [limits] section knobs, LimitError hierarchy
+  metrics.py         # In-process metrics registry, slow query log
+  store.py           # VstashStore: SQLite + sqlite-vec + FTS5, RRF, scoring, MMR dedup, reindex, integrity (4700+ LOC, scheduled split via #280)
+  ingest.py          # parse -> chunk -> embed pipeline
+  code_split.py      # hybrid code splitting: tree-sitter -> parso -> regex (25+ languages)
+  embed.py           # FastEmbed ONNX + MLX backends + built-in model registry (English + multilingual) + custom encoder resolver hook
+  config.py          # Pydantic v2 config from vstash.toml, all defaults
+  chat.py            # LLM chat/ask/ask_full with retrieval context. Returns AskResult (content + reasoning + usage + backend + model).
+  mcp.py             # MCP server for Claude Desktop (vstash_search/vstash_ask route through services/)
+  web.py             # FastAPI server: search, ask, upload, /debug/why
+  memory.py          # Python SDK (from vstash import Memory). search/ask/ask_full route through services/.
+  langchain.py       # VstashRetriever for LangChain
+  models.py          # Pydantic models (SearchResult, AskResult, DocumentInfo, StoreStats, IngestResult)
+  profile.py         # Multi-profile management: resolution chain, CRUD, federated search
+  journal.py         # Cross-session memory: save, recall, log, prune, transcript parsing
+  retrain.py         # Eval-gated self-supervised embedding fine-tuning. Composes split_corpus_for_eval, evaluate_model, generate_triples, train_mnrl. Refuses to save a model that regresses on held-out NDCG@10.
+  retrain_batch.py   # Bulk training-pair mining helpers
+  retrain_synth.py   # LLM query synthesis for retrain training pairs (OpenAI-compat, Ollama). JSONL cache keyed by (chunk_id, prompt_hash, model).
+  watch.py           # File watcher for auto-ingestion and deletion handling
 
-tests/
-  test_store.py     # Store CRUD, search, MMR dedup, reindex, scoring, context expansion
-  test_ingest.py    # Ingestion, chunking
-  test_code_split.py  # Hybrid code splitting backends (tree-sitter / parso / regex)
-  test_code_chunking.py # Code-aware chunking integration
-  test_cli_commands.py  # CLI command tests
-  test_scoring_e2e.py   # End-to-end scoring scenarios
-  test_snapvec_backend.py # Optional snapvec backend tests
-  test_robustness.py  # Expand context isolation, reindex safety, scoring edge cases
-  test_watch_e2e.py   # Watch mode e2e: create, modify, delete, debounce, shutdown
-  test_retry_e2e.py   # Retry with backoff e2e tests
-  test_url_titles_e2e.py # URL title extraction e2e tests
-  test_profile.py   # Multi-profile resolution, management, federated search, CLI, SDK
-  test_journal.py   # Journal save/recall/log/prune, CLI, SDK, MCP, transcript parsing
-  test_get_chunk.py # Direct chunk retrieval by ID (store, SDK, MCP, edge cases)
-  test_store_helpers.py # Store helper methods (get_document_chunks, added_at, batching)
-  test_retrain.py   # generate_triples + evaluate_model + retrain() composer (eval gate, atomic promote, synth-queries integration)
-  test_retrain_synth.py # LLM query synthesis: prompt builder, parser edge cases, JSONL cache, LLM-failure resilience
-  conftest.py       # Fixtures (tmp_db_path, sample_store, populated_store -- the workhorse for most new tests)
+tests/               # 1200+ tests across 50+ files. Highlights below; see tests/ for the full set.
+  conftest.py                # Fixtures (tmp_db_path, sample_store, populated_store: workhorse for most new tests)
+  test_store.py              # Store CRUD, search, MMR dedup, reindex, scoring, context expansion
+  test_store_helpers.py      # Store helper methods (get_document_chunks, added_at, batching)
+  test_store_open.py         # open_store_for_config end-to-end
+  test_services.py           # services.search / services.ask shared validation + plumbing
+  test_vectorbackend.py      # VectorBackend Protocol conformance
+  test_snapvec_backend.py    # Flat snapvec backend
+  test_snapvec_ivfpq_backend.py # IVFPQ backend, fp16 rerank, stale-load detection
+  test_builtin_backend_registry.py # Embed-side built-in model registry
+  test_encoder_resolver.py   # Custom encoder resolver hook
+  test_embed.py / test_embed_daemon.py / test_embed_mlx.py
+  test_retrieval_mode.py     # hybrid / vec_only / fts_only enum
+  test_query_cache.py        # LRU query cache invalidation
+  test_deferred_fts.py / test_ingest_batch.py # Batched ingest + deferred FTS
+  test_integrity.py / test_schema_versioning.py
+  test_validation.py / test_errors.py / test_metrics.py
+  test_chat.py / test_memory.py / test_mcp.py / test_web.py / test_langchain.py
+  test_cli_commands.py / test_cli_error_messages.py / test_cli_get_store_lifecycle.py / test_cli_retrain.py
+  test_retrain.py / test_retrain_batch.py / test_retrain_multi.py / test_retrain_synth.py
+  test_code_split.py / test_code_chunking.py
+  test_watch.py / test_watch_e2e.py / test_watch_burst.py
+  test_ingest.py / test_export.py / test_frontmatter.py / test_remember.py / test_get_chunk.py
+  test_profile.py / test_journal.py / test_config.py
+  test_miss_analysis.py / test_robustness.py / test_stem_conn_cleanup.py
+  test_retry_e2e.py / test_url_titles_e2e.py / test_beir_regression.py
 
-experiments/        # Research experiment scripts + results
-paper/              # Academic paper (vstash-paper.md)
+experiments/        # Research experiment scripts + results (BEIR, scoring grids, perf probes)
+paper/              # Academic paper (v1 in paper/, v2 in paper/v2/, arXiv build in paper/arxiv/)
 docs/               # User-facing documentation
 ```
 
@@ -72,10 +92,10 @@ docs/               # User-facing documentation
 
 - **Hybrid search**: Vector (sqlite-vec cosine) + FTS5 keyword, combined via Reciprocal Rank Fusion (k=60).
 - **Adaptive RRF**: IDF-based weight adjustment per query. Rare terms boost FTS; common terms boost vector. Long queries (>50 words) relax distance cutoff. Cached via fts5vocab.
-- **Pipeline**: vector search → FTS5 keyword → adaptive RRF fusion (IDF-weighted) → optional recency boost → MMR dedup. Frequency+decay scoring was evaluated and removed in v0.18.0. Replaced by opt-in recency boost in v0.19.0.
+- **Pipeline**: vector search -> FTS5 keyword -> adaptive RRF fusion (IDF-weighted) -> optional recency boost -> MMR dedup. Frequency+decay scoring was evaluated and removed in v0.18.0. Replaced by opt-in recency boost in v0.19.0.
 - **MMR dedup**: Intra-document Maximal Marginal Relevance replaces hard per-document dedup. `mmr_lambda=0.5` (fixed).
 - **Embeddings**: FastEmbed (ONNX) or MLX (Apple Silicon). Default `BAAI/bge-small-en-v1.5` (384 dims). Multilingual models available via `vstash reindex`.
-- **Code-aware chunking**: Hybrid 3-tier splitting — tree-sitter AST (25+ languages, optional) → parso AST (Python) → regex (6 languages). Graceful degradation. See `code_split.py`.
+- **Code-aware chunking**: Hybrid 3-tier splitting: tree-sitter AST (25+ languages, optional) -> parso AST (Python) -> regex (6 languages). Graceful degradation. See `code_split.py`.
 - **Single SQLite file**: WAL mode, foreign keys, all data in one `.db`.
 - **Optional snapvec backends**: Compressed ANN via PolarQuant. Two variants: `snapvec` (flat quantized) and `snapvec-ivfpq` (IVFPQ with fp16 rerank, pareto-dominant over sqlite-vec at N >= 50K). Opt-in with `storage.vector_backend`; sqlite-vec stays default. Fit via `vstash snapvec fit` before use.
 - **Local-first LLM**: Default backend `"local"` auto-detects Ollama, LM Studio, or any OpenAI-compatible local server.
@@ -86,6 +106,10 @@ docs/               # User-facing documentation
 - **`retrieval_mode` enum (v0.33)**: `Literal["hybrid", "vec_only", "fts_only"] = "hybrid"` on `VstashStore.search`, `Memory.search`, `Memory.ask`, MCP tools, and `VstashRetriever`. `vec_only` is the new symmetric branch to `fts_only` (skip FTS5, force `(1.0, 0.0)` weights). Default stays `hybrid` -- paper / README / v3 model numbers all measured against it. Legacy `fts_only=True` bool is deprecated in v0.33.0 with a `DeprecationWarning`.
 - **`chat.ask_full()` returning `AskResult` (v0.36)** (#303/#310): Public API that surfaces the reasoning channel and token usage that `ask()` discards. `_ask_cerebras` / `_ask_ollama` / `_ask_openai` now return `AskResult` internally; `ask()` is a thin wrapper returning `.content` so the existing `-> str` contract is preserved with zero call-site changes. Cerebras `gpt-oss-120b` populates `message.reasoning`; Ollama qwen3 thinking-mode uses `message.thinking`; OpenAI-compat servers (vLLM, DeepSeek, Together, xAI Grok, OpenAI o1/o3) read `message.reasoning_content`. Shared helpers `_extract_reasoning` (accepts both field names) and `_normalize_usage` (returns complete dict or `None`, never partial). `Memory.ask_full()` mirrors `Memory.ask()`; `Memory.ask` itself routes through `ask_full(...).content` so retrieval / LLM plumbing live in a single load-bearing path. Drives Merken Phase 2 distillation (`Q -> reasoning_trace -> A` shape).
 - **Centralized store construction (v0.36)** (#297/#306): `vstash._store_open.open_store_for_config(cfg)` is the single entry point used by CLI, MCP, web, SDK, journal, and `federated_search`. Replaces the previous per-surface `VstashStore(...)` wiring that silently dropped IVFPQ tuning fields on some paths.
+- **Services layer (post-v0.36)** (#327/#334/#335/#336): `vstash/services/{search,ask}.py` centralises the `embed -> validate -> search -> expand` triplet that the four adapters (web, MCP, CLI, SDK) all duplicated. Every adapter now routes through `services/`, so validation runs at the API boundary before the daemon round-trip and there is one load-bearing path for retrieval/LLM plumbing. When changing search behaviour, edit `services/search.py` first; `VstashStore.search` remains the underlying primitive.
+- **Domain error tree (post-v0.36)** (#326): `vstash/errors.py` defines `VstashError` as the ancestor for `LimitError` (boundary validation), `SchemaVersionError`, and friends. Each leaf multi-inherits the historical `ValueError` / `RuntimeError` it used to raise, so existing `except ValueError` callers keep working without changes.
+- **VectorBackend Protocol (post-v0.36)** (#328): `vstash/vectorbackend/base.py` defines the `VectorBackend` `Protocol` (runtime-checkable). `snapvec_ivfpq.py` is the first concrete impl extracted from legacy `_ivfpq_backend.py`; the legacy module is a deprecated re-export shim slated for removal in v0.40. Use the Protocol contract when adding a new backend.
+- **Built-in embed model registry (post-v0.36)** (#330): replaces the if/elif dispatch in `embed_texts` / `embed_query` / `warmup`. New built-in models register themselves in the registry; the custom encoder resolver hook (#278) still wins over built-ins for non-stock models.
 - **`vec_only` long-query distance cutoff (v0.36)** (#304): `retrieval_mode="vec_only"` now applies the same long-query distance-cutoff relaxation as `hybrid`. Previously it forced `adaptive_rrf=False` and skipped the relaxation; ArguAna `vec_only` had been collapsing to NDCG@10 = 0.0013 (1403/1406 zero) and is now 0.4250. Hybrid mode and all paper / model-card numbers untouched.
 - **`vstash why` miss analysis (v0.33)**: CLI + `/debug/why` HTTP route + auto-logged `miss_hint` on empty / low-relevance searches. `vstash why "<q>" --expect <path>` traces where a target chunk was eliminated in the pipeline (vector pool, distance cutoff, FTS match, RRF fusion, MMR, context expansion) and suggests the parameter that would have surfaced it. `vstash why --recent` lists recent misses from the auto-log.
 - **Eval-gated retrain (v0.33 complete: T1.1 / T1.3 / T1.4 / T1.5 / H-R1 / H-R5 / H-R7 / H-R8)**: `retrain()` composes `split_corpus_for_eval` + `evaluate_model` + `generate_triples` + `train_mnrl` + atomic `.candidate`/`.old` promote. Refuses to save a candidate whose held-out NDCG@10 is worse than the baseline. `qrels_to_eval_queries` converts BEIR-style labels. Multi-corpus training with temperature sampling (T1.4), GPU-batched mining + eval (T1.4b/c), labeled-query mining from BEIR qrels (T1.5), auto-promoted eval queries (H-R1), bulk mining on single-corpus (H-R8), full eval observability + seed reproducibility (H-R5/H-R7). Validated in Colab at +5.00% macro NDCG@10. v3 model on HF as `Stffens/bge-small-rrf-v3`.
@@ -94,9 +118,9 @@ docs/               # User-facing documentation
 - **`vec_chunks` cosine metric + schema v2 (v0.34)** (#271/#272/#286): sqlite-vec defaults to L2, but vstash labelled the value "cosine distance" everywhere. Worked accidentally for BGE unit-normalized embeddings; broke for `paraphrase-multilingual` and any model where L2 exceeds 2.0. DDL now includes `distance_metric=cosine`; v1 DBs migrate in place on open via atomic (`BEGIN IMMEDIATE`) + idempotent (`sqlite_master` guard) + streaming-in-SQL (`TEMP` backup, no Python materialisation) rebuild. `relevance_tier` thresholds rescaled to cosine (0.4513/0.4802) and `distance_cutoff` defaults squared (`1.15 -> 1.3225`, long-query `5.0 -> 25.0`) so BGE keeps identical behaviour. BEIR 5-dataset regression gate passed. Validation probes in `experiments/probe_272_*.py` + `experiments/beir_272_cosine_validation_colab.ipynb`.
 - **Custom encoder resolver hook (v0.34)** (#278/#287/#288): `register_encoder_resolver(fn)` / `unregister_encoder_resolver` + an `Encoder` `Protocol` let callers plug in LoRA-adapted, locally fine-tuned, or otherwise-unnamable encoders. Consulted before every built-in path (daemon, Gemma, HF ONNX, MLX, FastEmbed); identity-based registration; shape + protocol validation on resolver output; `ValueError` with offending index when a custom encoder returns the wrong batch size or dim. Docstring carries a SentenceTransformer adapter recipe (ST uses `get_sentence_embedding_dimension()`).
 - **Flat snapvec similarity-to-distance fix (v0.34)** (#289/#290): `SnapIndex.search` returns similarity in `[-1, 1]` but the store was feeding it straight into `distance_cutoff` / `relevance_tier` / `last_best_distance`. Ranking worked by accident, but the cutoff was effectively a no-op and perfect matches reported as `"low"` relevance. Per-backend conversion at the call site; `[0, 2]` clamp; sibling `snapvec-ivfpq` backend already did the right thing internally and is not double-inverted.
-- **Integrity & recovery (v0.24)**: `doc_completeness(path, collection)` → idempotent ingest; `integrity_check()` runs 5 invariants (chunk_count parity, vec/snapvec parity, FTS5 built-in `integrity-check`, orphans, PRAGMA) and returns a `list[IntegrityCheck]`; `integrity_repair()` is profile-scoped (rebuilds `fts_chunks`, recomputes chunk_count, deletes orphans). v0.24.1 made the **partial-ingest recovery path** (via `delete_document(path, collection=...)`) collection-scoped so repairing one collection cannot wipe a sibling collection's copy of the same path. Exposed as `vstash check [--repair] [--json]`.
+- **Integrity & recovery (v0.24)**: `doc_completeness(path, collection)` -> idempotent ingest; `integrity_check()` runs 5 invariants (chunk_count parity, vec/snapvec parity, FTS5 built-in `integrity-check`, orphans, PRAGMA) and returns a `list[IntegrityCheck]`; `integrity_repair()` is profile-scoped (rebuilds `fts_chunks`, recomputes chunk_count, deletes orphans). v0.24.1 made the **partial-ingest recovery path** (via `delete_document(path, collection=...)`) collection-scoped so repairing one collection cannot wipe a sibling collection's copy of the same path. Exposed as `vstash check [--repair] [--json]`.
 - **Explicit contracts & schema versioning (v0.25)**: `SCHEMA_VERSION` + `KNOWN_SCHEMA_VERSIONS` stamped in the `store_meta` table; `SchemaVersionError` on unknown versions; `INSERT OR IGNORE` for concurrent fresh-open; forward-compatible top-level config keys (warn-on-unknown). `SearchResult.score` is the RRF score with `k=60`, range `[0, ~0.033]`, comparable within a query but **not across queries**.
-- **Operational observability (v0.21–v0.22)**: in-process metrics registry, slow query log, `miss_analysis(query_embedding, query_text, *, expected_path=...)` API for ranking debugging (traces where a chunk was eliminated + rule-based suggestions).
+- **Operational observability (v0.21-v0.22)**: in-process metrics registry, slow query log, `miss_analysis(query_embedding, query_text, *, expected_path=...)` API for ranking debugging (traces where a chunk was eliminated + rule-based suggestions).
 - **Explicit limits (v0.23)**: `vstash/validation.py` + `[limits]` section with 7 knobs and a `LimitError(ValueError)` hierarchy. Rejects pathological inputs at `VstashStore`/`Memory` boundaries before they hit SQLite/sqlite-vec/ONNX.
 - **Threading hardening (v0.20)**: `sqlite3.threadsafety > 0` asserted at module import time; STEM (FTS5 Porter stemming) connections can be closed from any thread.
 
@@ -106,9 +130,9 @@ docs/               # User-facing documentation
 - **Pydantic v2** for all config and data models (frozen=True)
 - **Type hints** on all public functions
 - **ruff** for linting and formatting (enforced in CI)
-- **pytest** for testing (900+ tests as of v0.35.0, benchmark regression tests marker-gated off by default)
+- **pytest** for testing (1200+ tests as of v0.36.0, benchmark regression tests marker-gated off by default)
 - **Conventional commits** with emoji prefixes (feat, fix, docs, chore, perf)
-- **No AI co-author lines** — do NOT add `Co-Authored-By` or any AI attribution to commit messages
+- **No AI co-author lines**: do NOT add `Co-Authored-By` or any AI attribution to commit messages
 
 ## Database schema
 
@@ -123,15 +147,17 @@ search_events (id, query, best_distance, relevance_tier, result_count, dismissed
 
 ## Config file
 
-`vstash.toml` — resolution order: `$VSTASH_CONFIG` → `./vstash.toml` → `~/.vstash/vstash.toml` → defaults.
+`vstash.toml` resolution order: `$VSTASH_CONFIG` -> `./vstash.toml` -> `~/.vstash/vstash.toml` -> defaults.
 
 Key sections: `[inference]`, `[cerebras]`, `[ollama]`, `[openai]`, `[embeddings]`, `[chunking]`, `[scoring]`, `[storage]`.
 
 ## Common tasks
 
-- **Add a new CLI command**: Add `@app.command()` function in `cli.py`, update docstring at top of file.
-- **Add a new embedding model**: Add to `KNOWN_DIMS` and optionally `_MLX_MODEL_MAP` in `embed.py`.
-- **Change search behavior**: Modify `VstashStore.search()` in `store.py`. The pipeline is: vector search → FTS search → RRF merge → scoring → MMR dedup → context expansion.
+- **Add a new CLI command**: Add `@app.command()` function in `cli.py`, update docstring at top of file. (#284 will split this into `vstash/cli/<command>.py`; until merged, cli.py stays monolithic.)
+- **Add a new embedding model**: Register in the built-in registry in `embed.py` (and optionally `_MLX_MODEL_MAP` for MLX). For non-stock fine-tunes, prefer `register_encoder_resolver(fn)` over editing the registry.
+- **Change search behavior**: Edit `vstash/services/search.py` first if it is adapter-shared (validation, embedding, expand). Edit `VstashStore.search()` in `store.py` for the underlying retrieval pipeline: vector search -> FTS search -> RRF merge -> scoring -> MMR dedup -> context expansion.
+- **Add a new vector backend**: Implement the `VectorBackend` Protocol in `vstash/vectorbackend/base.py`. See `snapvec_ivfpq.py` as the reference impl. Add a runtime-checkable conformance test mirroring `test_vectorbackend.py`.
+- **Open a `VstashStore` from a new surface**: call `vstash._store_open.open_store_for_config(cfg)`. Never instantiate `VstashStore(...)` directly from an adapter.
 - **Add a config field**: Add to the relevant Pydantic model in `config.py`, update `docs/configuration.md`.
 - **Run experiments**: `python -m experiments.<name>` (e.g., `experiments.scoring_grid`).
 - **Run Kaggle-scale benchmarks**: `python -m experiments.arxiv_retrieval_bench` (1K papers, 3 models) or `python -m experiments.dataset_discovery` (954 HuggingFace datasets, interactive mode with `--interactive`).
@@ -141,18 +167,18 @@ Key sections: `[inference]`, `[cerebras]`, `[ollama]`, `[openai]`, `[embeddings]
 ## Branching strategy
 
 ```
-feature/* ──→ develop ──→ main (via release PR)
-   │              │            │
-   │              │            └── protected, = PyPI published version
-   │              └── integration branch, all features merge here
-   └── short-lived, one feature per branch
+feature/* --> develop --> main (via release PR)
+   |             |            |
+   |             |            +-- protected, = PyPI published version
+   |             +-- integration branch, all features merge here
+   +-- short-lived, one feature per branch
 ```
 
 - **Feature branches**: branch from `develop`, PR back to `develop`.
 - **develop**: integration branch. All feature PRs target `develop`.
 - **main**: protected. Only updated via release PRs from `develop`. Always matches the latest PyPI version.
-- **Release flow**: when `develop` is ready, create a version bump PR from `develop` → `main`, then publish to PyPI and create a GitHub release.
-- **NEVER merge features directly to `main`** — this causes `develop` to fall behind and creates conflicts.
+- **Release flow**: when `develop` is ready, create a version bump PR from `develop` -> `main`, then publish to PyPI and create a GitHub release.
+- **NEVER merge features directly to `main`**: this causes `develop` to fall behind and creates conflicts.
 
 ## CI
 

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -1,4 +1,4 @@
-"""vstash.services.search -- the embed -> search -> expand triplet.
+"""vstash.services.search -- the validate -> embed -> search -> expand triplet.
 
 A pure function that the adapters (CLI, MCP, web, SDK) all call to
 turn a user query into a list of relevant chunks. Replaces the


### PR DESCRIPTION
## Summary

CLAUDE.md was written before the Sprint 2 architectural seams (errors,
services, vectorbackend, embed registry) landed. A new agent reading it
would have edited adapters as before instead of routing through `services/`,
duplicating the `embed -> validate -> search -> expand` triplet that #327
removed.

## What changed

- **`vstash/` structure**: added `_store_open.py`, `services/`,
  `vectorbackend/`, `errors.py`, `validation.py`, `metrics.py`, `web.py`,
  `retrain_batch.py`, and the deprecated `_ivfpq_backend.py` shim.
- **`tests/`**: 1200+ tests across 50+ files (was "900+ as of v0.35.0");
  list reorganised by layer instead of chronologically.
- **Architecture decisions**: 4 new entries for services layer
  (#327/#334/#335/#336), domain error tree (#326), VectorBackend
  Protocol (#328), and built-in embed registry (#330). Centralized
  store construction (#306) was already documented.
- **Common tasks**: `services/search.py` is now the canonical edit site
  for adapter-shared retrieval changes; added "Add a new vector backend"
  and "Open a `VstashStore` from a new surface".
- **ASCII-only**: replaced 7 em dashes, 1 en dash, 5 Unicode arrows, and
  the branching diagram box-drawing chars with standard keyboard
  equivalents.

## Test plan

- [x] No code touched, doc-only.
- [x] `grep -P "[^\x00-\x7F]" CLAUDE.md` returns nothing (file is pure ASCII).
- [x] All file/directory references in the structure block exist on develop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project guide to reflect current architecture, components, conventions, branching strategy, and guidance for adding adapters and embedding/search/backend integrations; refreshed counts, wording, and key design notes.
  * Clarified module header wording to better describe the end-to-end processing flow.

* **Chores**
  * Expanded ignore rules to exclude local working directories and specific draft artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/337)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->