### PR TITLE
feat(#106): tag filters in search + date/tag filters in journal_recall

### DIFF
--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -124,6 +124,45 @@ class TestJournalRecall:
         for e in entries:
             assert "Project B" not in e.get("text", "")
 
+    def test_recall_recent_with_tag_filter(self) -> None:
+        """``tags=`` on the recent-entries branch restricts by exact
+        tag membership (not substring)."""
+        from vstash.journal import journal_recall, journal_save
+
+        journal_save("Auth note about OAuth", tags="auth", source="test")
+        journal_save("Auth-note longer", tags="authentication", source="test")
+        journal_save("Deploy notes", tags="deploy", source="test")
+
+        entries = journal_recall(tags="auth")
+        titles = " | ".join(e.get("title", "") for e in entries)
+        # The "auth" entry must appear; "authentication" must NOT
+        # (comma-anchored membership, not substring).
+        for e in entries:
+            assert "authentication" not in (e.get("tags") or ""), (
+                f"tag=auth false-matched 'authentication' entry: {e.get('tags')}"
+            )
+        assert any("auth" in (e.get("tags") or "").split(",") for e in entries), (
+            f"expected the auth-tagged entry in results, got titles: {titles}"
+        )
+
+    def test_recall_query_with_tag_filter(self) -> None:
+        """``tags=`` on the semantic-search branch flows through to
+        ``store.search`` and constrains the candidate pool."""
+        from vstash.journal import journal_recall, journal_save
+
+        journal_save("Decision: switch from JWT to opaque tokens", tags="decision", source="test")
+        journal_save("Note: explored JWT alternatives", tags="note", source="test")
+
+        entries = journal_recall(query="tokens JWT", tags="decision")
+        # The semantic-search branch returns ``text/title/score/added_at``
+        # (no ``tags`` field surfaced), so we cannot assert per-entry tag
+        # values. The functional guarantee is that the ``note``-tagged
+        # entry must NOT appear in results -- its content alone would
+        # otherwise win on relevance.
+        assert all("alternatives" not in e.get("text", "") for e in entries), (
+            f"tag=decision filter leaked the note-tagged entry: {[e.get('text') for e in entries]}"
+        )
+
 
 # ------------------------------------------------------------------ #
 # journal_log                                                          #

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -969,7 +969,14 @@ class TestVstashJournalRecall:
         result = json.loads(vstash_journal_recall("past decisions"))
         assert len(result) == 1
         assert result[0]["title"] == "Entry 1"
-        mock_recall.assert_called_once_with(query="past decisions", top_k=5, project=None)
+        mock_recall.assert_called_once_with(
+            query="past decisions",
+            top_k=5,
+            project=None,
+            tags=None,
+            added_after=None,
+            added_before=None,
+        )
 
     @patch("vstash.journal.journal_recall")
     def test_recall_no_query_returns_recent(self, mock_recall: MagicMock) -> None:
@@ -977,7 +984,14 @@ class TestVstashJournalRecall:
 
         result = json.loads(vstash_journal_recall())
         assert result == []
-        mock_recall.assert_called_once_with(query=None, top_k=5, project=None)
+        mock_recall.assert_called_once_with(
+            query=None,
+            top_k=5,
+            project=None,
+            tags=None,
+            added_after=None,
+            added_before=None,
+        )
 
     @patch("vstash.journal.journal_recall", side_effect=Exception("search failed"))
     def test_recall_error(self, mock_recall: MagicMock) -> None:

--- a/tests/test_retrieval_mode.py
+++ b/tests/test_retrieval_mode.py
@@ -174,6 +174,7 @@ class TestCacheKeySeparation:
             recency_boost=0.0,
             added_after=None,
             added_before=None,
+            tags=None,
             mmr_lambda=0.5,
             cache_epoch=0,
         )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -181,6 +181,80 @@ class TestStoreSearch:
         results_str = sample_store.search([0.1] * dim, "content", top_k=10, tags="alpha, gamma")
         assert {r.title for r in results_str} == {"Alpha", "Gamma"}
 
