### PR TITLE
⚡ Bolt: Optimize MMR deduplication by replacing linear scans with O(1) structures

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - O(N) to O(1) Replacement in Selection Arrays
+**Learning:** In MMR deduplication, the selected candidates are extracted from a list (`remaining`) during the greedy loop. Using `remaining.remove(idx)` is an O(N) operation per step because Python shifts subsequent items. Additionally, repeatedly scanning all the items sequentially to find matches on a property (like `doc_keys`) when we know the group structure is highly redundant.
+**Action:** Replace `remove()` with an O(1) swap-with-last strategy (`remaining[best_rem_idx] = remaining[-1]; remaining.pop()`) guarded by an `in_remaining` boolean mask array. For repeated group lookups during iterations, build an index dictionary once before the loop (e.g., `doc_to_indices[doc_key] = [i, j, ...]`) to process sibling chunks efficiently.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3277,6 +3277,7 @@ class VstashStore:
 
         selected: list[dict[str, str | int | float]] = []
         remaining = list(range(len(ranked)))
+        in_remaining = [True] * len(ranked)
 
         # Pre-compute normalized scores once (#167).  The value of
         # ``(score - s_min) / s_range`` is invariant across the outer
@@ -3297,6 +3298,13 @@ class VstashStore:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
+        # Pre-group chunk indices by doc_keys to avoid O(N) linear scans when updating max_sims
+        doc_to_indices: dict[str, list[int]] = {}
+        for i, doc_key in enumerate(doc_keys):
+            if doc_key not in doc_to_indices:
+                doc_to_indices[doc_key] = []
+            doc_to_indices[doc_key].append(i)
+
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
 
@@ -3307,14 +3315,16 @@ class VstashStore:
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
             best_mmr = -float("inf")
+            best_rem_idx = -1
 
-            for idx in remaining:
+            for rem_idx, idx in enumerate(remaining):
                 max_sim = max_sims[idx]
 
                 mmr_score = relevance_terms[idx] - penalty_multiplier * max_sim
                 if mmr_score > best_mmr:
                     best_mmr = mmr_score
                     best_idx = idx
+                    best_rem_idx = rem_idx
 
             if best_idx < 0 or best_mmr < 0:
                 # Stop when the best remaining candidate has negative MMR,
@@ -3325,7 +3335,11 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # O(1) swap-with-last removal
+            remaining[best_rem_idx] = remaining[-1]
+            remaining.pop()
+            in_remaining[best_idx] = False
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
@@ -3333,8 +3347,8 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
💡 What: Replaced the O(N) list removal operation in `_mmr_dedup` with an O(1) swap-with-last removal, tracked by an `in_remaining` boolean mask. Pre-grouped chunk indices by `doc_keys` using a dictionary `doc_to_indices`.
🎯 Why: In the `_mmr_dedup` method, removing elements from the `remaining` list was an O(N) operation per top-K iteration. Additionally, when updating the `max_sims` for elements in the same document, the code would do an O(N) linear scan over all remaining items to check if they shared the same `doc_key`.
📊 Impact: This optimization drops the array shifting cost to O(1) and reduces the redundancy penalty update complexity from O(K * N) to O(N + K * S), saving redundant operations.
🔬 Measurement: Run the test suite using `pytest tests/test_store.py`.

---
*PR created automatically by Jules for task [7323953212385480129](https://jules.google.com/task/7323953212385480129) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notes documenting MMR deduplication selection optimization strategies.

* **Performance**
  * Optimized the Maximum Marginal Relevance (MMR) deduplication selection mechanism to enhance efficiency. Improved state tracking and per-document indexing during candidate selection to reduce computational overhead when processing duplicate items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->