### PR TITLE
⚡ Bolt: Pre-group chunk indices in MMR deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+## 2024-05-20 - Pre-group elements by key to avoid linear scans
+**Learning:** In MMR deduplication (`_mmr_dedup`), computing the redundancy penalty iteratively scanned all remaining elements to find sibling chunks from the same document. This caused an unnecessary $O(K \times N)$ linear scan overhead.
+**Action:** Pre-group chunk indices by their document key (`doc_keys`) into a dictionary (`doc_to_indices`). This avoids scanning all remaining chunks and drops the redundancy penalty update loop complexity from $O(K \times N)$ to $O(N + K \times S)$, where S is the number of sibling chunks.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3300,6 +3300,14 @@ class VstashStore:
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
 
+        # Pre-group chunk indices by document key to avoid O(K * N) linear scans.
+        # This reduces the redundancy penalty update loop to O(N + K * S).
+        from collections import defaultdict
+
+        doc_to_indices = defaultdict(list)
+        for idx in remaining:
+            doc_to_indices[doc_keys[idx]].append(idx)
+
         # Track the maximum similarity to any selected chunk from the *same document*.
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
@@ -3327,21 +3335,22 @@ class VstashStore:
             selected.append(chosen)
             remaining.remove(best_idx)
 
+            new_doc_key = doc_keys[best_idx]
+            doc_to_indices[new_doc_key].remove(best_idx)
+
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
-            new_doc_key = doc_keys[best_idx]
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+                for idx in doc_to_indices[new_doc_key]:
+                    idx_emb = chunk_embs[idx]
+                    if idx_emb is not None:
+                        sim = _cosine_sim(
+                            idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
+                        )
+                        if sim > max_sims[idx]:
+                            max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
💡 **What**: Refactored the `_mmr_dedup` diversity selection loop in `vstash/store.py` to pre-group chunk indices by document keys (`doc_keys`) using a `defaultdict`.
🎯 **Why**: When a chunk is selected for top-k results, MMR updates the maximum similarity state for all other chunk candidates from the same document. Previously, locating these sibling chunks required a linear scan across all `remaining` indices, imposing a redundant $O(K \times N)$ computational overhead inside the core MMR loop. By maintaining an index map of `doc_keys` to remaining elements, we can look up sibling chunks in $O(1)$ and only iterate over the specific siblings when updating max similarities.
📊 **Impact**: Drops the diversity penalty update complexity from $O(K \times N)$ to $O(N + K \times S)$, where `S` is the number of same-document sibling candidates. For corpuses with large numbers of distinct documents, this removes thousands of unnecessary comparisons.
🔬 **Measurement**: Verified using `pytest tests/` mapping functionality and `git diff`. Correctness is fully preserved because iterating `doc_to_indices` yields exactly the same values as the filtered linear scan. Checked for speed gains and code health passed.

---
*PR created automatically by Jules for task [13813513377271035206](https://jules.google.com/task/13813513377271035206) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of result deduplication by optimizing similarity computation logic, reducing unnecessary recalculations when processing large result sets.

* **Documentation**
  * Updated internal documentation with algorithm optimization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->