### PR TITLE
chore(release): expose tags= in Memory.prune/compact + drop age length cap

### DIFF
--- a/vstash/cli.py
+++ b/vstash/cli.py
@@ -1375,6 +1375,16 @@ def compact(
         None, "--project", "-p", help="Restrict prune to this project"
     ),
     layer: str | None = typer.Option(None, "--layer", "-l", help="Restrict prune to this layer"),
+    tag: list[str] | None = typer.Option(
+        None,
+        "--tag",
+        "-t",
+        help=(
+            "Restrict prune to docs tagged with this value. Repeatable for OR "
+            "(``--tag archive --tag old``), or comma-joined "
+            "(``--tag 'archive,old'``). Comma-anchored match."
+        ),
+    ),
     no_vacuum: bool = typer.Option(
         False, "--no-vacuum", help="Skip the VACUUM step (faster on large DBs)"
     ),
@@ -1409,7 +1419,7 @@ def compact(
     """
     from .memory import Memory
 
-    if before is None and (collection or project or layer):
+    if before is None and (collection or project or layer or tag):
         # ``Memory.compact`` skips the prune phase entirely when
         # ``before`` is ``None``, so any scope filter the caller
         # passed is silently inert. Surface this loudly so users do
@@ -1438,6 +1448,7 @@ def compact(
             collection=collection,
             project=project,
             layer=layer,
+            tags=tag,
             dry_run=dry_run,
         )
 

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -1056,6 +1056,7 @@ def vstash_compact(
     collection: str | None = None,
     project: str | None = None,
     layer: str | None = None,
+    tags: str | None = None,
     vacuum: bool = True,
     optimize_fts: bool = True,
     dry_run: bool = False,
@@ -1067,7 +1068,8 @@ def vstash_compact(
       * **Prune** -- if ``before`` is set, deletes every doc whose
         ``added_at`` is strictly older. ``before`` accepts an age
         string (``"30d"``, ``"2w"``, ``"24h"``) or an ISO date /
-        timestamp. Scope with ``collection`` / ``project`` / ``layer``.
+        timestamp. Scope with ``collection`` / ``project`` /
+        ``layer`` / ``tags``.
       * **VACUUM** -- rebuilds the SQLite file to reclaim space.
         Can take seconds-to-minutes on large DBs; pass
         ``vacuum=False`` to skip.
@@ -1082,6 +1084,9 @@ def vstash_compact(
         collection: Restrict prune to this collection.
         project: Restrict prune to this project.
         layer: Restrict prune to this layer.
+        tags: Comma-separated list of tags; restrict prune to docs
+            tagged with any of them (OR semantics). Comma-anchored
+            match so ``alpha`` does NOT false-match ``alphabet``.
         vacuum: Run SQLite VACUUM after the prune.
         optimize_fts: Run FTS5 ``'optimize'`` after the prune.
         dry_run: Preview-only -- no writes.
@@ -1106,6 +1111,7 @@ def vstash_compact(
                 collection=collection,
                 project=project,
                 layer=layer,
+                tags=tags,
                 dry_run=dry_run,
             )
         return _ok(report)

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -81,8 +81,11 @@ def _resolve_before(before: str) -> str:
     # ``24h``) is an age. Lowercase the suffix so ``30D`` / ``2W`` /
     # ``24H`` parse too -- ``_parse_age`` is case-sensitive on the
     # unit, and rejecting the upper-case form here would be more
-    # surprising than just normalising it.
-    if len(stripped) <= 6 and stripped[-1].lower() in "dwh" and stripped[:-1].isdigit():
+    # surprising than just normalising it. No length cap: any number
+    # of leading digits is fine (``"100000h"`` is ~11 years, a
+    # perfectly valid age cutoff), and the digit+suffix shape is
+    # unambiguously distinct from any ISO date / timestamp.
+    if stripped[-1].lower() in "dwh" and stripped[:-1].isdigit():
         delta = _parse_age(stripped.lower())
         return (datetime.now(timezone.utc) - delta).isoformat()
     # Not an age: must be a parseable ISO datetime. ``fromisoformat``
@@ -661,6 +664,7 @@ class Memory:
         collection: object = _UNSET,
         project: object = _UNSET,
         layer: str | None = None,
+        tags: str | list[str] | None = None,
         dry_run: bool = False,
     ) -> dict:
         """Delete documents matching a date / metadata filter.
@@ -682,6 +686,10 @@ class Memory:
             project: Restrict to a project. Same UNSET / None rules
                 as the constructor.
             layer: Restrict to a layer.
+            tags: Restrict to docs tagged with any of these tags
+                (OR semantics). Same shape as the search-side tag
+                filter -- comma-separated string or list, comma-anchored
+                match so ``alpha`` does not false-match ``alphabet``.
             dry_run: If ``True``, return what would be deleted without
                 touching the store.
 
@@ -694,6 +702,7 @@ class Memory:
             mem.prune(before="90d", dry_run=True)        # preview
             mem.prune(before="90d")                       # apply
             mem.prune(layer="scratch")                    # by layer
+            mem.prune(tags="archive")                     # by tag
         """
         before_iso: str | None = None
         if before is not None:
@@ -712,6 +721,7 @@ class Memory:
             collection=self._resolve_collection(collection),
             project=self._resolve_project(project),
             layer=layer,
+            tags=tags,
             dry_run=dry_run,
         )
 
@@ -724,6 +734,7 @@ class Memory:
         collection: object = _UNSET,
         project: object = _UNSET,
         layer: str | None = None,
+        tags: str | list[str] | None = None,
         dry_run: bool = False,
     ) -> dict:
         """Full housekeeping pass: prune (optional) + VACUUM + FTS optimize.
@@ -761,6 +772,7 @@ class Memory:
                 collection=collection,
                 project=project,
                 layer=layer,
+                tags=tags,
                 dry_run=dry_run,
             )
         if dry_run:

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -85,7 +85,7 @@ def _resolve_before(before: str) -> str:
     # of leading digits is fine (``"100000h"`` is ~11 years, a
     # perfectly valid age cutoff), and the digit+suffix shape is
     # unambiguously distinct from any ISO date / timestamp.
