### PR TITLE
fix: UTC-canonicalise search/list added_after/added_before date filters (#384)

### DIFF
--- a/tests/test_search_date_filters.py
+++ b/tests/test_search_date_filters.py
@@ -35,6 +35,14 @@ class TestCanonicalizeAddedFilter:
         value = "2026-01-15T05:00:00+00:00"
         assert _canonicalize_added_filter(value, label="x") == value
 
+    def test_z_suffix_supported_on_python_310(self) -> None:
+        # Python 3.10's fromisoformat rejects the 'Z' suffix; the helper
+        # normalises it so the common ...Z form parses on all supported versions.
+        assert (
+            _canonicalize_added_filter("2026-01-15T05:00:00Z", label="x")
+            == "2026-01-15T05:00:00+00:00"
+        )
+
     @pytest.mark.parametrize("bad", ["not-a-date", "", "2026-13-99", "30d"])
     def test_invalid_raises_with_label(self, bad: str) -> None:
         with pytest.raises(ValueError, match="added_after"):

--- a/tests/test_search_date_filters.py
+++ b/tests/test_search_date_filters.py
@@ -1,0 +1,59 @@
+"""#384: ``added_after`` / ``added_before`` are UTC-canonicalised before the
+lexical ``added_at`` comparison used by search and ``list_documents``.
+
+``added_at`` is stored as UTC ISO (``...+00:00``) and SQLite compares the column
+lexically, so a non-UTC offset would sort out of chronological order and return
+the wrong rows. The store now canonicalises the inputs (and rejects non-ISO).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vstash.store._common import _canonicalize_added_filter
+
+
+class TestCanonicalizeAddedFilter:
+    def test_date_only_becomes_utc_midnight(self) -> None:
+        assert _canonicalize_added_filter("2026-01-15", label="x") == "2026-01-15T00:00:00+00:00"
+
+    def test_naive_timestamp_treated_as_utc(self) -> None:
+        assert (
+            _canonicalize_added_filter("2026-01-15T08:30:00", label="x")
+            == "2026-01-15T08:30:00+00:00"
+        )
+
+    def test_non_utc_offset_converted_to_utc(self) -> None:
+        # 00:00 at -05:00 is 05:00 UTC; the raw string would have sorted
+        # lexically before the equivalent UTC instant (the #384 bug).
+        assert (
+            _canonicalize_added_filter("2026-01-15T00:00:00-05:00", label="x")
+            == "2026-01-15T05:00:00+00:00"
+        )
+
+    def test_already_utc_is_idempotent(self) -> None:
+        value = "2026-01-15T05:00:00+00:00"
+        assert _canonicalize_added_filter(value, label="x") == value
+
+    @pytest.mark.parametrize("bad", ["not-a-date", "", "2026-13-99", "30d"])
+    def test_invalid_raises_with_label(self, bad: str) -> None:
+        with pytest.raises(ValueError, match="added_after"):
+            _canonicalize_added_filter(bad, label="added_after")
+
+
+class TestSearchAcceptsDateFilters:
+    def test_search_with_non_utc_offset_does_not_crash(self, sample_store) -> None:
+        dim = sample_store.embedding_dim
+        sample_store.add_document(
+            path="/d.md", title="d", chunks=["alpha"], embeddings=[[0.5] * dim]
+        )
+        # Non-UTC offset must be accepted and canonicalised, not rejected.
+        results = sample_store.search(
+            [0.5] * dim, "alpha", top_k=5, added_after="2020-01-01T00:00:00-05:00"
+        )
+        assert isinstance(results, list)
+
+    def test_search_rejects_garbage_date(self, sample_store) -> None:
+        dim = sample_store.embedding_dim
+        with pytest.raises(ValueError):
+            sample_store.search([0.5] * dim, "alpha", top_k=5, added_after="not-a-date")

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -45,6 +45,7 @@ from ._common import (
     _LONG_QUERY_DISTANCE_CUTOFF,
     _PipelineTracer,
     _SQLITE_PARAM_BATCH,
+    _canonicalize_added_filter,
     _cosine_sim,
     _deserialize,
     _normalize_tags,
@@ -1219,7 +1220,7 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
         )
         if added_after:
             conditions.append("added_at >= ?")
-            filter_params.append(added_after)
+            filter_params.append(_canonicalize_added_filter(added_after, label="added_after"))
         where = ("WHERE " + " AND ".join(conditions)) if conditions else ""
         rows = self._conn.execute(
             f"""SELECT path, title, source_type, collection,

--- a/vstash/store/_common.py
+++ b/vstash/store/_common.py
@@ -259,3 +259,32 @@ _ADAPTIVE_RRF_LONG_QUERY = 50
 # compress distances; without this relaxation the default 1.3225 cutoff
 # rejects nearly every candidate past rank 0.
 _LONG_QUERY_DISTANCE_CUTOFF = 25.0
+
+
+def _canonicalize_added_filter(value: str, *, label: str) -> str:
+    """Validate + UTC-canonicalise an ISO date/timestamp ``added_at`` filter.
+
+    ``added_at`` is stored as a UTC ISO string (``...+00:00``, from
+    ``datetime.now(timezone.utc).isoformat()``) and SQLite compares the column
+    **lexically**. A non-UTC offset (e.g. ``2026-01-15T00:00:00-05:00``) sorts
+    lexically out of chronological order versus the stored ``+00:00`` form, so a
+    raw `added_after` / `added_before` would return the wrong rows around
+    timezone boundaries (#384). Naive inputs are treated as UTC; aware inputs are
+    converted with ``astimezone``. Non-ISO input is rejected with a clear
+    ``ValueError`` rather than passed through to a lexical comparison that would
+    silently match the wrong rows. Mirrors the prune/compact ``before=`` handling.
+    """
+    from datetime import datetime, timezone
+
+    try:
+        parsed = datetime.fromisoformat(value.strip())
+    except (ValueError, AttributeError) as exc:
+        raise ValueError(
+            f"{label}={value!r} is not a parseable ISO date / timestamp "
+            f"('2026-01-15' or '2026-01-15T00:00:00+00:00')."
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.isoformat()

--- a/vstash/store/_common.py
+++ b/vstash/store/_common.py
@@ -277,7 +277,13 @@ def _canonicalize_added_filter(value: str, *, label: str) -> str:
     from datetime import datetime, timezone
 
     try:
-        parsed = datetime.fromisoformat(value.strip())
+        stripped = value.strip()
+        # Python 3.10's datetime.fromisoformat rejects the ``Z`` / ``z`` UTC
+        # suffix (only 3.11+ accepts it); normalise it so the project's 3.10
+        # floor parses the common ``...Z`` form. Mirrors journal.py's handling.
+        if stripped.endswith(("Z", "z")):
+            stripped = stripped[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(stripped)
     except (ValueError, AttributeError) as exc:
         raise ValueError(
             f"{label}={value!r} is not a parseable ISO date / timestamp "

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -32,6 +32,7 @@ from ._common import (
     _LONG_QUERY_DISTANCE_CUTOFF,
     _PipelineTracer,
     _SQLITE_PARAM_BATCH,
+    _canonicalize_added_filter,
     _cosine_sim,
     _deserialize,
     _normalize_tags,
@@ -1715,10 +1716,10 @@ class _SearchEngineMixin:
             params.extend(f"%,{t},%" for t in tag_list)
         if added_after:
             conditions.append(f"{prefix}added_at >= ?")
-            params.append(added_after)
+            params.append(_canonicalize_added_filter(added_after, label="added_after"))
         if added_before:
             conditions.append(f"{prefix}added_at < ?")
-            params.append(added_before)
+            params.append(_canonicalize_added_filter(added_before, label="added_before"))
         return conditions, params
 
     @staticmethod


### PR DESCRIPTION
Closes #384.

## Problem
`added_at` is stored as UTC ISO (`...+00:00`) and SQLite compares the column **lexically**. A non-UTC-offset `added_after`/`added_before` (e.g. `...-05:00`) sorts out of chronological order versus the stored `+00:00` form, returning the wrong rows around timezone boundaries; non-ISO input was passed straight into the lexical comparison and silently matched the wrong rows. Same class as the v0.37 prune/compact UTC fix; the read-side filters never got it.

## Fix
New `_canonicalize_added_filter()` in `store/_common.py` — validates via `datetime.fromisoformat`, treats naive inputs as UTC, converts aware inputs with `astimezone`, and rejects non-ISO with a clear `ValueError`. Applied where the filters become SQL params: `_get_filter_conditions` (search) and `list_documents`. Date-only / UTC inputs are unchanged (canonicalisation is idempotent).

## Tests
`tests/test_search_date_filters.py` — helper canonicalisation (date-only, naive, non-UTC offset, idempotent, invalid→raise) + search accepts a non-UTC offset and rejects a garbage date. `pytest tests/` green; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved date filter handling for `added_after` and `added_before` parameters in document search/listing.
  * Date inputs are now properly normalized to UTC and validated correctly.
  * Added support for non-UTC timezone dates with automatic conversion to UTC.

* **Tests**
  * Added comprehensive tests for date filter validation and canonicalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->