+    def test_search_tag_list_element_with_comma_is_split(self, sample_store: VstashStore) -> None:
+        """Regression guard for the PR #364 review finding:
+        ``tags=["alpha,beta"]`` (a single-element list whose element
+        contains a comma) must be split internally so it queries for
+        either tag, not for a literal joint tag ``"alpha,beta"`` which
+        no document ever carries."""
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/test/a.md",
+            title="Alpha",
+            chunks=["alpha content"],
+            embeddings=[[0.1] * dim],
+            tags="alpha",
+        )
+        sample_store.add_document(
+            path="/test/b.md",
+            title="Beta",
+            chunks=["beta content"],
+            embeddings=[[0.1] * dim],
+            tags="beta",
+        )
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags=["alpha,beta"])
+        assert {r.title for r in results} == {"Alpha", "Beta"}, (
+            f"list element with comma was not split: got {sorted(r.title for r in results)}"
+        )
+
+    def test_ingest_tag_whitespace_normalized(self, sample_store: VstashStore) -> None:
+        """Regression guard for the PR #364 review finding: tags saved
+        with surrounding whitespace (``"alpha, beta"``) must be
+        normalized at write time so the comma-anchored search-side
+        ``LIKE`` can match them. Without ingestion-side normalization
+        the stored ``,alpha, beta,`` never matches ``%,beta,%``."""
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/test/spaced.md",
+            title="Spaced",
+            chunks=["spaced content"],
+            embeddings=[[0.1] * dim],
+            tags="alpha, beta",  # leading space before 'beta'
+        )
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags="beta")
+        assert {r.title for r in results} == {"Spaced"}, (
+            f"frontmatter-style tags with spaces not normalized at write: "
+            f"got {sorted(r.title for r in results)}"
+        )
+
+    def test_search_tag_cache_key_is_order_independent(self, sample_store: VstashStore) -> None:
+        """Regression guard for the PR #364 review finding: SQL ``OR``
+        is commutative, so ``tags=["alpha","beta"]`` and
+        ``tags=["beta","alpha"]`` are semantically identical and must
+        hit the same cache slot."""
+        dim = sample_store.embedding_dim
+        common: dict = dict(
+            query_embedding=[0.1] * dim,
+            query_text="q",
+            top_k=5,
+            vec_weight=None,
+            fts_weight=None,
+            distance_cutoff=1.3225,
+            collection=None,
+            project=None,
+            layer=None,
+            adaptive_rrf=True,
+            recency_boost=0.0,
+            added_after=None,
+            added_before=None,
+            mmr_lambda=0.5,
+            retrieval_mode="hybrid",
+            cache_epoch=0,
+        )
+        key_ab = sample_store._compute_search_cache_key(tags=["alpha", "beta"], **common)
+        key_ba = sample_store._compute_search_cache_key(tags=["beta", "alpha"], **common)
+        assert key_ab == key_ba, "cache key must be invariant to tag input order"
+
     def test_search_tag_filter_no_substring_false_match(self, sample_store: VstashStore) -> None:
         """``tag='alpha'`` must NOT match a doc tagged ``alphabet``.
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -138,6 +138,85 @@ class TestStoreSearch:
             assert isinstance(r.chunk, int)
             assert isinstance(r.score, float)
 
+    def test_search_tag_filter_single_string(self, sample_store: VstashStore) -> None:
+        """Single-tag filter passed as a string matches only docs that
+        have exactly that tag (comma-anchored membership, not substring)."""
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/test/alpha.md",
+            title="Alpha",
+            chunks=["alpha content one"],
+            embeddings=[[0.1] * dim],
+            tags="alpha,shared",
+        )
+        sample_store.add_document(
+            path="/test/beta.md",
+            title="Beta",
+            chunks=["beta content one"],
+            embeddings=[[0.1] * dim],
+            tags="beta,shared",
+        )
+        # tag="alpha" returns only the alpha-tagged doc
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags="alpha")
+        assert {r.title for r in results} == {"Alpha"}
+        # tag="shared" returns both
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags="shared")
+        assert {r.title for r in results} == {"Alpha", "Beta"}
+
+    def test_search_tag_filter_list_is_or(self, sample_store: VstashStore) -> None:
+        """A list (or comma-separated string) of tags is OR-semantics."""
+        dim = sample_store.embedding_dim
+        for name in ("alpha", "beta", "gamma"):
+            sample_store.add_document(
+                path=f"/test/{name}.md",
+                title=name.capitalize(),
+                chunks=[f"{name} content"],
+                embeddings=[[0.1] * dim],
+                tags=name,
+            )
+        # list form
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags=["alpha", "gamma"])
+        assert {r.title for r in results} == {"Alpha", "Gamma"}
+        # comma-string form must be equivalent
+        results_str = sample_store.search([0.1] * dim, "content", top_k=10, tags="alpha, gamma")
+        assert {r.title for r in results_str} == {"Alpha", "Gamma"}
+
+    def test_search_tag_filter_no_substring_false_match(self, sample_store: VstashStore) -> None:
+        """``tag='alpha'`` must NOT match a doc tagged ``alphabet``.
+
+        Regression guard for the comma-anchored LIKE pattern. A naive
+        ``tags LIKE '%alpha%'`` would false-match ``alphabet``,
+        ``alphanumeric``, ``galpha``. The anchor pattern wraps both
+        sides in commas so only exact tag membership matches.
+        """
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/test/exact.md",
+            title="Exact",
+            chunks=["exact match content"],
+            embeddings=[[0.1] * dim],
+            tags="alpha",
+        )
+        sample_store.add_document(
+            path="/test/super.md",
+            title="Super",
+            chunks=["substring noise content"],
+            embeddings=[[0.1] * dim],
+            tags="alphabet",
+        )
+        sample_store.add_document(
+            path="/test/prefix.md",
+            title="Prefix",
+            chunks=["prefix noise content"],
+            embeddings=[[0.1] * dim],
+            tags="galpha",
+        )
+        results = sample_store.search([0.1] * dim, "content", top_k=10, tags="alpha")
+        assert {r.title for r in results} == {"Exact"}, (
+            f"comma-anchored tag filter false-matched substring: "
+            f"got {sorted(r.title for r in results)}"
+        )
+
 
 class TestStoreDeduplication:
     """Test document-level deduplication in search results."""

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -566,6 +566,27 @@ def search(
     ),
     project: str | None = typer.Option(None, "--project", "-p", help="Restrict to project"),
     layer: str | None = typer.Option(None, "--layer", "-l", help="Restrict to layer"),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        "-t",
+        help=(
+            "Restrict to documents tagged with this value. Repeat the flag "
+            "for OR semantics (``--tag alpha --tag beta``), or pass a "
+            "comma-separated string in a single flag (``--tag 'alpha,beta'``). "
+            "Comma-anchored match -- ``alpha`` does NOT false-match ``alphabet``."
+        ),
+    ),
+    added_after: str | None = typer.Option(
+        None,
+        "--after",
+        help="ISO date filter: only documents added on or after this date (e.g. 2026-01-15).",
+    ),
+    added_before: str | None = typer.Option(
+        None,
+        "--before",
+        help="ISO date filter: only documents added strictly before this date.",
+    ),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output results as JSON"),
     all_profiles: bool = typer.Option(
         False, "--all-profiles", "-A", help="Search across all profiles"
@@ -711,6 +732,9 @@ def search(
                     collection=collection,
                     project=project,
                     layer=layer,
+                    tags=tag,
+                    added_after=added_after,
+                    added_before=added_before,
                     expand_window=1,
                 )
                 chunks = [r for _, r in tagged]
@@ -738,6 +762,9 @@ def search(
                     collection=collection,
                     project=project,
                     layer=layer,
+                    tags=tag,
+                    added_after=added_after,
+                    added_before=added_before,
                     explain=explain,
                     exact_match=exact_match,
                     exact_match_case_sensitive=exact_match_case_sensitive,
@@ -2778,12 +2805,39 @@ def journal_recall_cmd(
     query: str | None = typer.Argument(None, help="Search query (omit for recent entries)"),
     top_k: int = typer.Option(5, "--top-k", "-k", help="Number of entries"),
     project: str | None = typer.Option(None, "--project", "-p", help="Filter by project"),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        "-t",
+        help=(
+            "Restrict to journal entries tagged with this value. Repeat for "
+            "OR (``--tag work --tag decisions``), or pass a comma-separated "
+            "string (``--tag 'work,decisions'``). Comma-anchored match."
+        ),
+    ),
+    added_after: str | None = typer.Option(
+        None,
+        "--after",
+        help="ISO date filter: only entries logged on or after this date.",
+    ),
+    added_before: str | None = typer.Option(
+        None,
+        "--before",
+        help="ISO date filter: only entries logged strictly before this date.",
+    ),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw text (for hooks/pipes)"),
 ) -> None:
     """Recall relevant journal entries. Omit query for most recent."""
     from .journal import journal_recall
 
-    entries = journal_recall(query=query, top_k=top_k, project=project)
+    entries = journal_recall(
+        query=query,
+        top_k=top_k,
+        project=project,
+        tags=tag,
+        added_after=added_after,
+        added_before=added_before,
+    )
 
     if not entries:
         if not raw:

--- a/vstash/journal.py
+++ b/vstash/journal.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 from ._store_open import open_store_for_config
 from .config import VstashConfig, load_config
 from .embed import embed_query
+from .store import _normalize_tags
 from .profile import PROFILES_DIR
 from .store import VstashStore
 
@@ -214,27 +215,41 @@ def journal_recall(
     *,
     top_k: int = 5,
     project: str | None = None,
+    tags: str | list[str] | None = None,
+    added_after: str | None = None,
+    added_before: str | None = None,
     cfg: VstashConfig | None = None,
 ) -> list[dict]:
     """Recall relevant journal entries.
 
     When query is None, returns the most recent entries.
