### PR TITLE
⚡ Bolt: O(1) MMR deduplication candidate removal and penalty updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-22 - O(1) swap-with-last removal in hot loops
+**Learning:** In MMR deduplication (`_mmr_dedup`), using `list.remove()` inside the top-k selection loop introduces an O(N) penalty because it requires scanning the list and shifting elements. Combined with an O(N) array scan to update siblings, this degrades performance.
+**Action:** Replace `list.remove()` with an O(1) swap-with-last removal (`remaining[idx] = remaining[-1]; remaining.pop()`). Use a boolean mask array (`in_remaining`) for O(1) membership checks, and pre-group sibling indices into a dictionary (`doc_to_indices`) to avoid O(N) array scans when updating similarity penalties.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3304,17 +3304,29 @@ class VstashStore:
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
 
+        # O(1) mask for remaining checks.
+        in_remaining = [True] * len(ranked)
+
+        # Pre-group indices by document key to avoid O(N) scans when updating max_sims.
+        from collections import defaultdict
+
+        doc_to_indices = defaultdict(list)
+        for i, dk in enumerate(doc_keys):
+            doc_to_indices[dk].append(i)
+
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
             best_mmr = -float("inf")
+            best_rem_idx = -1
 
-            for idx in remaining:
+            for rem_idx, idx in enumerate(remaining):
                 max_sim = max_sims[idx]
 
                 mmr_score = relevance_terms[idx] - penalty_multiplier * max_sim
                 if mmr_score > best_mmr:
                     best_mmr = mmr_score
                     best_idx = idx
+                    best_rem_idx = rem_idx
 
             if best_idx < 0 or best_mmr < 0:
                 # Stop when the best remaining candidate has negative MMR,
@@ -3325,16 +3337,22 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # Use O(1) swap-with-last removal, combined with an array mask,
+            # to replace the O(N) list.remove() inside the hot selection loop.
+            remaining[best_rem_idx] = remaining[-1]
+            remaining.pop()
+            in_remaining[best_idx] = False
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
+            # Use pre-grouped sibling indices to avoid O(N) array scans here.
             new_doc_key = doc_keys[best_idx]
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
### 💡 What
This PR optimizes the inner loop of `_mmr_dedup` inside `vstash/store.py` by:
1. Replacing the O(N) `list.remove()` operation with an O(1) swap-with-last removal logic.
2. Introducing an O(1) boolean mask (`in_remaining`) for fast membership checks.
3. Pre-grouping candidate indices by document key (`doc_to_indices`) to drastically narrow down the similarity recalculation loop bounds from scanning the entirety of `remaining` to only scanning sibling chunks.

### 🎯 Why
In large datasets with highly duplicate chunks, the MMR deduplication loops suffer heavy computational overhead. Removing an element using `list.remove()` scans and shifts arrays (O(N)), and updating penalties requires scanning all remaining candidates to check for sibling keys (O(N)). These overheads add up to O(K*N) complexity. The new approach eliminates these bottlenecks.

### 📊 Impact
Reduces loop overhead for MMR deduplication arrays from O(K*N) down to O(K) complexity during removal operations, avoiding linear shifts and unneeded iteration.

### 🔬 Measurement
All `tests/test_store.py` tests pass without regression. Benchmarks measuring MMR operations run noticeably faster under large candidate duplicate generation.

---
*PR created automatically by Jules for task [761548708940058339](https://jules.google.com/task/761548708940058339) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized the deduplication algorithm to reduce computational costs during result processing. These improvements enhance system performance by streamlining the duplicate-removal workflow, delivering faster query response times, better efficiency, and improved scalability when handling large result datasets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->