### PR TITLE
⚡ Bolt: Optimize MMR deduplication penalty updates using pre-grouped document indices

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - Pre-group chunk indices by document to optimize MMR penalty updates
+**Learning:** During MMR deduplication (`_mmr_dedup`), scanning the entire `remaining` list of candidates to find chunks from the same document in order to update their redundancy penalty (max similarity) is extremely inefficient, scaling at $O(K \times N)$.
+**Action:** Pre-group chunk indices by their document key (`doc_keys`) into a dictionary (`doc_to_indices`) outside the loop. When a chunk is selected, iterate only over its pre-grouped sibling indices. This reduces the penalty update complexity from $O(K \times N)$ to $O(N + K \times S)$, where $S$ is the number of siblings per document.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3300,6 +3300,14 @@ class VstashStore:
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
 
+        # Pre-group chunk indices by document key to avoid O(N) scans
+        # when updating max_sims for sibling chunks.
+        import collections
+
+        doc_to_indices = collections.defaultdict(list)
+        for idx, doc_key in enumerate(doc_keys):
+            doc_to_indices[doc_key].append(idx)
+
         # Track the maximum similarity to any selected chunk from the *same document*.
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
@@ -3333,8 +3341,12 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    # We only need to check idx that are still remaining, but iterating
+                    # over them is very fast. Checking if idx is in remaining could be O(N).
+                    # Actually we can just update max_sims[idx] even if it's already selected
+                    # (it won't affect anything because we only pick from `remaining`).
+                    if idx != best_idx:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
💡 **What**:
Pre-groups chunk indices by their document key (`doc_keys`) into a `collections.defaultdict(list)` before entering the inner `max_sims` penalty update loop in `_mmr_dedup`.

🎯 **Why**:
When applying the redundancy penalty in the greedy selection algorithm, the loop was linearly scanning the entire `remaining` list of candidates (an `O(N)` operation) just to find chunks belonging to the same document. For large sets of candidates `N` and `top_k` iterations `K`, this resulted in an expensive `O(K * N)` update bottleneck purely from checking `if doc_keys[idx] == new_doc_key`.

📊 **Impact**:
Reduces the redundancy penalty update complexity in `_mmr_dedup` from `O(K * N)` to `O(N + K * S)`, where `S` is the number of sibling chunks per document. This significantly decreases computational overhead and speeds up the search pipeline for tasks requiring diversity selection over many duplicated candidates.

🔬 **Measurement**:
Unit tests for `_mmr_dedup` confirm correct deduplication behavior. Checked performance overhead logic visually. Checked syntax correctly resolves through Ruff. No breaking changes or regressions introduced.

---
*PR created automatically by Jules for task [8110545118953558751](https://jules.google.com/task/8110545118953558751) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized deduplication logic for improved performance when handling search result rankings and similarity assessments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->