### PR TITLE
feat: Memory.prune() + Memory.compact() + vstash compact CLI

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -636,10 +636,18 @@ class TestMemoryPruneAndCompact:
 
     @requires_sqlite_vec
     def test_prune_requires_filter(self, tmp_path: Path) -> None:
-        """An unfiltered prune raises rather than wiping the store."""
+        """An unfiltered prune (``collection=None`` clears the
+        instance default) raises rather than wiping the store.
+
+        With no explicit ``collection`` argument, ``Memory.prune``
+        scopes to the instance collection (default ``"default"``),
+        which IS a valid filter. To trigger the no-filter guard the
+        caller has to explicitly clear it with ``collection=None``,
+        ``project=None``, no ``layer``, no ``before``.
+        """
         with Memory(db=tmp_path / "test.db") as mem:
             with pytest.raises(ValueError, match="no filter"):
-                mem.prune()
+                mem.prune(collection=None)
 
     @requires_sqlite_vec
     def test_prune_by_layer(self, tmp_path: Path) -> None:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -631,6 +631,100 @@ class TestMemoryUpdate:
             assert {d.collection for d in after} == {"default", "research"}
 
 
+class TestMemoryPruneAndCompact:
+    """Test Memory.prune and Memory.compact."""
+
+    @requires_sqlite_vec
+    def test_prune_requires_filter(self, tmp_path: Path) -> None:
+        """An unfiltered prune raises rather than wiping the store."""
+        with Memory(db=tmp_path / "test.db") as mem:
+            with pytest.raises(ValueError, match="no filter"):
+                mem.prune()
+
+    @requires_sqlite_vec
+    def test_prune_by_layer(self, tmp_path: Path) -> None:
+        """Layer scope deletes only matching docs."""
+        keep = tmp_path / "keep.md"
+        drop = tmp_path / "drop.md"
+        keep.write_text("Content that must stay in the store.")
+        drop.write_text("Content that the prune call must remove from the store.")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(keep, layer="permanent")
+            mem.add(drop, layer="scratch")
+            assert len(mem.list()) == 2
+
+            report = mem.prune(layer="scratch")
+            assert report["status"] == "ok"
+            assert report["deleted"] == 1
+            remaining = {d.path for d in mem.list()}
+            assert remaining == {str(keep.resolve())}
+
+    @requires_sqlite_vec
+    def test_prune_dry_run_is_readonly(self, tmp_path: Path) -> None:
+        """Dry-run returns the would-delete set without touching the store."""
+        doc = tmp_path / "preview.md"
+        doc.write_text("Content for the dry-run preview test scenario.")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc, layer="scratch")
+            before_count = len(mem.list())
+
+            report = mem.prune(layer="scratch", dry_run=True)
+            assert report["status"] == "dry_run"
+            assert report["deleted"] == 1
+            assert len(mem.list()) == before_count, "dry_run must not delete"
+
+    @requires_sqlite_vec
+    def test_compact_runs_vacuum_and_optimize(self, tmp_path: Path) -> None:
+        """compact() with no `before` skips prune and runs only the
+        housekeeping primitives, both of which must report success."""
+        doc = tmp_path / "doc.md"
+        doc.write_text("Content for the compact housekeeping smoke test.")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc)
+            report = mem.compact()
+            assert report["prune"] is None
+            assert report["vacuum"] is True
+            assert report["optimize_fts"] is True
+            # Store still functional after VACUUM + optimize.
+            assert mem.search("compact")[0].text  # at least one hit, smoke
+
+    @requires_sqlite_vec
+    def test_compact_dry_run_skips_writes(self, tmp_path: Path) -> None:
+        """dry_run forwards to prune and skips VACUUM / optimize."""
+        doc = tmp_path / "doc.md"
+        doc.write_text("Content for the compact dry-run regression test.")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc, layer="scratch")
+            report = mem.compact(before="0d", layer="scratch", dry_run=True)
+            assert report["prune"]["status"] == "dry_run"
+            assert report["vacuum"] is False
+            assert report["optimize_fts"] is False
+
+    @requires_sqlite_vec
+    def test_prune_rejects_freeform_before(self, tmp_path: Path) -> None:
+        """Regression guard for the silent-wipe bug flagged on PR #366:
+        passing a non-age, non-ISO ``before`` value would lexically sort
+        higher than every ``2026-...`` timestamp under SQLite's TEXT
+        comparison, so ``added_at < 'invalid'`` would match every row
+        and ``prune`` would silently delete the entire store.
+
+        The fix is to validate ``before`` via ``datetime.fromisoformat``
+        when it does not parse as an age. Any unparseable value must
+        raise ``ValueError`` *before* it reaches the store.
+        """
+        doc = tmp_path / "doc.md"
+        doc.write_text("Critical content that must survive a bad ``before`` argument.")
+        with Memory(db=tmp_path / "test.db") as mem:
+            mem.add(doc)
+            before_count = len(mem.list())
+            for bad in ("invalid", "tomorrow", "yesterday", "30x", ""):
+                with pytest.raises(ValueError):
+                    mem.prune(before=bad)
+            assert len(mem.list()) == before_count, (
+                "prune accepted an invalid ``before`` and mutated the store"
+            )
+
+
 # ------------------------------------------------------------------ #
 # Memory.list and Memory.stats                                         #
 # ------------------------------------------------------------------ #

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -720,6 +720,7 @@ class TestMemoryPruneAndCompact:
             for bad in ("invalid", "tomorrow", "yesterday", "30x", ""):
                 with pytest.raises(ValueError):
                     mem.prune(before=bad)
