### PR TITLE
⚡ Bolt: Lazy MMR L2 Norm Evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2025-02-27 - Lazily evaluate L2 norms in MMR deduplication
+**Learning:** In MMR deduplication, eagerly precomputing L2 norms (`math.hypot`) for all candidates scales with the number of duplicate chunks returned by the search, which can be expensive. Many chunks may never actually compete against a sibling if they are filtered out or are the only representative of their document in the remaining set.
+**Action:** Lazily evaluate L2 norms only when a chunk is actually compared against a selected sibling. Additionally, bypass similarity penalty updates entirely if the selected chunk is the only one from its document (`len(doc_indices) <= 1`).

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3567,8 +3567,8 @@ class VstashStore:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily compute L2 norms for cosine similarity only when compared against a sibling.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -3623,18 +3623,34 @@ class VstashStore:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
-            new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+            doc_indices = doc_to_indices[new_doc_key]
+
+            # Short-circuit: If this is the only chunk from this document,
+            # no sibling penalties need to be updated.
+            if len(doc_indices) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    # Lazily evaluate the norm for the newly selected chunk
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = math.hypot(*new_emb)
+                        chunk_norms[best_idx] = new_norm
+
+                    for idx in doc_indices:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                # Lazily evaluate the norm for the sibling chunk
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = math.hypot(*idx_emb)
+                                    chunk_norms[idx] = idx_norm
+
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
💡 **What**: Refactored `_mmr_dedup` in `vstash/store.py` to only calculate L2 norms (`math.hypot`) lazily when a chunk is actually compared against a selected sibling, rather than eagerly precomputing it for all $N$ chunks in the results array. Additionally added a short-circuit bypass to completely skip the redundancy penalty evaluation loop if the selected document has $\le 1$ chunk in the results.

🎯 **Why**: Previously, `math.hypot` was eagerly computed for every single candidate chunk passed to MMR, regardless of whether that chunk would ever be selected or if it even had a sibling to compete against. In the context of MMR diversity scaling, single-chunk documents don't need redundancy penalties applied against siblings, so computing those norms and setting up the inner loop overhead for them was wasted CPU effort.

📊 **Impact**: This saves $O(N)$ redundant math calculations and entirely skips the inner O(N) penalty update loop for any result set populated by unique single-chunk document results. 

🔬 **Measurement**: Verified using the `_mmr_dedup` isolated logic tests and ran the full unit test suite, confirming exact behavioral match with the previous mathematical semantics.

---
*PR created automatically by Jules for task [9262127145209723965](https://jules.google.com/task/9262127145209723965) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized MMR deduplication to compute L2 norms lazily, only when candidates are actively compared against selected items.
  * Improved efficiency by skipping similarity-penalty updates for documents containing a single chunk.

* **Documentation**
  * Updated release notes documenting the optimization changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stffns/vstash/pull/372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->