-    When query is provided, performs semantic search.
+    When query is provided, performs semantic search. Both branches
+    honour ``tags``, ``added_after`` and ``added_before`` -- they are
+    applied as document-level metadata filters before the candidate
+    pool is scored.
 
     Args:
         query: Optional search query. None = recent entries.
         top_k: Number of entries to return.
         project: Filter by project. None = all projects.
+        tags: Restrict to journal entries tagged with one or more of
+            these tags (OR semantics). Accepts a comma-separated string
+            (``"work,decisions"``) or a list. Comma-anchored LIKE match
+            so ``work`` does not false-match ``workflow``.
+        added_after: ISO date — only entries logged on or after this date.
+        added_before: ISO date — only entries logged strictly before this date.
         cfg: Optional pre-loaded config.
 
     Returns:
-        List of dicts with text, title, score, added_at.
+        List of dicts with text, title, score/added_at, tags.
     """
     top_k = max(1, top_k)
     cfg, store = _get_journal_store(cfg)
     try:
         if query:
-            # Semantic search
+            # Semantic search -- thread the new filters through the
+            # store.search call so tag/date constraints are applied
+            # BEFORE RRF / MMR see the candidate pool.
             q_embedding = embed_query(query, cfg.embeddings.model)
             results = store.search(
                 query_embedding=q_embedding,
@@ -243,6 +258,9 @@ def journal_recall(
                 collection=JOURNAL_COLLECTION,
                 project=project,
                 layer=JOURNAL_LAYER,
+                tags=tags,
+                added_after=added_after,
+                added_before=added_before,
             )
             # Look up added_at for each result's source document
             unique_paths = list({r.path for r in results})
@@ -257,17 +275,37 @@ def journal_recall(
                 for r in results
             ]
         else:
-            # Recent entries — list documents sorted by newest first
+            # Recent entries -- list documents sorted by newest first.
+            # ``list_documents`` already accepts collection/project/layer;
+            # tag and date filters are layered on top in Python because
+            # ``list_documents`` does not expose them as kwargs (its
+            # query is shared with the more permissive non-journal
+            # surfaces and we keep this filter local to recall).
             docs = store.list_documents(
                 collection=JOURNAL_COLLECTION,
                 project=project,
                 layer=JOURNAL_LAYER,
             )
+            tag_filter = _normalize_tags(tags)
+            filtered = []
+            for doc in docs:
+                doc_added = getattr(doc, "added_at", None)
+                if added_after and doc_added and doc_added < added_after:
+                    continue
+                if added_before and doc_added and doc_added >= added_before:
+                    continue
+                if tag_filter:
+                    doc_tags = [t.strip() for t in (doc.tags or "").split(",") if t.strip()]
+                    if not any(t in doc_tags for t in tag_filter):
+                        continue
+                filtered.append(doc)
+                if len(filtered) >= top_k:
+                    break
             entries = []
             # Batch-fetch chunks for all docs in one query (avoid N+1)
-            doc_paths = [doc.path for doc in docs[:top_k]]
+            doc_paths = [doc.path for doc in filtered]
             chunks_by_path = store.get_chunks_for_documents(doc_paths)
-            for doc in docs[:top_k]:
+            for doc in filtered:
                 chunks = chunks_by_path.get(doc.path, [])
                 # Use first chunk only for single-chunk entries (most journal);
                 # for multi-chunk, join with blank line to reduce overlap noise.

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -622,6 +622,7 @@ def vstash_search(
     recency_boost: float = 0.0,
     added_after: str | None = None,
     added_before: str | None = None,
+    tags: str | None = None,
     mmr_lambda: float = 0.5,
     vec_weight: float | None = None,
     fts_weight: float | None = None,
@@ -645,6 +646,10 @@ def vstash_search(
             recent chunks score higher. Use 0.5 for mild bias, 1.0 for strong.
         added_after: ISO date (e.g. '2024-01-15') — only documents added on or after.
         added_before: ISO date (e.g. '2024-06-01') — only documents added before.
+        tags: Comma-separated list of tags (``"alpha,beta"``); restrict to
+            documents tagged with any of them (OR semantics).
+            Comma-anchored match so ``alpha`` does NOT false-match
+            ``alphabet``. Tags are case-sensitive.
         mmr_lambda: Intra-document MMR diversity parameter (0.0=max diversity,
             1.0=hard dedup). Default 0.5.
         vec_weight: Pin the RRF vector weight for this query (overrides adaptive
@@ -715,6 +720,7 @@ def vstash_search(
             recency_boost=float(recency_boost),
             added_after=added_after,
             added_before=added_before,
+            tags=tags,
             mmr_lambda=float(mmr_lambda),
             vec_weight=vec_weight_coerced,
             fts_weight=fts_weight_coerced,
@@ -1081,6 +1087,9 @@ def vstash_journal_recall(
     query: str | None = None,
     top_k: int = 5,
     project: str | None = None,
+    tags: str | None = None,
+    added_after: str | None = None,
+    added_before: str | None = None,
 ) -> str:
     """Recall relevant journal entries from past sessions.
 