-    if stripped[-1].lower() in "dwh" and stripped[:-1].isdigit():
+    if len(stripped) > 1 and stripped[-1].lower() in "dwh" and stripped[:-1].isdigit():
         delta = _parse_age(stripped.lower())
         return (datetime.now(timezone.utc) - delta).isoformat()
     # Not an age: must be a parseable ISO datetime. ``fromisoformat``


### PR DESCRIPTION
## Summary

Pre-publish touch-ups for v0.37.0 from the gemini-code-assist review on release PR #368. Should land before that release PR merges.

- ``Memory.prune`` / ``Memory.compact`` now expose ``tags=`` and forward to ``VstashStore.prune_documents``. The store primitive accepted ``tags=`` post-#366 rebase but the SDK / CLI / MCP surfaces never wired it through. CLI gains ``--tag`` (repeatable) and MCP ``vstash_compact`` gains the ``tags`` arg.
- ``_resolve_before`` drops the ``len(stripped) <= 6`` cap so valid large ages like ``"100000h"`` (~11 years) parse correctly. The suffix-digit shape is already unambiguous vs ISO, so the length test was over-restrictive.

Deliberately NOT in this PR: the gemini ``zip(..., strict=False)`` -> ``strict=True`` suggestion at ``store.py:5018``. The block already has an explicit ``len(embeddings) != len(ids)`` guard immediately above the zip, so the change is redundant cosmetic consistency rather than a real safety improvement. Filed for a follow-up cleanup PR rather than blocking the release.

## Test plan

- [x] ``python -m pytest tests/test_memory.py::TestMemoryPruneAndCompact tests/test_memory.py::TestMemoryUpdate -x -q`` (12 passed)
- [x] ``python -m ruff check . && python -m ruff format --check .`` (clean)