### PR TITLE
⚡ Bolt: [performance improvement] optimize MMR deduplication complexity

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - MMR list removal and indexing optimization
+**Learning:** In MMR deduplication, `remaining.remove(idx)` is an O(N) operation and iterating over all remaining elements to find siblings is another O(N) scan. This increases selection loop complexity to O(K*N).
+**Action:** Replace `list.remove()` with an O(1) swap-with-last strategy (`list[idx] = list[-1]; list.pop()`). Introduce a boolean array mask (`in_remaining`) for O(1) membership checks, and pre-group candidates by document key (`doc_to_indices`) to reduce the sibling lookup to O(S).

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3300,21 +3300,33 @@ class VstashStore:
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
 
+        # Pre-group chunk indices by document to avoid O(N) scans when updating max_sims
+        from collections import defaultdict
+
+        doc_to_indices = defaultdict(list)
+        for idx, doc_key in enumerate(doc_keys):
+            doc_to_indices[doc_key].append(idx)
+
         # Track the maximum similarity to any selected chunk from the *same document*.
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
 
+        # Boolean mask for O(1) membership checks
+        in_remaining = [True] * len(ranked)
+
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
+            best_pos = -1
             best_mmr = -float("inf")
 
-            for idx in remaining:
+            for pos, idx in enumerate(remaining):
                 max_sim = max_sims[idx]
 
                 mmr_score = relevance_terms[idx] - penalty_multiplier * max_sim
                 if mmr_score > best_mmr:
                     best_mmr = mmr_score
                     best_idx = idx
+                    best_pos = pos
 
             if best_idx < 0 or best_mmr < 0:
                 # Stop when the best remaining candidate has negative MMR,
@@ -3325,7 +3337,11 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # O(1) removal using swap-with-last
+            remaining[best_pos] = remaining[-1]
+            remaining.pop()
+            in_remaining[best_idx] = False
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
@@ -3333,8 +3349,9 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                # Iterate only over siblings instead of all remaining
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
💡 What: Replaced the O(N) `list.remove()` with an O(1) swap-with-last strategy during MMR candidate selection. Added a `doc_to_indices` index to map document keys to their candidate chunk indices, bypassing a full O(N) scan on every loop in favor of evaluating only document siblings O(S).

🎯 Why: The nested selection loop during MMR deduplication contained hidden O(N) array shifts from `remove()` and O(N) linear scans searching for sibling candidates, needlessly compounding the complexity. This change optimizes the hot loop computationally without sacrificing code readability.

📊 Impact: Reduces sibling lookup complexity from O(K*N) to O(S), and array removal complexity from O(N) to O(1), improving query execution speeds over large batches with severe redundancy.

🔬 Measurement: Evaluated manually via `test_mmr.py` isolation script verifying functionality stability on chunk removals.

---
*PR created automatically by Jules for task [843996661808297382](https://jules.google.com/task/843996661808297382) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the MMR deduplication algorithm for faster and more efficient candidate selection and redundancy computation during result processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/356?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->