@@ -1094,6 +1103,13 @@ def vstash_journal_recall(
         query: Search query (omit for most recent entries).
         top_k: Number of entries to return (default: 5).
         project: Filter by project tag.
+        tags: Comma-separated list of tags (``"work,decisions"``); restrict
+            to journal entries tagged with any of them (OR semantics).
+            Comma-anchored match so ``work`` does NOT false-match
+            ``workflow``.
+        added_after: ISO date (e.g. ``"2026-01-15"``) — only entries
+            logged on or after this date.
+        added_before: ISO date — only entries logged strictly before this date.
 
     Returns:
         JSON array of journal entries with text, title, and score/date.
@@ -1101,7 +1117,14 @@ def vstash_journal_recall(
     try:
         from .journal import journal_recall
 
-        entries = journal_recall(query=query, top_k=top_k, project=project)
+        entries = journal_recall(
+            query=query,
+            top_k=top_k,
+            project=project,
+            tags=tags,
+            added_after=added_after,
+            added_before=added_before,
+        )
         return _ok(entries)
     except Exception as exc:
         logger.exception("vstash_journal_recall failed")

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -278,6 +278,7 @@ class Memory:
         recency_boost: float = 0.0,
         added_after: str | None = None,
         added_before: str | None = None,
+        tags: str | list[str] | None = None,
         mmr_lambda: float = 0.5,
         vec_weight: float | None = None,
         fts_weight: float | None = None,
@@ -302,6 +303,11 @@ class Memory:
                 from documents added on or after this date.
             added_before: ISO date (e.g. '2024-06-01') — only return results
                 from documents added before this date.
+            tags: Restrict to documents tagged with one or more of these
+                tags (OR semantics). Accepts a comma-separated string
+                (``"alpha,beta"``) or a list (``["alpha", "beta"]``).
+                Comma-anchored LIKE match so ``alpha`` does not
+                false-match ``alphabet``.
             vec_weight: Pin the RRF vector weight for this single call,
                 overriding adaptive RRF. Valid range ``[0.0, 1.0]``.
                 Pass ``None`` (default) to keep adaptive per-query
@@ -363,6 +369,7 @@ class Memory:
             recency_boost=recency_boost,
             added_after=added_after,
             added_before=added_before,
+            tags=tags,
             mmr_lambda=mmr_lambda,
             vec_weight=vec_weight,
             fts_weight=fts_weight,
@@ -682,6 +689,9 @@ class Memory:
         query: str | None = None,
         *,
         top_k: int = 5,
+        tags: str | list[str] | None = None,
+        added_after: str | None = None,
+        added_before: str | None = None,
     ) -> list[dict]:
         """Recall relevant journal entries from past sessions.
 
@@ -691,6 +701,14 @@ class Memory:
         Args:
             query: Search query, or None for recent entries.
             top_k: Number of entries to return.
+            tags: Restrict to journal entries tagged with one or more of
+                these tags (OR semantics). Accepts a comma-separated
+                string (``"work,decisions"``) or a list. Comma-anchored
+                LIKE match so ``work`` does not false-match ``workflow``.
+            added_after: ISO date (e.g. ``"2026-01-15"``) — only return
+                entries logged on or after this date.
+            added_before: ISO date — only return entries logged strictly
+                before this date.
 
         Returns:
             List of dicts with text, title, score/added_at.
@@ -699,6 +717,7 @@ class Memory:
 
             mem = Memory(project="my_agent")
             context = mem.journal_recall("authentication decisions")
+            recent_work = mem.journal_recall(tags="work", added_after="2026-05-20")
         """
         from .journal import journal_recall
 
@@ -706,6 +725,9 @@ class Memory:
             query=query,
             top_k=top_k,
             project=self._project,
+            tags=tags,
+            added_after=added_after,
+            added_before=added_before,
             cfg=self._cfg,
         )
 

