### PR TITLE
⚡ Bolt: O(1) removals and O(S) updates for MMR deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - O(1) removals and O(S) sibling updates in MMR Deduplication
+**Learning:** In MMR deduplication (`_mmr_dedup`), linear scans (`list.remove()`) and looping over all remaining chunks to update max similarities for sibling chunks add significant overhead ($O(N)$ per selection and $O(K \times N)$ max similarity updates).
+**Action:** Replace $O(N)$ `list.remove()` operations with $O(1)$ swap-with-last removal, combined with an `in_remaining` boolean mask and `pos_in_remaining` mapping. Additionally, pre-group chunk indices by their document key (`doc_keys`) into a `doc_to_indices` dictionary to restrict the max similarity updates only to relevant sibling chunks, reducing the inner loop complexity from $O(N)$ to $O(S)$ where $S$ is the number of sibling chunks.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3277,6 +3277,8 @@ class VstashStore:
 
         selected: list[dict[str, str | int | float]] = []
         remaining = list(range(len(ranked)))
+        pos_in_remaining = list(range(len(ranked)))
+        in_remaining = [True] * len(ranked)
 
         # Pre-compute normalized scores once (#167).  The value of
         # ``(score - s_min) / s_range`` is invariant across the outer
@@ -3296,6 +3298,14 @@ class VstashStore:
         # Extract values into fast lists for index-based access
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
+
+        # Pre-group chunk indices by document key to avoid O(N) linear scans
+        # when updating max_sims for sibling chunks.
+        from collections import defaultdict
+
+        doc_to_indices: dict[str, list[int]] = defaultdict(list)
+        for idx, doc_key in enumerate(doc_keys):
+            doc_to_indices[doc_key].append(idx)
 
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
@@ -3325,7 +3335,14 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # O(1) swap-with-last removal
+            idx_in_remaining = pos_in_remaining[best_idx]
+            last_idx = remaining[-1]
+            remaining[idx_in_remaining] = last_idx
+            pos_in_remaining[last_idx] = idx_in_remaining
+            remaining.pop()
+            in_remaining[best_idx] = False
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
@@ -3333,8 +3350,8 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
💡 What:
Replaced $O(N)$ `list.remove()` operations in `_mmr_dedup` with an $O(1)$ swap-with-last removal, utilizing an `in_remaining` boolean mask and `pos_in_remaining` tracking. Additionally, pre-grouped chunk indices by document key into a `doc_to_indices` dictionary. This restricts the inner max similarity update loop to iterate only over relevant sibling chunks, avoiding a full linear scan of all remaining candidates.

🎯 Why:
In the `_mmr_dedup` (Maximal Marginal Relevance) algorithm, selecting candidates involved an expensive `remaining.remove(best_idx)` list operation, costing $O(N)$ per selection. Even more critically, updating the redundancy penalty (maximum similarity against previously selected same-document chunks) scanned the entire `remaining` pool of size $N$ just to locate the few sibling chunks of the chosen document. This resulted in unnecessary $O(K \times N)$ operations in a hot algorithmic path.

📊 Impact:
- Reduces item removal complexity from $O(N)$ to $O(1)$.
- Reduces sibling max similarity update complexity from $O(K \times N)$ to $O(K \times S)$, where $S$ is the (typically very small) number of sibling chunks belonging to the selected document.
- Overall drastically reduces pure-Python overhead during the greedy selection loops, especially for queries returning high numbers of chunks or when $K$ is large.

🔬 Measurement:
Run retrieval benchmarks focusing on large contexts or high `top_k` values where same-document density is high. The speedup should be noticeable in pure CPU time spent during the `_mmr_dedup` reranking phase.

---
*PR created automatically by Jules for task [14280449975809835386](https://jules.google.com/task/14280449975809835386) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refactored MMR deduplication and selection implementation for enhanced performance.

* **Documentation**
  * Added technical learning notes on MMR optimization strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->