### PR TITLE
⚡ Bolt: Optimize MMR deduplication loop complexity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,10 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2026-05-17 - O(1) Swap-with-last Removal and Pre-grouping in Hot Loops
+**Learning:** In tight ranking/deduplication hot loops (like MMR), iterating repeatedly over remaining candidate chunks with O(N) `list.remove()` operations and O(N) membership/property checks (e.g. "does this chunk have the same `doc_key`?") scales very poorly, dropping from O(K * N) to slower empirical speeds due to array shifts and linear scanning.
+**Action:** In loops tracking 'remaining' candidates:
+1. Replace `list.remove()` with an O(1) swap-with-last approach (`remaining[pos] = remaining[-1]; remaining.pop()`), tracking index positions.
+2. Introduce an `in_remaining` boolean array accessed directly via candidate index for O(1) membership checks.
+3. Pre-group indices by keys (like `doc_to_indices`) to directly access matching elements without full iteration scans.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3304,6 +3304,17 @@ class VstashStore:
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
 
+        # Pre-group chunk indices by document key to avoid O(N) linear scans when updating max_sims
+        from collections import defaultdict
+
+        doc_to_indices = defaultdict(list)
+        for i, dk in enumerate(doc_keys):
+            doc_to_indices[dk].append(i)
+
+        in_remaining = [True] * len(ranked)
+        # For O(1) removal, track position in the remaining list
+        pos_in_remaining = list(range(len(ranked)))
+
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
             best_mmr = -float("inf")
@@ -3325,7 +3336,14 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # O(1) swap-with-last removal
+            in_remaining[best_idx] = False
+            remove_pos = pos_in_remaining[best_idx]
+            last_idx = remaining[-1]
+            remaining[remove_pos] = last_idx
+            pos_in_remaining[last_idx] = remove_pos
+            remaining.pop()
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
@@ -3333,8 +3351,8 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
💡 **What:** 
- Group chunk indices by their document key (`doc_keys`) into a dictionary (`doc_to_indices`) prior to the greedy MMR loop.
- Replace the $O(N)$ `remaining.remove(best_idx)` with an $O(1)$ swap-with-last operation, maintaining an `in_remaining` boolean mask and tracking index positions.

🎯 **Why:** 
In the MMR deduplication loop, tracking remaining chunks via $O(N)$ `list.remove()` operations and performing an $O(N)$ linear scan to find sibling chunks (checking `doc_keys[idx] == new_doc_key`) scales extremely poorly as $N$ grows. This dropped the theoretical $O(K \times N \times D)$ runtime closer to $O(K \times N^2)$ overhead due to array shifting and exhaustive iteration.

📊 **Impact:** 
Cuts the intra-loop removal and penalty update logic from $O(N)$ to $O(S)$ where $S$ is the number of sibling chunks for a specific document, drastically reducing pure-Python computational overhead for large inputs.

🔬 **Measurement:**
Tested locally via an isolated mock script simulating the `_mmr_dedup` input constraints to ensure the optimized O(1) swap logic exactly preserves the expected penalty application and resultant deduplication array. All unit tests (`pytest tests/test_store.py -k mmr`) pass/skip cleanly without regressional breaks.

---
*PR created automatically by Jules for task [14302590518378672058](https://jules.google.com/task/14302590518378672058) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized ranking and duplicate handling operations for improved performance during search and filtering tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->