### PR TITLE
chore(deps): pin tree-sitter-language-pack <1.8 (#344)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ ingest = ["markitdown>=0.1.0"]
 serve = ["starlette>=0.37.0", "uvicorn>=0.30.0"]
 langchain = ["langchain-core>=0.2.0,<1"]
 watch = ["watchdog>=4.0.0"]
-treesitter = ["tree-sitter-language-pack>=0.7.0"]
+treesitter = ["tree-sitter-language-pack>=0.7.0,<1.8"]
 snapvec = ["snapvec>=0.7.1"]
 all = [
     "vstash[cerebras]",


### PR DESCRIPTION
## Summary

- Pin `tree-sitter-language-pack>=0.7.0,<1.8` in `pyproject.toml`.
- Unblocks CI on every open PR (incl. #337) that hits a fresh dep install.

## Root cause

`tree-sitter-language-pack==1.8.0` (released between develop's last
green CI on 2026-05-04 and today) changed `get_parser()` to return
the bare C-extension `Parser` (`type(p).__module__ == 'builtins'`,
`dir(p) == []`) instead of the Python wrapper that exposed `.parse()`.
`vstash/code_split.py:226` calls `parser.parse(encoded)` and dies.

`tree-sitter` itself is unchanged: still `0.25.2` in both 1.6.2 and
1.8.0. The regression is entirely in `tree-sitter-language-pack`.

There is no `1.7.x` on PyPI -- the jump is `1.6.2 -> 1.8.0`.

## Repro

```bash
python -m venv /tmp/ts-repro
/tmp/ts-repro/bin/pip install 'tree-sitter-language-pack==1.8.0'
/tmp/ts-repro/bin/python -c "
from tree_sitter_language_pack import get_parser
p = get_parser('python')
print(type(p).__module__, type(p).__name__, hasattr(p, 'parse'))
"
# builtins Parser False   <-- BROKEN
```

With `1.6.2` the same script prints a wrapper class with `parse=True`.

## Bisect

| `tree-sitter-language-pack` | `tree-sitter` | `Parser.parse()` |
| --- | --- | --- |
| 1.4.2 | 0.25.2 | OK |
| 1.5.0 | 0.25.2 | OK |
| 1.6.0 | 0.25.2 | OK |
| 1.6.2 | 0.25.2 | **OK (last good)** |
| 1.8.0 | 0.25.2 | **BROKEN** |

## Test plan

- [ ] CI green on this branch (lint + 3.10/3.11/3.12 + CodeQL + CodeRabbit)
- [ ] After merge, rebase PR #337 and confirm its CI flips to green too
- [ ] When upstream ships a `1.8.x`/`1.9.x` that restores the wrapper API, relax the pin

Closes #344.