### PR TITLE
feat: explicit Memory.update() in-place document mutation

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -486,6 +486,94 @@ class TestMemoryRemove:
             assert removed is False
 
 
+class TestMemoryUpdate:
+    """Test in-place document mutation via Memory.update()."""
+
+    @requires_sqlite_vec
+    def test_update_metadata_only_does_not_re_embed(self, tmp_path: Path) -> None:
+        """Passing only ``title`` / ``tags`` runs a SQL UPDATE; the
+        embed pipeline must not be invoked because no chunk content
+        changed. We patch ``embed_query``/``embed_texts`` so any call
+        during the update would blow up the test loudly."""
+        doc = tmp_path / "spec.md"
+        doc.write_text("This is the original spec text used for embedding.")
+
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc, tags="old-tag")
+            resolved = str(doc.resolve())
+
+            # Patch the embed entry points the ingest pipeline uses;
+            # if Memory.update reaches them on a metadata-only call,
+            # the assertion fires loudly.
+            with patch("vstash.embed.embed_texts") as mock_embed:
+                result = mem.update(
+                    resolved,
+                    title="Spec v2",
+                    tags="new,spec",
+                )
+                assert mock_embed.call_count == 0, (
+                    "metadata-only update must not invoke the embed pipeline"
+                )
+
+            assert result["status"] == "updated"
+            assert result["mode"] == "metadata"
+            assert set(result["fields"]) == {"title", "tags"}
+
+            docs = mem.list()
+            target = next(d for d in docs if d.path == resolved)
+            assert target.title == "Spec v2"
+            assert target.tags == "new,spec"
+
+    @requires_sqlite_vec
+    def test_update_text_replaces_chunks(self, tmp_path: Path) -> None:
+        """Passing ``text`` re-chunks and re-embeds; the new content
+        must be searchable and the original content must NOT."""
+        doc = tmp_path / "doc.md"
+        doc.write_text(
+            "Original content about authentication and OAuth flows. "
+            "The original document discusses session tokens at length."
+        )
+
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc)
+            resolved = str(doc.resolve())
+
+            # Sanity: the original content is searchable.
+            assert any("authentication" in r.text.lower() for r in mem.search("OAuth"))
+
+            new_text = (
+                "Replacement content about kubernetes pod scheduling. "
+                "We now discuss container orchestration patterns."
+            )
+            result = mem.update(resolved, text=new_text)
+            assert result["status"] == "updated"
+            assert result["mode"] == "content"
+            assert result["chunks"] >= 1
+
+            # Old content must be gone.
+            for hit in mem.search("OAuth authentication"):
+                assert "authentication" not in hit.text.lower(), (
+                    f"old content survived the update: {hit.text!r}"
+                )
+            # New content must be findable.
+            assert any(
+                "kubernetes" in r.text.lower()
+                for r in mem.search("kubernetes container")
+            )
+
+    @requires_sqlite_vec
+    def test_update_no_fields_raises(self, tmp_path: Path) -> None:
+        with Memory(db=tmp_path / "test.db") as mem:
+            with pytest.raises(ValueError, match="at least one"):
+                mem.update("any/path.md")
+
+    @requires_sqlite_vec
+    def test_update_nonexistent_returns_not_found(self, tmp_path: Path) -> None:
+        with Memory(db=tmp_path / "test.db") as mem:
+            result = mem.update("/nonexistent/file.md", title="ignored")
+            assert result["status"] == "not_found"
+
+
 # ------------------------------------------------------------------ #
 # Memory.list and Memory.stats                                         #
 # ------------------------------------------------------------------ #

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -556,10 +556,7 @@ class TestMemoryUpdate:
                     f"old content survived the update: {hit.text!r}"
                 )
             # New content must be findable.
-            assert any(
-                "kubernetes" in r.text.lower()
-                for r in mem.search("kubernetes container")
-            )
+            assert any("kubernetes" in r.text.lower() for r in mem.search("kubernetes container"))
 
     @requires_sqlite_vec
     def test_update_no_fields_raises(self, tmp_path: Path) -> None:
