### PR TITLE
fix: integrity_repair keeps snapvec index in sync when deleting orphans (#381)

### DIFF
--- a/tests/test_integrity_repair_snapvec.py
+++ b/tests/test_integrity_repair_snapvec.py
@@ -1,0 +1,51 @@
+"""#381: ``integrity_repair`` keeps the in-memory snapvec index in sync when it
+deletes orphan chunks, so the next ``snapvec_parity`` check still passes.
+
+Only exercises the opt-in snapvec backend (the default sqlite-vec path has no
+``self._snap``), so it is skipped when snapvec is not installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("snapvec", reason="snapvec not installed")
+
+from pathlib import Path
+
+from vstash.store import VstashStore
+
+DIM = 8
+
+
+def _snap_store(tmp_path: Path) -> VstashStore:
+    return VstashStore(
+        str(tmp_path / "snap.db"),
+        embedding_dim=DIM,
+        vector_backend="snapvec",
+        snapvec_bits=4,
+    )
+
+
+def test_repair_orphan_keeps_snapvec_parity(tmp_path: Path) -> None:
+    store = _snap_store(tmp_path)
+    try:
+        store.add_document(
+            path="/doc.md", title="doc", chunks=["alpha beta"], embeddings=[[0.5] * DIM]
+        )
+        # Orphan the chunk: delete its document row WITHOUT cascading, leaving the
+        # chunk in chunks + vec_chunks + the in-memory snapvec index.
+        store._conn.execute("PRAGMA foreign_keys=OFF")
+        store._conn.execute("DELETE FROM documents WHERE path = '/doc.md'")
+        store._conn.execute("PRAGMA foreign_keys=ON")
+        store._conn.commit()
+
+        repairs = {r.name: r for r in store.integrity_repair()}
+        assert repairs["no_orphan_chunks"].success
+
+        # The fix: the snap index was updated alongside the SQLite delete, so the
+        # parity invariant holds immediately after repair (it failed before #381).
+        checks = {c.name: c for c in store.integrity_check()}
+        assert checks["snapvec_parity"].passed, checks["snapvec_parity"].detail
+    finally:
+        store.close()

--- a/vstash/store/_integrity.py
+++ b/vstash/store/_integrity.py
@@ -24,6 +24,7 @@ class _IntegrityMixin:
     # Attributes supplied by the host class (``VstashStore.__init__``).
     _conn: sqlite3.Connection
     _snap: Any
+    _snap_dirty: bool
 
     def integrity_check(self) -> list[IntegrityCheck]:
         """Run a battery of database integrity checks.
@@ -271,6 +272,14 @@ class _IntegrityMixin:
                                 f"DELETE FROM chunks WHERE id IN ({placeholders})",
                                 batch,
                             )
+                        # Keep the in-memory snapvec index in sync with the
+                        # SQLite delete so the next snapvec_parity check passes
+                        # (#381). Mirrors delete_document's snap handling; the
+                        # flush is deferred to close() / _checkpoint_snapvec().
+                        if self._snap is not None:
+                            for cid in orphan_ids:
+                                self._snap.delete(cid)
+                            self._snap_dirty = True
                     repairs.append(
                         IntegrityRepair(
                             name="no_orphan_chunks",

--- a/vstash/store/_integrity.py
+++ b/vstash/store/_integrity.py
@@ -308,6 +308,12 @@ class _IntegrityMixin:
                 self._bump_cache_epoch()
             except Exception as exc:
                 self._conn.rollback()
+                # The orphan cleanup above may have mutated the in-memory snap
+                # index before the failing statement. The SQLite rollback restored
+                # those chunks, so reload the snap from disk to match — otherwise
+                # the in-memory index would be missing chunks SQLite still has
+                # (#381 review). No-op when self._snap is None / unmutated.
+                self._reload_snapvec()
                 repairs.append(
                     IntegrityRepair(
                         name="repair_transaction",


### PR DESCRIPTION
Closes #381.

## Problem
`integrity_repair`'s `no_orphan_chunks` path deletes orphan chunks from `chunks` + `vec_chunks` but **not** from the in-memory snapvec index (`self._snap`). On the opt-in snapvec / snapvec-ivfpq backend, the next `snapvec_parity` check then fails — repair leaves the store failing its own invariant. Surfaced by the gemini review of #380 (moved verbatim there; pre-existing).

## Fix
Mirror `delete_document`'s snap handling: delete the orphan ids from `self._snap` and set `_snap_dirty = True` (flush deferred to `close()` / `_checkpoint_snapvec()`, same as every other delete path). The parity check reads `len(self._snap)` in memory, so it passes immediately after repair. Default sqlite-vec path unaffected (`self._snap is None`).

## Tests
`tests/test_integrity_repair_snapvec.py` (skipped without snapvec): orphan a real indexed chunk, repair, assert `snapvec_parity` passes. **Verified it fails without this change** (`chunks=0, snapvec=1`). `pytest tests/` green; ruff clean.