### PR TITLE
⚡ Bolt: O(1) Sibling Updates in MMR Deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - O(1) Sibling Updates in MMR Deduplication
+**Learning:** During MMR deduplication (`_mmr_dedup`), mutating the `remaining` candidates list with `list.remove()` (which is $O(N)$) and performing a linear scan over all remaining elements just to update `max_sims` for a few same-document siblings causes a massive $O(K \times N)$ performance penalty.
+**Action:** Replace $O(N)$ list removals with an $O(1)$ swap-with-last removal, tracked by an `in_remaining` boolean mask. Pre-group chunk indices by document key (`doc_to_indices`) outside the loop to transform the $O(N)$ sibling scan into an $O(S)$ exact lookup, reducing redundancy penalty update complexity.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3300,21 +3300,35 @@ class VstashStore:
         # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
         chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
 
+        # Pre-group chunk indices by document key to avoid O(N) linear scans
+        # when updating sibling similarities.
+        doc_to_indices: dict[str, list[int]] = {}
+        for i, dk in enumerate(doc_keys):
+            if dk not in doc_to_indices:
+                doc_to_indices[dk] = [i]
+            else:
+                doc_to_indices[dk].append(i)
+
+        # Track membership for O(1) checks during sibling updates
+        in_remaining = [True] * len(ranked)
+
         # Track the maximum similarity to any selected chunk from the *same document*.
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
 
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
+            best_rem_idx = -1
             best_mmr = -float("inf")
 
-            for idx in remaining:
+            for rem_idx, idx in enumerate(remaining):
                 max_sim = max_sims[idx]
 
                 mmr_score = relevance_terms[idx] - penalty_multiplier * max_sim
                 if mmr_score > best_mmr:
                     best_mmr = mmr_score
                     best_idx = idx
+                    best_rem_idx = rem_idx
 
             if best_idx < 0 or best_mmr < 0:
                 # Stop when the best remaining candidate has negative MMR,
@@ -3325,7 +3339,11 @@ class VstashStore:
             if _explain:
                 chosen["_mmr_penalty"] = (1 - mmr_lambda) * max_sims[best_idx]
             selected.append(chosen)
-            remaining.remove(best_idx)
+
+            # O(1) removal using swap-with-last
+            in_remaining[best_idx] = False
+            remaining[best_rem_idx] = remaining[-1]
+            remaining.pop()
 
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
@@ -3333,8 +3351,8 @@ class VstashStore:
             new_emb = chunk_embs[best_idx]
             new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in remaining:
-                    if doc_keys[idx] == new_doc_key:
+                for idx in doc_to_indices[new_doc_key]:
+                    if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
                             sim = _cosine_sim(


### PR DESCRIPTION
### 💡 What
Optimized the Maximum Marginal Relevance (MMR) deduplication logic (`_mmr_dedup`) in `vstash/store.py` by removing two $O(N)$ inner-loop operations:
1. Replaced `list.remove()` (which shifts elements, costing $O(N)$) with an $O(1)$ swap-with-last removal logic.
2. Replaced the linear scan over all remaining candidate chunks to update maximum similarities for same-document siblings with an $O(S)$ exact lookup by pre-grouping chunk indices by document keys before the loop.
3. Added an `in_remaining` boolean array to keep $O(1)$ membership checks accurate without scanning the mutated array.

### 🎯 Why
In MMR deduplication, after a chunk is greedily selected, the redundancy penalty (`max_sims`) for any remaining chunks from the *same* document must be updated. Previously, the algorithm linearly scanned the entire `remaining` list (size $N$) to find these siblings, causing a significant $O(K \times N)$ performance overhead just to find a few matching siblings. Similarly, `remaining.remove(best_idx)` caused an $O(N)$ array shift for every selected item.

### 📊 Impact
Changes the inner-loop complexity for sibling updates from $O(N)$ to $O(S)$ (where $S$ is the number of sibling chunks from the same document). List removal drops from $O(N)$ to $O(1)$. This drastically reduces computational overhead for the MMR diversity pass, particularly on large candidate lists.

### 🔬 Measurement
Verified functionality and correctness via mock scripts asserting MMR logic correctly selects the same top_k diverse chunks as the original algorithm. No test regressions observed when running the test suite (`python -m pytest tests/ -m "not requires_sqlite_vec and not snapvec"`). Tested against `test_store.py`.

---
*PR created automatically by Jules for task [310081479211812417](https://jules.google.com/task/310081479211812417) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized MMR deduplication selection performance through improved candidate removal efficiency and streamlined redundancy penalty calculations.

* **Documentation**
  * Added optimization notes on loop invariant hoisting and deduplication strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/362?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->