@@ -572,6 +569,66 @@ class TestMemoryUpdate:
         with Memory(db=tmp_path / "test.db") as mem:
             result = mem.update("/nonexistent/file.md", title="ignored")
             assert result["status"] == "not_found"
+
+    @requires_sqlite_vec
+    def test_update_metadata_scopes_to_instance_collection(self, tmp_path: Path) -> None:
+        """Regression guard for the bot-flagged ``"default"->None`` bug:
+        a ``Memory(collection="default")`` instance must NOT silently
+        update every collection's copy of the same path."""
+        doc = tmp_path / "shared.md"
+        doc.write_text("Body shared across two collections for the scope test.")
+
+        db = tmp_path / "test.db"
+        # Put a copy of the doc into a non-default collection.
+        with Memory(db=db, collection="research") as mem:
+            mem.add(doc, collection="research")
+        # And one into "default".
+        with Memory(db=db, collection="default") as mem:
+            mem.add(doc, collection="default")
+            mem.update(doc, title="default-only")
+            # "default" copy must have the new title.
+            default_doc = next(
+                d for d in mem.list(collection="default") if d.path == str(doc.resolve())
+            )
+            assert default_doc.title == "default-only"
+        # "research" copy must still have the original title (the
+        # update was scoped to "default" only, not silently widened
+        # to all collections).
+        with Memory(db=db) as mem:
+            research_doc = next(
+                d for d in mem.list(collection="research") if d.path == str(doc.resolve())
+            )
+            assert research_doc.title != "default-only"
+
+    @requires_sqlite_vec
+    def test_update_text_across_all_collections(self, tmp_path: Path) -> None:
+        """Regression guard for the cross-collection content-update bug:
+        when ``collection=None`` is passed, the delete-then-add must
+        re-add the new chunks into *every* collection that previously
+        held ``source``, not silently collapse the doc into one."""
+        doc = tmp_path / "shared.md"
+        doc.write_text("Initial content shared by the two collections.")
+        db = tmp_path / "test.db"
+        with Memory(db=db, collection="default") as mem:
+            mem.add(doc, collection="default")
+            mem.add(doc, collection="research")
+            # Two rows exist for the same path.
+            assert sum(1 for d in mem.list(collection=None) if d.path == str(doc.resolve())) == 2
+
+            # Content update with collection=None must touch both.
+            result = mem.update(
+                doc,
+                text="Replacement content that overwrites both collections.",
+                collection=None,
+            )
+            assert result["status"] == "updated"
+
+            # Both rows must still exist.
+            after = [d for d in mem.list(collection=None) if d.path == str(doc.resolve())]
+            assert len(after) == 2, (
+                f"cross-collection update lost a row: {[(d.collection, d.title) for d in after]}"
+            )
+            assert {d.collection for d in after} == {"default", "research"}
 
 
 # ------------------------------------------------------------------ #

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1256,6 +1256,74 @@ def forget(
             console.print(f"[yellow]Not found:[/yellow] {path}")
 
 
+@app.command()
+def update(
+    ctx: typer.Context,
+    path: str = typer.Argument(..., help="File path or URL of the document to update"),
+    text: str | None = typer.Option(
+        None,
+        "--text",
+        help=(
+            "Replace the document content with this text. Triggers re-chunking "
+            "and re-embedding. Pass '-' to read from stdin."
+        ),
+    ),
+    title: str | None = typer.Option(
+        None,
+        "--title",
+        help="New title for the document.",
+    ),
+    tags: str | None = typer.Option(
+        None,
+        "--tags",
+        "-t",
+        help="New comma-separated tag string. Pass an empty string to clear tags.",
+    ),
+) -> None:
+    """Update an existing document in place.
+
+    Three modes:
+
+      * metadata-only: --title and/or --tags without --text -- a single
+        SQL UPDATE, no embedding model invocation.
+      * content: --text (with optional --title/--tags) -- re-chunks
+        and re-embeds the document.
+      * (no field): error.
+
+    For multi-collection stores, the update applies to every collection
+    holding `path`. Wrap with `--collection` (future) for narrower
+    scopes when that lands.
+    """
+    if text is None and title is None and tags is None:
+        console.print("[red]✗[/red] Pass at least one of --text, --title, or --tags.")
+        raise typer.Exit(1)
+
+    if text == "-":
+        import sys as _sys
+
+        text = _sys.stdin.read()
+
+    from .memory import Memory
+
+    with Memory(profile=_profile_from_ctx(ctx)) as mem:
+        result = mem.update(path, text=text, title=title, tags=tags)
+
+    status = result.get("status")
+    mode = result.get("mode")
+    if status == "not_found":
+        console.print(f"[yellow]Not found:[/yellow] {path}")
+        raise typer.Exit(1)
+    if status == "noop":
+        console.print(f"[yellow]No-op:[/yellow] the supplied text produced no chunks ({path}).")
+        raise typer.Exit(1)
+    fields = ", ".join(result.get("fields") or [])
+    suffix = f" ({result['chunks']} chunks)" if mode == "content" else ""
+    console.print(
+        f"[green]✓[/green] Updated [bold]{path}[/bold] -- {mode} mode, "
+        f"fields: {fields or 'none'}{suffix}."
+    )
+
+
 # ------------------------------------------------------------------ #
 # vstash check                                                         #
 # ------------------------------------------------------------------ #

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1305,8 +1305,12 @@ def update(
 
     from .memory import Memory
 
+    # The CLI documents "the update applies to every collection
+    # holding `path`", so pass ``collection=None`` explicitly to
+    # override the Memory-instance default (``"default"``) and update
+    # every collection's copy of ``path``.
     with Memory(profile=_profile_from_ctx(ctx)) as mem:
-        result = mem.update(path, text=text, title=title, tags=tags)
+        result = mem.update(path, text=text, title=title, tags=tags, collection=None)
 
     status = result.get("status")
     mode = result.get("mode")

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -980,6 +980,71 @@ def vstash_forget(source: str, collection: str | None = None) -> str:
 
 
 @mcp_server.tool()
+def vstash_update(
+    source: str,
+    text: str | None = None,
+    title: str | None = None,
+    tags: str | None = None,
+    collection: str | None = None,
+) -> str:
+    """Update an existing document in vstash memory.
+
+    Two modes, picked from the fields you set:
+
+      * **metadata-only** -- pass ``title`` and/or ``tags`` without
+        ``text``. A single SQL UPDATE; no re-chunking or
+        re-embedding. Use for renames and retagging.
+      * **content** -- pass ``text`` (optionally with ``title`` / ``tags``).
+        Re-chunks and re-embeds the document. Equivalent to
+        ``vstash_add(source, force=True)`` plus an atomic metadata update,
+        but does not require the caller to know the source path's
+        on-disk file.
+
+    Returns ``status="not_found"`` (no row matched ``source``) or
+    ``status="noop"`` (text mode produced no chunks) without modifying
+    the store.
+
+    Args:
+        source: File path, URL, or ``text://`` identifier of the document.
+        text: New content. Triggers re-chunk + re-embed when set.
+        title: New title (optional in both modes).
+        tags: New comma-separated tag string (optional in both modes).
+            Pass ``""`` to clear all tags.
+        collection: Restrict the update to a specific ``(collection, source)``
+            row. Default ``None`` updates every collection holding ``source``.
+
+    Returns:
+        JSON object with status, mode, fields, and chunk count.
+    """
+    if text is None and title is None and tags is None:
+        return _error("vstash_update needs at least one of `text`, `title`, or `tags`.")
+    try:
+        from .memory import Memory
+
+        # Memory.update normalises paths; pass through verbatim. The
+        # collection kwarg defaults to the Memory-instance collection
+        # (which is "default" here unless the caller overrides it via
+        # this tool), so a None collection means "every collection
+        # holding the path".
+        with Memory(collection=collection or "default") as mem:
+            result = mem.update(
+                source,
+                text=text,
+                title=title,
+                tags=tags,
+                collection=collection,
+            )
+        return _ok(result)
+    except ValueError as exc:
+        return _error(str(exc))
+    except FileNotFoundError:
+        return _error("vstash database not found.")
+    except Exception as exc:
+        logger.exception("vstash_update failed")
+        return _error(f"Failed to update document: {exc}")
+
+
+@mcp_server.tool()
 def vstash_collections() -> str:
     """List all available collections in vstash memory.
 

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -590,6 +590,171 @@ class Memory:
             source_str = str(Path(source_str).resolve())
         return self._store.delete_document(source_str)
 
+    def update(
+        self,
+        source: str | Path,
+        *,
+        text: str | None = None,
+        title: str | None = None,
+        tags: str | None = None,
+        collection: object = _UNSET,
+    ) -> dict:
+        """Update an existing document in place.
+
+        Three update modes, picked from the kwargs provided:
+
+        - **metadata-only** (``title`` and/or ``tags`` set, ``text`` is
+          ``None``): runs a single SQL ``UPDATE`` against the
+          ``documents`` row. No re-chunking, no re-embedding, no
+          embedding model invocation. Tags pass through verbatim;
+          pass ``tags=""`` to clear all tags.
+        - **content** (``text`` set): re-runs the full ingest pipeline
+          for the new text -- chunk + embed + store -- replacing every
+          chunk of the matching document. ``title`` and ``tags`` may be
+          updated in the same call; they ride on the freshly-stored
+          row. The previous document row is removed first via
+          ``Memory.remove`` so the new content cannot collide with stale
+          chunk ids.
+        - **noop** (no field provided): raises ``ValueError`` -- a
+          caller that does not pass any field to update is almost
+          always a bug.
+
+        File-path normalization matches ``add()``/``remove()`` so
+        relative paths resolve consistently. URLs and ``text://``
+        synthetic paths pass through unchanged.
+
+        Args:
+            source: File path, URL, or ``text://`` identifier of the
+                document to mutate.
+            text: New content. When provided, every chunk of the doc is
+                re-embedded; ``title`` falls back to ``add``'s
+                title-extraction logic if not overridden.
+            title: New title. Optional in both modes.
+            tags: New comma-separated tag string. Optional in both modes.
+                Pass an empty string to clear tags.
+            collection: Override the default collection filter when
+                multiple ``(collection, path)`` rows could match the
+                same ``source``. Default uses the ``Memory``-instance
+                collection; pass ``None`` to update every collection's
+                copy of ``source``.
+
+        Returns:
+            Dict describing the update::
+
+                {
+                  "status": "updated" | "not_found" | "noop",
+                  "mode":   "metadata" | "content",
+                  "fields": ["title", "tags"],   # what was changed
+                  "chunks": <int>,               # for content mode
+                }
+
+            ``status="not_found"`` means no row matched ``source``; the
+            store was not modified. ``status="noop"`` means a content
+            update produced an empty result (text too short to chunk).
+
+        Raises:
+            ValueError: No field was provided to update.
+
+        Example::
+
+            mem = Memory(project="my_agent")
+            mem.update("docs/spec.md", title="Spec v2")
+            mem.update("docs/spec.md", tags="archive,spec")
+            mem.update("docs/spec.md", text=open("docs/spec.md").read())
+        """
+        if text is None and title is None and tags is None:
+            raise ValueError(
+                "Memory.update called with no field to update -- "
+                "pass at least one of `text=`, `title=`, or `tags=`."
+            )
+
+        source_str = str(source)
+        if not source_str.startswith(("http://", "https://", "text://")):
+            source_str = str(Path(source_str).resolve())
+
+        col = self._collection if collection is _UNSET else collection
+
+        if text is None:
+            # Metadata-only path. Use the store's atomic UPDATE
+            # primitive; do not invoke the embed pipeline at all.
+            updated = self._store.update_metadata(
+                source_str,
+                title=title,
+                tags=tags,
+                collection=col if col != "default" else None,
+            )
+            fields = [k for k, v in (("title", title), ("tags", tags)) if v is not None]
+            return {
+                "status": "updated" if updated else "not_found",
+                "mode": "metadata",
+                "fields": fields,
+                "chunks": 0,
+            }
+
+        # Content update: replace the chunks in place with the
+        # caller-supplied text. We deliberately do NOT re-read the
+        # path from disk (the caller is overriding the content), and
+        # we preserve every metadata field the caller did NOT pass so
+        # tags / project / layer / source_type / collection survive a
+        # content-only refresh.
+        col_filter = col if col != "default" else None
+        existing = next(
+            (d for d in self._store.list_documents(collection=col_filter) if d.path == source_str),
+            None,
+        )
+        if existing is None:
+            return {
+                "status": "not_found",
+                "mode": "content",
+                "fields": [],
+                "chunks": 0,
+            }
+
+        # Chunk + embed the new text directly. ``chunk_text`` and
+        # ``embed_texts`` are the same primitives ``ingest_text`` uses,
+        # so chunking semantics match ``Memory.add`` exactly.
+        from .embed import embed_texts
+        from .ingest import chunk_text
+
+        cs = self._chunk_size if self._chunk_size is not None else self._cfg.chunking.size
+        co = self._chunk_overlap if self._chunk_overlap is not None else self._cfg.chunking.overlap
+        new_chunks = chunk_text(text, cs, co)
+        if not new_chunks:
+            return {
+                "status": "noop",
+                "mode": "content",
+                "fields": [],
+                "chunks": 0,
+            }
+        new_embeddings = embed_texts(new_chunks, self._cfg.embeddings.model)
+
+        # Delete-then-add. Not strictly atomic (the doc is briefly
+        # missing between the two steps), but the same window already
+        # exists in the ``force=True`` re-ingest path used by ``add()``
+        # and the watch worker, so callers already tolerate it.
+        self._store.delete_document(source_str, collection=col_filter)
+        merged_collection = (
+            existing.collection if col == "default" else (col or existing.collection)
+        )
+        self._store.add_document(
+            path=source_str,
+            title=title if title is not None else existing.title,
+            chunks=new_chunks,
+            embeddings=new_embeddings,
+            source_type=existing.source_type,
+            collection=merged_collection,
+            project=existing.project,
+            layer=existing.layer,
+            tags=tags if tags is not None else existing.tags,
+        )
+        fields = [k for k, v in (("text", text), ("title", title), ("tags", tags)) if v is not None]
+        return {
+            "status": "updated",
+            "mode": "content",
+            "fields": fields,
+            "chunks": len(new_chunks),
+        }
+
     def list(
         self,
         *,

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -677,11 +677,21 @@ class Memory:
         if text is None:
             # Metadata-only path. Use the store's atomic UPDATE
             # primitive; do not invoke the embed pipeline at all.
+            #
+            # ``col`` is the Memory-instance default OR the caller's
+            # explicit override. We pass it through *verbatim*: the
+            # ``"default"``->``None`` mapping the previous version did
+            # re-introduced the #165 read/write asymmetry (a
+            # ``Memory(collection="default")`` user who called
+            # ``mem.update`` would have their change silently applied
+            # across every collection). To update every collection
+            # holding ``source``, the caller passes ``collection=None``
+            # explicitly.
             updated = self._store.update_metadata(
                 source_str,
                 title=title,
                 tags=tags,
-                collection=col if col != "default" else None,
+                collection=col,
             )
             fields = [k for k, v in (("title", title), ("tags", tags)) if v is not None]
             return {
@@ -697,20 +707,28 @@ class Memory:
         # we preserve every metadata field the caller did NOT pass so
         # tags / project / layer / source_type / collection survive a
         # content-only refresh.
-        col_filter = col if col != "default" else None
-        existing = next(
-            (d for d in self._store.list_documents(collection=col_filter) if d.path == source_str),
-            None,
-        )
-        if existing is None:
+        #
+        # The scope is whatever the caller asked for: ``col`` is
+        # ``"default"`` / explicit string / ``None`` (=all collections).
+        # We do NOT collapse ``"default"`` to ``None`` -- doing so
+        # would silently widen the scope and re-introduce #165.
+        existing_rows = self._store._conn.execute(
+            "SELECT path, title, source_type, collection, "
+            "project, layer, tags, chunk_count, char_count, added_at "
+            "FROM documents WHERE path = ?" + (" AND collection = ?" if col is not None else ""),
+            [source_str, col] if col is not None else [source_str],
+        ).fetchall()
+        if not existing_rows:
             return {
                 "status": "not_found",
                 "mode": "content",
                 "fields": [],
                 "chunks": 0,
             }
+        existing_docs = [DocumentInfo(**dict(row)) for row in existing_rows]
 
-        # Chunk + embed the new text directly. ``chunk_text`` and
+        # Chunk + embed the new text once and reuse for every
+        # collection that holds this ``source``. ``chunk_text`` and
         # ``embed_texts`` are the same primitives ``ingest_text`` uses,
         # so chunking semantics match ``Memory.add`` exactly.
         from .embed import embed_texts
@@ -728,31 +746,32 @@ class Memory:
             }
         new_embeddings = embed_texts(new_chunks, self._cfg.embeddings.model)
 
-        # Delete-then-add. Not strictly atomic (the doc is briefly
-        # missing between the two steps), but the same window already
-        # exists in the ``force=True`` re-ingest path used by ``add()``
-        # and the watch worker, so callers already tolerate it.
-        self._store.delete_document(source_str, collection=col_filter)
-        merged_collection = (
-            existing.collection if col == "default" else (col or existing.collection)
-        )
-        self._store.add_document(
-            path=source_str,
-            title=title if title is not None else existing.title,
-            chunks=new_chunks,
-            embeddings=new_embeddings,
-            source_type=existing.source_type,
-            collection=merged_collection,
-            project=existing.project,
-            layer=existing.layer,
-            tags=tags if tags is not None else existing.tags,
-        )
+        # Delete-then-add, scoped to the same set of collections we
+        # just listed. Re-add into *each* existing collection so a
+        # multi-collection update does not silently collapse the doc
+        # into a single collection. Not strictly atomic (the doc is
+        # briefly missing between the two steps), but the same window
+        # already exists in the ``force=True`` re-ingest path used by
+        # ``add()`` and the watch worker.
+        self._store.delete_document(source_str, collection=col)
+        for existing in existing_docs:
+            self._store.add_document(
+                path=source_str,
+                title=title if title is not None else existing.title,
+                chunks=new_chunks,
+                embeddings=new_embeddings,
+                source_type=existing.source_type,
+                collection=existing.collection,
+                project=existing.project,
+                layer=existing.layer,
+                tags=tags if tags is not None else existing.tags,
+            )
         fields = [k for k, v in (("text", text), ("title", title), ("tags", tags)) if v is not None]
         return {
             "status": "updated",
             "mode": "content",
             "fields": fields,
-            "chunks": len(new_chunks),
+            "chunks": len(new_chunks) * len(existing_docs),
         }
 
     def list(

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1705,6 +1705,79 @@ class VstashStore:
                 raise
             return True
 
+    def update_metadata(
+        self,
+        path: str,
+        *,
+        title: str | None = None,
+        tags: str | None = None,
+        collection: str | None = None,
+    ) -> bool:
+        """Update document metadata (``title`` and/or ``tags``) in place.
+
+        This is the in-place mutator for fields that do NOT require
+        re-chunking or re-embedding. Use it for renames, retagging, or
+        any metadata-only correction. To change the chunk text itself,
+        use ``Memory.update(path, text=...)`` which re-runs the embed
+        pipeline.
+
+        Args:
+            path: Document path (or URL) identifying the row.
+            title: New title; pass ``None`` to leave unchanged.
+            tags: New comma-separated tags string; pass ``None`` to
+                leave unchanged. Pass ``""`` to clear the tag set.
+            collection: If set, restrict the update to a specific
+                ``(collection, path)`` pair. ``None`` (default) updates
+                every matching row across collections, mirroring
+                ``delete_document``'s default semantics.
+
+        Returns:
+            ``True`` if at least one row was updated.
+
+        Raises:
+            ValueError: Neither ``title`` nor ``tags`` was provided
+                (the call would be a no-op and almost always indicates
+                a caller bug).
+        """
+        if title is None and tags is None:
+            raise ValueError(
+                "update_metadata called with no field to update -- "
+                "pass at least one of `title=` or `tags=`."
+            )
+        with self._write_lock:
+            # Build the SET clause and bind params dynamically so the
+            # statement only touches the fields the caller actually
+            # provided. Mirrors the `_get_filter_conditions` style used
+            # elsewhere in this module.
+            set_parts: list[str] = []
+            set_params: list[str] = []
+            if title is not None:
+                set_parts.append("title = ?")
+                set_params.append(title)
+            if tags is not None:
+                set_parts.append("tags = ?")
+                set_params.append(tags)
+            where_parts = ["path = ?"]
+            where_params: list[str] = [path]
+            if collection is not None:
+                where_parts.append("collection = ?")
+                where_params.append(collection)
+            sql = f"UPDATE documents SET {', '.join(set_parts)} WHERE {' AND '.join(where_parts)}"
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                cur = self._conn.execute(sql, [*set_params, *where_params])
+                rowcount = cur.rowcount
+                self._conn.commit()
+                if rowcount > 0:
+                    # Tag/title changes are visible to search filters
+                    # (tag-anchored LIKE in `_get_filter_conditions`) and
+                    # to result formatting, so invalidate the LRU.
+                    self._bump_cache_epoch()
+            except Exception:
+                self._conn.rollback()
+                raise
+            return rowcount > 0
+
     def _delete_by_doc_id(self, doc_id: str) -> bool:
         """Delete a document by its internal hash ID.
 


### PR DESCRIPTION
## Summary

Adds a first-class ``update`` API across every adapter. Mirrors the shape of ``add`` / ``remove`` / ``forget`` that callers already know. Maps to feedback point 2 from the hermes-agent vstash-plugin review (\"vstash_update -- modify memories\").

Two distinct modes, picked from the kwargs the caller passes:

| Mode | When | What happens |
|---|---|---|
| **metadata-only** | ``title`` and/or ``tags`` set, ``text`` is ``None`` | Single atomic SQL ``UPDATE`` via ``VstashStore.update_metadata``. **No re-chunking, no embed pipeline invocation.** Bumps the query cache epoch so tag/title filters reflect the change immediately. |
| **content** | ``text`` set | Chunks + embeds the caller-supplied text and replaces every chunk. Preserves ``source_type`` / ``collection`` / ``project`` / ``layer`` / non-overridden metadata. |
| (noop) | no field passed | ``ValueError`` -- almost always a caller bug. |

Not-found and noop (text too short to chunk) come back as a structured return, not exceptions, so callers can branch on the three outcomes without try/except.

## What this PR contains

- ``VstashStore.update_metadata(path, *, title=, tags=, collection=)`` -- new atomic SQL primitive. ``BEGIN IMMEDIATE`` + UPDATE + commit, bumps cache epoch on success. Raises if no field provided.
- ``Memory.update(source, *, text=, title=, tags=, collection=)`` -- SDK entry point. Reuses the path-normalisation rules from ``add``/``remove`` so relative/absolute paths and URLs all resolve consistently. The content path does NOT re-read the on-disk file -- the caller's ``text`` is authoritative.
- CLI ``vstash update <path>`` with ``--text``, ``--title``, ``--tags``. ``--text -`` reads from stdin.
- MCP ``vstash_update`` tool.

## Test plan

- [x] ``python -m pytest tests/test_memory.py tests/test_store.py tests/test_cli_commands.py tests/test_mcp.py -q`` (235 passed)
- [x] ``python -m ruff check . && python -m ruff format --check .`` (clean)
- [x] 4 new focused tests in ``TestMemoryUpdate``:
  - ``test_update_metadata_only_does_not_re_embed`` -- patches ``embed_texts`` and asserts ``call_count == 0`` so a metadata-only update can never silently re-embed.
  - ``test_update_text_replaces_chunks`` -- searches for old content (must be gone) and new content (must be findable) after the update.
  - ``test_update_no_fields_raises`` -- ``ValueError`` on noop.
  - ``test_update_nonexistent_returns_not_found`` -- structured ``status="not_found"``.

## Notes

- **Atomicity**: the content path is delete-then-add (matches the existing ``add(force=True)`` window). Not strictly transactional across the two store calls, but no new partial-state semantics are introduced.
- **Multi-collection**: by default the metadata update applies to the ``Memory``-instance collection only. Pass ``collection=None`` to update every collection's copy of the source.
- **Out of scope (future PRs)**: ``Memory.compact()`` / ``vstash compact`` (separate branch); plugin schema updates for hermes-agent (separate repo).