### PR TITLE
fix: allow 'adaptive_fallback' StageVerdict stage so miss_analysis doesn't crash (#383)

### DIFF
--- a/tests/test_miss_analysis.py
+++ b/tests/test_miss_analysis.py
@@ -338,3 +338,38 @@ class TestNearMiss:
         if analysis.final_rank is not None and analysis.final_rank >= 3:
             joined = " ".join(analysis.suggestions).lower()
             assert "near-miss" in joined or "competitive" in joined
+
+
+# ------------------------------------------------------------------ #
+# Regression: adaptive_fallback trace stage (#383)                      #
+# ------------------------------------------------------------------ #
+
+
+class TestAdaptiveFallbackStage:
+    def test_stage_verdict_accepts_adaptive_fallback(self):
+        """#383: the search pipeline records an ``adaptive_fallback`` stage when
+        the vector pool is empty after the distance cutoff but FTS still hits.
+        ``miss_analysis()`` builds a ``StageVerdict`` for every recorded stage, so
+        ``StageVerdict.stage`` must accept ``adaptive_fallback`` — it was missing
+        from the Literal, making ``miss_analysis()`` raise a ``ValidationError`` on
+        any fallback query."""
+        from vstash.models import StageVerdict
+
+        verdict = StageVerdict(
+            stage="adaptive_fallback",
+            passed=True,
+            detail="vector pool empty after distance cutoff: collapsed to FTS-only",
+        )
+        assert verdict.stage == "adaptive_fallback"
+
+    def test_adaptive_fallback_in_allowed_stages(self):
+        """``adaptive_fallback`` must be a member of the ``StageVerdict.stage``
+        Literal, alongside the other real pipeline stages."""
+        import typing
+
+        from vstash.models import StageVerdict
+
+        allowed = set(typing.get_args(StageVerdict.model_fields["stage"].annotation))
+        assert "adaptive_fallback" in allowed
+        # Sanity: it sits among the other genuine pipeline stages.
+        assert {"vector_search", "rrf_fusion", "mmr_dedup"} <= allowed

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -177,6 +177,7 @@ class StageVerdict(BaseModel):
         "vector_search",
         "distance_cutoff",
         "fts_search",
+        "adaptive_fallback",
         "rrf_fusion",
         "recency_boost",
         "mmr_dedup",


### PR DESCRIPTION
Closes #383.

## Problem
The search pipeline's miss-analysis tracer records an `"adaptive_fallback"` stage when the vector pool is empty after the distance cutoff but FTS still hits (the adaptive-RRF collapse to FTS-only scoring). `miss_analysis()` then builds a `StageVerdict` for every recorded stage — but `StageVerdict.stage` was a closed `Literal` that did **not** include `"adaptive_fallback"`, so constructing it raised `pydantic.ValidationError`, crashing `vstash why` / `Memory.miss_analysis()` on any fallback query. Surfaced by the CodeRabbit review of #382 (the code was moved verbatim there; the bug is pre-existing).

## Fix
Add `"adaptive_fallback"` to the `StageVerdict.stage` Literal, placed chronologically (after `fts_search`, before `rrf_fusion`). It's a legitimate, informative pipeline event worth surfacing in miss analysis — the tracer author intended to record it; the model just hadn't been updated. The miss-suggestion logic looks stages up by name (`by_stage.get(...)`, non-exhaustive), so the new value is harmless there.

## Tests
- `tests/test_miss_analysis.py::TestAdaptiveFallbackStage` — constructs the previously-rejected `StageVerdict`, and asserts `"adaptive_fallback"` is in the model's allowed stages. **Verified both fail without this change** (pydantic `ValidationError` / membership assertion).
- `pytest tests/` → **1261 passed**, 6 deselected. `ruff` clean.

Note: an integration test through the real `miss_analysis()` fallback path was attempted but the trigger (`not vec_rows and fts_rows`) requires a contrived metadata-filter scenario that's brittle with synthetic embeddings — the ratio-based distance cutoff always keeps the closest result. The model-level regression is reliable and directly protects the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `adaptive_fallback` stage in miss-analysis pipeline stage tracking.

* **Tests**
  * Added regression test coverage for the new `adaptive_fallback` stage to ensure proper pipeline tracing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->