--- a/vstash/profile.py
+++ b/vstash/profile.py
@@ -239,6 +239,9 @@ def federated_search(
     collection: str | None = None,
     project: str | None = None,
     layer: str | None = None,
+    tags: str | list[str] | None = None,
+    added_after: str | None = None,
+    added_before: str | None = None,
     expand_window: int = 0,
 ) -> list[tuple[str, SearchResult]]:
     """Search across all profiles and merge results with RRF.
@@ -306,6 +309,9 @@ def federated_search(
                     collection=collection,
                     project=project,
                     layer=layer,
+                    tags=tags,
+                    added_after=added_after,
+                    added_before=added_before,
                 )
                 # Expand context per-store before closing (the only
                 # opportunity — stores are closed after this).  Note: this

--- a/vstash/services/search.py
+++ b/vstash/services/search.py
@@ -45,6 +45,7 @@ def search_with_embedding(
     recency_boost: float = 0.0,
     added_after: str | None = None,
     added_before: str | None = None,
+    tags: str | list[str] | None = None,
     mmr_lambda: float = 0.5,
     vec_weight: float | None = None,
     fts_weight: float | None = None,
@@ -78,6 +79,11 @@ def search_with_embedding(
         recency_boost: Temporal decay multiplier (0.0 = off).
         added_after: ISO date filter on document add timestamp.
         added_before: ISO date filter on document add timestamp.
+        tags: Restrict to documents tagged with one or more of these tags
+            (OR semantics). Accepts a comma-separated string
+            (``"alpha,beta"``) or a list (``["alpha", "beta"]``).
+            Comma-anchored LIKE match so ``alpha`` does not false-match
+            ``alphabet``.
         mmr_lambda: MMR diversity coefficient (0.0 to 1.0).
         vec_weight: Pin RRF vector weight; None keeps adaptive RRF.
         fts_weight: Pin RRF FTS weight; None keeps adaptive RRF.
@@ -164,6 +170,7 @@ def search_with_embedding(
         recency_boost=recency_boost,
         added_after=added_after,
         added_before=added_before,
+        tags=tags,
         mmr_lambda=mmr_lambda,
         exact_match=exact_match,
         exact_match_case_sensitive=exact_match_case_sensitive,

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -154,6 +154,34 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _normalize_tags(tags: str | list[str] | None) -> list[str]:
+    """Normalize the ``tags`` filter input to a deduped list of tag strings.
+
+    Accepts:
+      - ``None`` / empty string / empty list -> ``[]`` (filter disabled).
+      - A comma-separated string (``"alpha, beta"``) -> ``["alpha", "beta"]``.
+      - A list of strings (``["alpha", "beta"]``) -> ``["alpha", "beta"]``.
+
+    Whitespace around each tag is stripped, empty entries are dropped, and
+    insertion order is preserved (no sort) so callers can keep meaningful
+    ordering when they care. Duplicates are removed.
+    """
+    if tags is None:
+        return []
+    if isinstance(tags, str):
+        parts = tags.split(",")
+    else:
+        parts = list(tags)
+    seen: set[str] = set()
+    out: list[str] = []
+    for part in parts:
+        cleaned = part.strip()
+        if cleaned and cleaned not in seen:
+            seen.add(cleaned)
+            out.append(cleaned)
+    return out
+
+
 def _serialize(vector: list[float]) -> bytes:
     """Serialize a float vector into a compact binary format for sqlite-vec."""
     return struct.pack(f"{len(vector)}f", *vector)
@@ -1790,6 +1818,7 @@ class VstashStore:
         recency_boost: float,
         added_after: str | None,
         added_before: str | None,
+        tags: str | list[str] | None,
         mmr_lambda: float,
         retrieval_mode: str,
         cache_epoch: int,
@@ -1800,7 +1829,8 @@ class VstashStore:
         entry without having to scan the LRU. ``retrieval_mode`` is
         one of ``"hybrid" | "vec_only" | "fts_only"`` so queries that
         short-circuit one branch do not collide with hybrid queries of
-        the same text.
+        the same text. ``tags`` is normalized to a tuple so the same
+        filter expressed as ``"a,b"`` and ``["a", "b"]`` shares a key.
         """
         emb_bytes = np.array(query_embedding, dtype=np.float32).tobytes()
         return hash(
@@ -1818,6 +1848,7 @@ class VstashStore:
                 recency_boost,
                 added_after,
                 added_before,
+                tuple(_normalize_tags(tags)),
                 mmr_lambda,
                 retrieval_mode,
                 cache_epoch,
@@ -2084,6 +2115,7 @@ class VstashStore:
         recency_boost: float = 0.0,
         added_after: str | None = None,
         added_before: str | None = None,
+        tags: str | list[str] | None = None,
         mmr_lambda: float = 0.5,
         retrieval_mode: Literal["hybrid", "vec_only", "fts_only"] | None = None,
         exact_match: str | None = None,
@@ -2193,6 +2225,7 @@ class VstashStore:
                 recency_boost=recency_boost,
                 added_after=added_after,
                 added_before=added_before,
+                tags=tags,
                 mmr_lambda=mmr_lambda,
                 retrieval_mode=_mode,
                 cache_epoch=self._cache_epoch,
@@ -2292,6 +2325,7 @@ class VstashStore:
                 collection=collection,
                 project=project,
                 layer=layer,
+                tags=tags,
                 added_after=added_after,
                 added_before=added_before,
             )
