### PR TITLE
⚡ Bolt: Lazy Evaluation of L2 norms in _mmr_dedup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - Lazily compute L2 norms and bypass updates for singleton documents in MMR deduplication
+**Learning:** In MMR deduplication, lazily evaluate L2 norms (e.g., `math.hypot`) only when a chunk is actually compared against a selected sibling, rather than eagerly precomputing them for all candidates. Additionally, bypass similarity penalty updates (like `max_sims`) entirely if the selected chunk is the only one from its document (`len(doc_indices) <= 1`).
+**Action:** When implementing MMR or similar similarity-penalty algorithms, avoid eager invariant calculation across all candidates if only a subset will ever be compared, and short-circuit update loops when no eligible siblings exist.

--- a/vstash/store.py
+++ b/vstash/store.py
@@ -3567,8 +3567,9 @@ class VstashStore:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily compute L2 norms for cosine similarity to avoid O(N) recomputation
+        # for chunks that are never compared (no siblings or never selected).
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -3623,13 +3624,25 @@ class VstashStore:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+
+            # Fast-path: Skip update if there are no other siblings from the same document
+            if len(doc_to_indices[new_doc_key]) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
+
+            if chunk_norms[best_idx] is None and new_emb is not None:
+                chunk_norms[best_idx] = math.hypot(*new_emb)
             new_norm = chunk_norms[best_idx]
+
             if new_emb is not None:
                 for idx in doc_to_indices[new_doc_key]:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
+                            if chunk_norms[idx] is None:
+                                chunk_norms[idx] = math.hypot(*idx_emb)
+
                             sim = _cosine_sim(
                                 idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
                             )


### PR DESCRIPTION
💡 What:
The `_mmr_dedup` method inside `vstash/store.py` was previously aggressively precomputing the L2 norms of all candidates upfront and looping through updates even when documents had no other sibling chunks. 
This optimization refactors `chunk_norms` to be initialized with `None`, and evaluated on the fly via `math.hypot()` only when the value is needed. Furthermore, a fast-path skip is added in the loop: if a selected chunk has no other remaining siblings from the same document (i.e., `len(doc_to_indices[new_doc_key]) <= 1`), we bypass the redundant `max_sims` updates completely.

🎯 Why:
MMR diversity filtering calculates chunk norms using `math.hypot`, which is relatively fast, but doing it upfront for hundreds of candidates—many of which will never be selected or may not have siblings to compare against—is a waste of CPU cycles. Bypassing updates for singletons skips the dictionary lookups and condition evaluations that don't result in state changes. 

📊 Impact:
In result lists with high top_k thresholds where MMR deduplication is active, these changes reduce CPU overhead related to embedding math by evaluating `math.hypot` only exactly when necessary, and reducing iterative list walks for documents that have only one candidate chunk in the results.

🔬 Measurement:
Run the MMR dedup tests natively or run the application against identical sibling chunks. The output chunk order remains deterministic but calculations for un-compared candidates will be bypassed.

---
*PR created automatically by Jules for task [5855073535671591145](https://jules.google.com/task/5855073535671591145) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized deduplication logic performance through lazy evaluation and conditional short-circuit evaluation to reduce unnecessary computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->