+            # The store must be untouched after every rejected call.
             assert len(mem.list()) == before_count, (
                 "prune accepted an invalid ``before`` and mutated the store"
             )

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -10,6 +10,8 @@ Commands:
   vstash list             → show ingested documents
   vstash stats            → memory statistics
   vstash forget <file>    → remove document
+  vstash update <file>    → mutate metadata or replace content in place
+  vstash compact          → prune old docs, VACUUM, optimize FTS5
   vstash reindex           → re-embed chunks with new model
   vstash config           → show current config
   vstash profile          → manage named profiles
@@ -1413,12 +1415,20 @@ def compact(
         # passed is silently inert. Surface this loudly so users do
         # not mistakenly believe their ``--layer scratch`` actually
         # deleted anything just because the command exited 0.
-        console.print(
-            "[yellow]Warning:[/yellow] --collection/--project/--layer are "
-            "ignored when --before is omitted -- the prune phase is "
-            "skipped entirely and this run will only VACUUM / optimize. "
-            "Pass --before to actually prune by scope."
+        # Route through stderr when ``--json`` is set so the stdout
+        # payload remains pure JSON for downstream parsers.
+        warning = (
+            "--collection/--project/--layer are ignored when --before is "
+            "omitted -- the prune phase is skipped entirely and this run "
+            "will only VACUUM / optimize. Pass --before to actually prune "
+            "by scope."
         )
+        if json_output:
+            import sys as _sys
+
+            print(f"Warning: {warning}", file=_sys.stderr)
+        else:
+            console.print(f"[yellow]Warning:[/yellow] {warning}")
 
     with Memory(profile=_profile_from_ctx(ctx)) as mem:
         report = mem.compact(

--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1355,6 +1355,107 @@ def update(
     )
 
 
+@app.command()
+def compact(
+    ctx: typer.Context,
+    before: str | None = typer.Option(
+        None,
+        "--before",
+        help=(
+            "Prune docs older than this age (e.g. '90d', '2w', '24h') or ISO date "
+            "('2026-01-15'). Omit to skip the prune phase and just VACUUM + optimize."
+        ),
+    ),
+    collection: str | None = typer.Option(
+        None, "--collection", "-c", help="Restrict prune to this collection"
+    ),
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="Restrict prune to this project"
+    ),
+    layer: str | None = typer.Option(None, "--layer", "-l", help="Restrict prune to this layer"),
+    no_vacuum: bool = typer.Option(
+        False, "--no-vacuum", help="Skip the VACUUM step (faster on large DBs)"
+    ),
+    no_optimize_fts: bool = typer.Option(
+        False, "--no-optimize-fts", help="Skip the FTS5 optimize step"
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        "-n",
+        help="Preview which docs would be pruned without modifying the store. "
+        "Also skips VACUUM and optimize.",
+    ),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output the report as JSON"),
+) -> None:
+    """Housekeeping pass: prune old docs (optional), VACUUM, optimize FTS5.
+
+    Three phases, each independently togglable:
+
+      * **Prune**: if ``--before`` is given, deletes every document
+        whose ``added_at`` is strictly older than the threshold,
+        scoped by ``--collection``/``--project``/``--layer``.
+      * **VACUUM**: rebuilds the SQLite file to reclaim space after
+        the prune. Can take seconds-to-minutes on large DBs; pass
+        ``--no-vacuum`` to defer.
+      * **Optimize FTS5**: merges FTS5 segments in place. Cheap;
+        ``--no-optimize-fts`` skips it.
+
+    With ``--dry-run``, only the prune preview runs; VACUUM and
+    optimize are skipped regardless of their flags because they would
+    modify the file.
+    """
+    from .memory import Memory
+
+    if before is None and (collection or project or layer):
+        # ``Memory.compact`` skips the prune phase entirely when
+        # ``before`` is ``None``, so any scope filter the caller
+        # passed is silently inert. Surface this loudly so users do
+        # not mistakenly believe their ``--layer scratch`` actually
+        # deleted anything just because the command exited 0.
+        console.print(
+            "[yellow]Warning:[/yellow] --collection/--project/--layer are "
+            "ignored when --before is omitted -- the prune phase is "
+            "skipped entirely and this run will only VACUUM / optimize. "
+            "Pass --before to actually prune by scope."
+        )
+
+    with Memory(profile=_profile_from_ctx(ctx)) as mem:
+        report = mem.compact(
+            before=before,
+            vacuum=not no_vacuum,
+            optimize_fts=not no_optimize_fts,
+            collection=collection,
+            project=project,
+            layer=layer,
+            dry_run=dry_run,
+        )
+
+    if json_output:
+        import json as _json
+
+        print(_json.dumps(report, indent=2))
+        return
+
+    prune_report = report.get("prune")
+    if prune_report is None:
+        console.print("[dim]No --before set; skipping prune phase.[/dim]")
+    else:
+        verb = "Would delete" if prune_report["status"] == "dry_run" else "Deleted"
+        console.print(f"[green]✓[/green] {verb} [bold]{prune_report['deleted']}[/bold] docs.")
+        if prune_report["paths"] and prune_report["deleted"] <= 20:
+            for p in prune_report["paths"]:
+                console.print(f"  [dim]- {p}[/dim]")
+        elif prune_report["paths"]:
+            console.print(f"  [dim](first 20 of {prune_report['deleted']})[/dim]")
+            for p in prune_report["paths"][:20]:
+                console.print(f"  [dim]- {p}[/dim]")
+    if report.get("vacuum"):
+        console.print("[green]✓[/green] VACUUM complete.")
+    if report.get("optimize_fts"):
+        console.print("[green]✓[/green] FTS5 optimize complete.")
+
+
 # ------------------------------------------------------------------ #
 # vstash check                                                         #
 # ------------------------------------------------------------------ #

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -1051,6 +1051,74 @@ def vstash_update(
 
 
 @mcp_server.tool()
+def vstash_compact(
+    before: str | None = None,
+    collection: str | None = None,
+    project: str | None = None,
+    layer: str | None = None,
+    vacuum: bool = True,
+    optimize_fts: bool = True,
+    dry_run: bool = False,
+) -> str:
+    """Housekeeping: prune old documents, VACUUM SQLite, optimize FTS5.
+
+    Three phases, each independently togglable:
+
+      * **Prune** -- if ``before`` is set, deletes every doc whose
+        ``added_at`` is strictly older. ``before`` accepts an age
+        string (``"30d"``, ``"2w"``, ``"24h"``) or an ISO date /
+        timestamp. Scope with ``collection`` / ``project`` / ``layer``.
+      * **VACUUM** -- rebuilds the SQLite file to reclaim space.
+        Can take seconds-to-minutes on large DBs; pass
+        ``vacuum=False`` to skip.
+      * **Optimize FTS5** -- merges FTS5 segments. Cheap;
+        ``optimize_fts=False`` skips it.
+
+    ``dry_run=True`` reports what the prune would delete without
+    modifying the store, and skips VACUUM and optimize.
+
+    Args:
+        before: Age string or ISO date; ``None`` skips the prune phase.
+        collection: Restrict prune to this collection.
+        project: Restrict prune to this project.
+        layer: Restrict prune to this layer.
+        vacuum: Run SQLite VACUUM after the prune.
+        optimize_fts: Run FTS5 ``'optimize'`` after the prune.
+        dry_run: Preview-only -- no writes.
+
+    Returns:
+        JSON describing each phase::
+
+            {
+              "prune":        {"status": "...", "deleted": N, "paths": [...]} | null,
+              "vacuum":       true | false,
+              "optimize_fts": true | false
+            }
+    """
+    try:
+        from .memory import Memory
+
+        with Memory(collection=collection or "default") as mem:
+            report = mem.compact(
+                before=before,
+                vacuum=vacuum,
+                optimize_fts=optimize_fts,
+                collection=collection,
+                project=project,
+                layer=layer,
+                dry_run=dry_run,
+            )
+        return _ok(report)
+    except ValueError as exc:
+        return _error(str(exc))
+    except FileNotFoundError:
+        return _error("vstash database not found.")
+    except Exception as exc:
+        logger.exception("vstash_compact failed")
+        return _error(f"Failed to compact: {exc}")
+
+
+@mcp_server.tool()
 def vstash_collections() -> str:
     """List all available collections in vstash memory.
 

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -51,10 +51,20 @@ def _resolve_before(before: str) -> str:
         time so back-to-back invocations of the same age cut at the
         same instant.
       * **ISO date / timestamp** (``"2026-01-15"`` or
-        ``"2026-01-15T00:00:00+00:00"``): returned unchanged. The
+        ``"2026-01-15T00:00:00+00:00"``): returned unchanged after
+        being validated against ``datetime.fromisoformat`` so the
         store comparison uses lexical ``<`` on the column, which is
         correct under the ``YYYY-MM-DDTHH:MM:SS+00:00`` form used by
         ingest's ``datetime.now(timezone.utc).isoformat()``.
+
+    Anything that is neither a recognised age nor a parseable ISO
+    timestamp raises ``ValueError``. This is the load-bearing safety
+    rail for ``prune_documents``: SQLite compares text columns
+    lexically, so a free-form string like ``"invalid"`` whose first
+    character ``'i'`` (ASCII 105) is greater than any plausible
+    ISO-prefix character ``'2'`` (ASCII 50) would let ``added_at <
+    'invalid'`` evaluate true for **every** row and silently wipe the
+    store. Validating upfront makes the failure mode loud and local.
 
     Reusing the journal's age parser keeps the two CLIs
     (``vstash compact`` and ``vstash journal prune``) accepting the
@@ -65,13 +75,32 @@ def _resolve_before(before: str) -> str:
     from .journal import _parse_age
 
     stripped = before.strip()
+    if not stripped:
+        raise ValueError("`before` must be a non-empty age or ISO date string")
     # Heuristic: any plain-digit-then-unit suffix (``30d``, ``2w``,
-    # ``24h``) is an age. Anything else (containing ``-`` or longer)
-    # is treated as ISO and returned verbatim so callers retain full
-    # precision and timezone control when they want it.
-    if len(stripped) <= 6 and stripped and stripped[-1] in "dwh" and stripped[:-1].isdigit():
-        delta = _parse_age(stripped)
+    # ``24h``) is an age. Lowercase the suffix so ``30D`` / ``2W`` /
+    # ``24H`` parse too -- ``_parse_age`` is case-sensitive on the
+    # unit, and rejecting the upper-case form here would be more
+    # surprising than just normalising it.
+    if len(stripped) <= 6 and stripped[-1].lower() in "dwh" and stripped[:-1].isdigit():
+        delta = _parse_age(stripped.lower())
         return (datetime.now(timezone.utc) - delta).isoformat()
+    # Not an age: must be a parseable ISO datetime. ``fromisoformat``
+    # accepts both ``YYYY-MM-DD`` and the full ``YYYY-MM-DDTHH:MM:SS``
+    # forms, and rejects everything else with ``ValueError``. We pass
+    # the bare exception through with a friendlier message so callers
+    # see WHY their input was refused without losing the original
+    # cause.
+    try:
+        datetime.fromisoformat(stripped)
+    except ValueError as exc:
+        raise ValueError(
+            f"`before={before!r}` is neither a recognised age "
+            f"('30d' / '2w' / '24h') nor a parseable ISO date / timestamp "
+            f"('2026-01-15' / '2026-01-15T00:00:00+00:00'). "
+            f"Refusing to pass through to the store because SQLite would "
+            f"compare lexically and silently delete every document."
+        ) from exc
     return stripped
 
 

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -38,6 +38,43 @@ from .services import search_with_embedding
 _UNSET = object()
 
 
+def _resolve_before(before: str) -> str:
+    """Normalize a ``before=`` filter to an ISO timestamp string.
+
+    Accepts two surface forms and resolves them to a single canonical
+    representation that ``VstashStore.prune_documents`` can compare
+    directly against the ``added_at`` column:
+
+      * **Age string** (``"30d"``, ``"2w"``, ``"24h"``): parsed the
+        same way as ``vstash journal prune`` and converted to
+        ``now(UTC) - delta``. The ``"now"`` snapshot is taken at call
+        time so back-to-back invocations of the same age cut at the
+        same instant.
+      * **ISO date / timestamp** (``"2026-01-15"`` or
+        ``"2026-01-15T00:00:00+00:00"``): returned unchanged. The
+        store comparison uses lexical ``<`` on the column, which is
+        correct under the ``YYYY-MM-DDTHH:MM:SS+00:00`` form used by
+        ingest's ``datetime.now(timezone.utc).isoformat()``.
+
+    Reusing the journal's age parser keeps the two CLIs
+    (``vstash compact`` and ``vstash journal prune``) accepting the
+    same vocabulary.
+    """
+    from datetime import datetime, timezone
+
+    from .journal import _parse_age
+
+    stripped = before.strip()
+    # Heuristic: any plain-digit-then-unit suffix (``30d``, ``2w``,
+    # ``24h``) is an age. Anything else (containing ``-`` or longer)
+    # is treated as ISO and returned verbatim so callers retain full
+    # precision and timezone control when they want it.
+    if len(stripped) <= 6 and stripped and stripped[-1] in "dwh" and stripped[:-1].isdigit():
+        delta = _parse_age(stripped)
+        return (datetime.now(timezone.utc) - delta).isoformat()
+    return stripped
+
+
 class Memory:
     """High-level Python SDK for vstash.
 
@@ -576,6 +613,121 @@ class Memory:
             retrieval_mode=retrieval_mode,
         )
         return _chat_ask_full(query, chunks, self._cfg, history)
+
+    def prune(
+        self,
+        *,
+        before: str | None = None,
+        collection: object = _UNSET,
+        project: object = _UNSET,
+        layer: str | None = None,
+        dry_run: bool = False,
+    ) -> dict:
+        """Delete documents matching a date / metadata filter.
+
+        ``before`` accepts either an age string (``"30d"``, ``"2w"``,
+        ``"24h"``) which is converted to an absolute UTC cutoff at the
+        moment of the call, OR a full ISO date / timestamp
+        (``"2026-01-15"``, ``"2026-01-15T00:00:00+00:00"``) which is
+        passed straight through. At least one filter must be provided;
+        an unfiltered prune raises ``ValueError`` rather than wiping
+        the store silently.
+
+        Args:
+            before: Age string or ISO date. Documents whose
+                ``added_at`` is strictly older are deleted.
+            collection: Restrict to a single collection. Defaults to
+                the ``Memory``-instance collection. Pass ``None`` to
+                cover every collection.
+            project: Restrict to a project. Same UNSET / None rules
+                as the constructor.
+            layer: Restrict to a layer.
+            dry_run: If ``True``, return what would be deleted without
+                touching the store.
+
+        Returns:
+            ``{"status": "ok"|"dry_run", "deleted": N, "paths": [...]}``.
+
+        Example::
+
+            mem = Memory(project="my_agent")
+            mem.prune(before="90d", dry_run=True)        # preview
+            mem.prune(before="90d")                       # apply
+            mem.prune(layer="scratch")                    # by layer
+        """
+        before_iso: str | None = None
+        if before is not None:
+            before_iso = _resolve_before(before)
+
+        col = self._collection if collection is _UNSET else collection
+        col_filter = None if col == "default" else col
+        proj = self._project if project is _UNSET else project
+
+        return self._store.prune_documents(
+            before_iso=before_iso,
+            collection=col_filter,
+            project=proj,
+            layer=layer,
+            dry_run=dry_run,
+        )
+
+    def compact(
+        self,
+        *,
+        before: str | None = None,
+        vacuum: bool = True,
+        optimize_fts: bool = True,
+        collection: object = _UNSET,
+        project: object = _UNSET,
+        layer: str | None = None,
+        dry_run: bool = False,
+    ) -> dict:
+        """Full housekeeping pass: prune (optional) + VACUUM + FTS optimize.
+
+        Composes ``prune`` with the two store-level cleanup primitives
+        in a single call. Each phase is independent; passing
+        ``before=None`` skips the prune entirely and ``compact`` reduces
+        to a pure VACUUM + optimize.
+
+        Args:
+            before: Age or ISO date for the prune phase. ``None`` skips
+                pruning. See ``Memory.prune`` for the accepted formats.
+            vacuum: Run ``VACUUM`` after pruning. Set ``False`` on very
+                large stores where you want to defer the file rebuild
+                (VACUUM can take seconds-to-minutes on multi-GB DBs).
+            optimize_fts: Run the FTS5 ``'optimize'`` directive to
+                compact the inverted index. Much cheaper than VACUUM;
+                independent of it.
+            collection / project / layer: Scope for the prune phase.
+                Defaults follow ``Memory.prune``.
+            dry_run: If ``True``, run the prune in dry-run mode and
+                skip VACUUM / optimize entirely. Lets callers preview
+                without modifying the file.
+
+        Returns:
+            ``{"prune": {...} | None, "vacuum": bool, "optimize_fts": bool}``
+            describing each phase. The ``prune`` field is the same dict
+            ``Memory.prune`` returns, or ``None`` when ``before`` was
+            not provided.
+        """
+        report: dict = {"prune": None, "vacuum": False, "optimize_fts": False}
+        if before is not None:
+            report["prune"] = self.prune(
+                before=before,
+                collection=collection,
+                project=project,
+                layer=layer,
+                dry_run=dry_run,
+            )
+        if dry_run:
+            return report
+        if vacuum:
+            self._store.vacuum()
+            report["vacuum"] = True
+        if optimize_fts:
+            self._store.optimize_fts()
+            report["optimize_fts"] = True
+        return report
 
     def remove(self, source: str | Path) -> bool:
         """Remove a document from memory.

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -92,7 +92,7 @@ def _resolve_before(before: str) -> str:
     # see WHY their input was refused without losing the original
     # cause.
     try:
-        datetime.fromisoformat(stripped)
+        parsed = datetime.fromisoformat(stripped)
     except ValueError as exc:
         raise ValueError(
             f"`before={before!r}` is neither a recognised age "
@@ -101,7 +101,18 @@ def _resolve_before(before: str) -> str:
             f"Refusing to pass through to the store because SQLite would "
             f"compare lexically and silently delete every document."
         ) from exc
-    return stripped
+    # Canonicalise to UTC. ``added_at`` is stored as
+    # ``datetime.now(timezone.utc).isoformat()`` (always ``+00:00``),
+    # and SQLite compares the column lexically. A naive cutoff like
+    # ``2026-01-15T00:00:00-05:00`` would sort lexically AFTER
+    # ``2026-01-15T00:00:00+00:00`` even though it represents an
+    # earlier instant, so prune would mis-delete around timezone
+    # boundaries. Treat naive inputs as UTC; convert aware inputs.
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.isoformat()
 
 
 class Memory:
@@ -688,14 +699,18 @@ class Memory:
         if before is not None:
             before_iso = _resolve_before(before)
 
-        col = self._collection if collection is _UNSET else collection
-        col_filter = None if col == "default" else col
-        proj = self._project if project is _UNSET else project
-
+        # Use the shared resolver helpers so prune obeys the same
+        # scope rules as every other read/write on this class. The
+        # previous ``col_filter = None if col == "default" else col``
+        # silently widened a ``Memory(collection="default")`` prune
+        # to *every* collection -- exactly the #165 asymmetry
+        # ``_resolve_collection`` is designed to prevent. Pass
+        # ``collection=None`` explicitly when you want "all
+        # collections", same as ``Memory.update`` and the CLI does.
         return self._store.prune_documents(
             before_iso=before_iso,
-            collection=col_filter,
-            project=proj,
+            collection=self._resolve_collection(collection),
+            project=self._resolve_project(project),
             layer=layer,
             dry_run=dry_run,
         )

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1892,16 +1892,35 @@ class VstashStore:
             conditions.append("added_at < ?")
             params.append(before_iso)
         where = "WHERE " + " AND ".join(conditions)
-        rows = self._conn.execute(f"SELECT id, path FROM documents {where}", params).fetchall()
-        if not rows:
-            return {"status": "dry_run" if dry_run else "ok", "deleted": 0, "paths": []}
-        doc_ids = [r["id"] for r in rows]
-        paths = [r["path"] for r in rows]
+        select_sql = f"SELECT id, path FROM documents {where}"
+
+        # ``dry_run`` is informational and tolerates the small race
+        # between SELECT and any concurrent writer -- it does not
+        # delete anything. The real prune below puts the SELECT INSIDE
+        # ``BEGIN IMMEDIATE`` so the rows we report deleted are exactly
+        # the rows that satisfied the filter at the instant the write
+        # lock was acquired. Otherwise a concurrent ``add_document``
+        # between the unlocked SELECT and the locked delete would let
+        # the reported ``paths`` / ``deleted`` count drift from what
+        # ``_delete_by_doc_ids`` actually removed.
         if dry_run:
-            return {"status": "dry_run", "deleted": len(paths), "paths": paths}
+            rows = self._conn.execute(select_sql, params).fetchall()
+            if not rows:
+                return {"status": "dry_run", "deleted": 0, "paths": []}
+            return {
+                "status": "dry_run",
+                "deleted": len(rows),
+                "paths": [r["path"] for r in rows],
+            }
         with self._write_lock:
             try:
                 self._conn.execute("BEGIN IMMEDIATE")
+                rows = self._conn.execute(select_sql, params).fetchall()
+                if not rows:
+                    self._conn.rollback()
+                    return {"status": "ok", "deleted": 0, "paths": []}
+                doc_ids = [r["id"] for r in rows]
+                paths = [r["path"] for r in rows]
                 self._delete_by_doc_ids(doc_ids)
                 self._conn.commit()
                 self._invalidate_idf_cache()

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -1810,8 +1810,12 @@ class VstashStore:
                 set_parts.append("title = ?")
                 set_params.append(title)
             if tags is not None:
+                # Normalize on write so the search-side comma-anchored
+                # LIKE matches reliably (same invariant as
+                # ``add_document`` post-#364). ``tags=""`` clears.
                 set_parts.append("tags = ?")
-                set_params.append(tags)
+                stored = ",".join(_normalize_tags(tags)) if tags else None
+                set_params.append(stored)
             where_parts = ["path = ?"]
             where_params: list[str] = [path]
             if collection is not None:
@@ -1832,6 +1836,111 @@ class VstashStore:
                 self._conn.rollback()
                 raise
             return rowcount > 0
+
+    def prune_documents(
+        self,
+        *,
+        before_iso: str | None = None,
+        collection: str | None = None,
+        project: str | None = None,
+        layer: str | None = None,
+        tags: str | list[str] | None = None,
+        dry_run: bool = False,
+    ) -> dict:
+        """Delete documents matching the given filters.
+
+        At least one filter (``before_iso`` or any metadata) must be
+        provided -- a fully-unfiltered prune would wipe the entire
+        store, which is almost always a caller bug and is better done
+        explicitly with ``delete_document`` in a loop.
+
+        Args:
+            before_iso: Delete documents whose ``added_at`` is strictly
+                older than this ISO timestamp (``"2026-01-15"`` or full
+                ``"2026-01-15T00:00:00+00:00"``).
+            collection: Restrict to this collection.
+            project: Restrict to this project.
+            layer: Restrict to this layer.
+            tags: Restrict to docs tagged with any of these tags (OR).
+                Accepts the same forms as the search-side tag filter:
+                comma-separated string (``"alpha,beta"``) or list.
+            dry_run: If ``True``, report what would be deleted without
+                touching the store.
+
+        Returns:
+            ``{"status": "ok"|"dry_run", "deleted": N, "paths": [...]}``.
+        """
+        if (
+            before_iso is None
+            and collection is None
+            and project is None
+            and layer is None
+            and not _normalize_tags(tags)
+        ):
+            raise ValueError(
+                "prune_documents called with no filter -- pass at least one "
+                "of `before_iso`, `collection`, `project`, `layer`, or `tags` "
+                "to scope the deletion."
+            )
+        conditions, params = self._get_filter_conditions(
+            collection=collection,
+            project=project,
+            layer=layer,
+            tags=tags,
+        )
+        if before_iso is not None:
+            conditions.append("added_at < ?")
+            params.append(before_iso)
+        where = "WHERE " + " AND ".join(conditions)
+        rows = self._conn.execute(f"SELECT id, path FROM documents {where}", params).fetchall()
+        if not rows:
+            return {"status": "dry_run" if dry_run else "ok", "deleted": 0, "paths": []}
+        doc_ids = [r["id"] for r in rows]
+        paths = [r["path"] for r in rows]
+        if dry_run:
+            return {"status": "dry_run", "deleted": len(paths), "paths": paths}
+        with self._write_lock:
+            try:
+                self._conn.execute("BEGIN IMMEDIATE")
+                self._delete_by_doc_ids(doc_ids)
+                self._conn.commit()
+                self._invalidate_idf_cache()
+                self._bump_cache_epoch()
+                if self._snap_dirty:
+                    self._save_snapvec()
+            except Exception:
+                self._conn.rollback()
+                self._reload_snapvec()
+                raise
+        return {"status": "ok", "deleted": len(paths), "paths": paths}
+
+    def vacuum(self) -> None:
+        """Run SQLite ``VACUUM`` to reclaim space and defragment the file.
+
+        VACUUM cannot run inside a transaction. The store's normal
+        write path uses ``BEGIN IMMEDIATE`` so callers must not invoke
+        this from within another operation -- it is intended as the
+        outermost step of ``Memory.compact()`` / ``vstash compact``,
+        well after the prune phase has committed.
+
+        VACUUM rebuilds the entire database file, so on large stores
+        it can take seconds to minutes and momentarily doubles the disk
+        usage (working copy + original). Both costs are unavoidable.
+        """
+        with self._write_lock:
+            self._conn.execute("VACUUM")
+
+    def optimize_fts(self) -> None:
+        """Merge FTS5 segments in place and reclaim space.
+
+        Uses the FTS5 ``'optimize'`` directive (``INSERT INTO fts_chunks
+        (fts_chunks) VALUES ('optimize')``) which compacts the
+        inverted index without altering any tokenization or content.
+        Much cheaper than ``VACUUM`` and safe to run independently.
+        """
+        with self._write_lock:
+            self._conn.execute("INSERT INTO fts_chunks(fts_chunks) VALUES ('optimize')")
+            self._conn.commit()
 
     def _delete_by_doc_id(self, doc_id: str) -> bool:
         """Delete a document by its internal hash ID.


### PR DESCRIPTION
## Summary

Adds general-purpose housekeeping for the document store. Maps to feedback point 9 from the hermes-agent vstash-plugin review (\"vstash_prune / vstash_compact to force cleanup of old entries\").

Three independent primitives wired through every adapter:

| Primitive | What it does |
|---|---|
| ``VstashStore.prune_documents`` | Atomic delete of every doc matching the supplied filter (``before_iso`` + ``collection`` + ``project`` + ``layer``). Requires at least one filter -- unfiltered raises ``ValueError`` so the foot-gun is opt-in. |
| ``VstashStore.vacuum`` | SQLite ``VACUUM`` outside any transaction. |
| ``VstashStore.optimize_fts`` | FTS5 ``'optimize'`` directive in place; much cheaper than VACUUM. |

Memory layer composes them:

- ``Memory.prune(*, before=None, ...)`` -- ``before`` accepts an age string (``"30d"``/``"2w"``/``"24h"``) OR an ISO date / timestamp via the new ``_resolve_before`` helper. Reuses the journal's ``_parse_age`` so ``vstash compact`` and ``vstash journal prune`` share the same vocabulary.
- ``Memory.compact(*, before=None, vacuum=True, optimize_fts=True, ..., dry_run=False)`` -- one-shot pass. ``before=None`` skips the prune. ``dry_run=True`` previews the prune and explicitly skips the write phases.

Adapters:

- CLI ``vstash compact [--before AGE_OR_ISO] [--collection X] [--project Y] [--layer L] [--no-vacuum] [--no-optimize-fts] [--dry-run] [--json]`` -- pretty + JSON output, prints the would-delete path list for dry-run previews.
- MCP ``vstash_compact`` tool with the same kwargs.

## Test plan

- [x] ``python -m pytest tests/test_memory.py tests/test_store.py tests/test_cli_commands.py tests/test_mcp.py tests/test_journal.py -q`` (267 passed)
- [x] ``python -m ruff check . && python -m ruff format --check .`` (clean)
- [x] 5 new focused tests in ``TestMemoryPruneAndCompact``:
  - ``test_prune_requires_filter`` -- unfiltered prune raises ``ValueError``.
  - ``test_prune_by_layer`` -- layer scope deletes only matching docs.
  - ``test_prune_dry_run_is_readonly`` -- dry-run reports without mutating.
  - ``test_compact_runs_vacuum_and_optimize`` -- ``before=None`` path skips prune; VACUUM + optimize both reported; store still functional after.
  - ``test_compact_dry_run_skips_writes`` -- dry-run forwards to prune-preview and skips VACUUM + optimize.

## Out of scope (future PR)

- Tag filtering on ``prune_documents`` -- the ``_get_filter_conditions`` extension that adds ``tags`` lives on the [#364 tag-filters branch](https://github.com/stffns/vstash/pull/364). Once that lands, ``prune_documents`` can accept ``tags=`` in a small follow-up. The docstring notes the deferral.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `compact` command for datastore housekeeping—prune documents older than a specified date, run database optimization, and optimize full-text search indexing with individually controllable phases.
  * Added support for scoped pruning by collection, project, or layer.
  * Included dry-run mode to preview changes without applying them.

* **Tests**
  * Added comprehensive test coverage for pruning and compaction functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->