@@ -3356,7 +3390,7 @@ class VstashStore:
         collection: str | None = None,
         project: str | None = None,
         layer: str | None = None,
-        tags: str | None = None,
+        tags: str | list[str] | None = None,
         added_after: str | None = None,
         added_before: str | None = None,
     ) -> tuple[list[str], list[str]]:
@@ -3367,7 +3401,11 @@ class VstashStore:
             collection: Filter by collection name.
             project: Filter by project tag.
             layer: Filter by layer tag.
-            tags: Filter by tag (LIKE match within comma-separated tags).
+            tags: Filter by one or more tags. Pass a comma-separated string
+                (``"alpha,beta"``) or a list (``["alpha", "beta"]``);
+                whitespace and empty entries are stripped, then matched OR
+                with comma-anchored LIKE (``",alpha,"``) so ``alpha`` does
+                not false-match ``alphabet``.
             added_after: ISO date — only documents added on or after this date.
             added_before: ISO date — only documents added before this date.
 
@@ -3386,9 +3424,18 @@ class VstashStore:
         if layer:
             conditions.append(f"{prefix}layer = ?")
             params.append(layer)
-        if tags:
-            conditions.append(f"{prefix}tags LIKE ?")
-            params.append(f"%{tags}%")
+        tag_list = _normalize_tags(tags)
+        if tag_list:
+            # Anchor the LIKE pattern with commas so a tag does not
+            # false-match a longer tag that contains it as a substring
+            # (e.g. searching ``alpha`` must NOT hit a doc tagged
+            # ``alphabet``). The stored ``tags`` column is a
+            # comma-separated string; wrapping both sides in commas
+            # turns substring containment into exact membership.
+            wrapped = f"','||{prefix}tags||','"
+            ors = [f"{wrapped} LIKE ?" for _ in tag_list]
+            conditions.append("(" + " OR ".join(ors) + ")")
+            params.extend(f"%,{t},%" for t in tag_list)
         if added_after:
             conditions.append(f"{prefix}added_at >= ?")
             params.append(added_after)

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -171,7 +171,16 @@ def _normalize_tags(tags: str | list[str] | None) -> list[str]:
     if isinstance(tags, str):
         parts = tags.split(",")
     else:
-        parts = list(tags)
+        # Each list element may itself contain commas (Typer's
+        # ``--tag "a,b"`` pattern, or callers who mix repeated flags
+        # with comma-joined strings). Split each element so the
+        # caller surface accepts ``["alpha,beta"]`` and
+        # ``["alpha", "beta"]`` interchangeably -- otherwise the
+        # comma-anchored ``LIKE`` match would look for a literal tag
+        # ``"alpha,beta"`` which never exists in storage.
+        parts = []
+        for t in tags:
+            parts.extend(str(t).split(","))
     seen: set[str] = set()
     out: list[str] = []
     for part in parts:
@@ -1345,6 +1354,17 @@ class VstashStore:
             limits=self._limits,
         )
 
+        # Normalize the on-disk tag representation to match the form
+        # the search-side comma-anchored ``LIKE`` expects. Writers
+        # routinely hand us ``"alpha, beta"`` (frontmatter style); if
+        # we stored it verbatim, a query for ``tag="beta"`` would
+        # generate ``%,beta,%`` against ``,alpha, beta,`` and miss
+        # because of the leading space. Round-tripping through
+        # ``_normalize_tags`` strips that whitespace and dedupes
+        # repeats once, at ingest time, so the storage invariant is
+        # ``"tag1,tag2,..."`` with no spaces and no duplicates.
+        stored_tags = ",".join(_normalize_tags(tags)) if tags else None
+
         doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
 
         with self._write_lock:
@@ -1369,7 +1389,7 @@ class VstashStore:
                         collection,
                         project,
                         layer,
-                        tags,
+                        stored_tags,
                         sum(len(c) for c in chunks),
                         len(chunks),
                         datetime.now(timezone.utc).isoformat(),
@@ -1495,6 +1515,13 @@ class VstashStore:
                         limits=self._limits,
                     )
 
+                    # Normalize tags on write so the search-side
+                    # comma-anchored ``LIKE`` matches reliably. Same
+                    # invariant as ``add_document``: stored form is
+                    # ``"tag1,tag2,..."`` with no whitespace and no
+                    # duplicates.
+                    stored_tags = ",".join(_normalize_tags(tags)) if tags else None
+
                     doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
                     doc_ids.append(doc_id)
 
@@ -1514,7 +1541,7 @@ class VstashStore:
                             collection,
                             project,
                             layer,
-                            tags,
+                            stored_tags,
                             sum(len(c) for c in chunks),
                             len(chunks),
                             now_iso,
@@ -1848,7 +1875,11 @@ class VstashStore:
                 recency_boost,
                 added_after,
                 added_before,
-                tuple(_normalize_tags(tags)),
+                # Sort so that ``tags=["alpha", "beta"]`` and
+                # ``tags=["beta", "alpha"]`` share the same cache entry
+                # -- the SQL ``OR`` is commutative, so semantically
+                # equivalent queries must hit the same cache slot.
+                tuple(sorted(_normalize_tags(tags))),
                 mmr_lambda,
                 retrieval_mode,
                 cache_epoch,


### PR DESCRIPTION
## Summary

Closes part of #106. Exposes the existing comma-separated `documents.tags` column as a first-class filter across every adapter, and rounds out `journal_recall` with the date and tag knobs it was missing.

## What changed

**Surfaces:**
- `VstashStore.search(tags=...)` -- single source of truth, threaded through `_build_doc_filter` and the query cache key.
- `services.search.search_with_embedding(tags=...)` -- adapter-shared path.
- `Memory.search(tags=...)` -- SDK.
- `Memory.journal_recall(tags=..., added_after=..., added_before=...)` and `journal.journal_recall(...)` -- semantic-search branch routes through `store.search`; recent-entries branch filters `list_documents` output in Python because that primitive does not expose date/tag kwargs.
- MCP `vstash_search` and `vstash_journal_recall` -- schemas updated.
- CLI `vstash search` and `vstash journal recall` -- new `--tag` (repeatable), `--after`, `--before` flags.
- `federated_search(tags=..., added_after=..., added_before=...)` so cross-profile queries are filtered consistently.

**Semantics:**
- `tags` accepts a comma-separated string OR a list (both equivalent; same cache key).
- Multiple tags = **OR semantics**.
- Tag matching is **comma-anchored** (`','||tags||','` against `'%,foo,%'`) so `tag='alpha'` does NOT false-match a doc tagged `alphabet`. Regression test in this PR.
- Added a module-level `vstash.store._normalize_tags(...)` helper so the SQL path and the Python-side `journal_recall` filter share identical input semantics.

**Out of scope (future PRs):**
- `Memory.update()` -- separate PR (already branched).
- `vstash compact` / `Memory.prune()` -- separate PR (already branched).
- Plugin (`silt/hermes-agent/plugins/memory/vstash`) tool schema updates -- the agent does not auto-discover new MCP params; that lands separately.

## Test plan

- [x] `python -m pytest tests/test_store.py tests/test_memory.py tests/test_journal.py tests/test_mcp.py tests/test_cli_commands.py tests/test_services.py tests/test_query_cache.py -q` (305 passed)
- [x] `python -m ruff check . && python -m ruff format --check .` (all clean)
- [x] 5 new focused regression tests:
  - `test_search_tag_filter_single_string` -- single tag string filters correctly
  - `test_search_tag_filter_list_is_or` -- list and comma-string both apply OR semantics
  - `test_search_tag_filter_no_substring_false_match` -- `alpha` does NOT match `alphabet`/`galpha`
  - `test_recall_recent_with_tag_filter` -- recent-entries branch honours tag membership
  - `test_recall_query_with_tag_filter` -- semantic-search branch honours tag membership