### PR TITLE
ci: cache embedding model + retrying warm-up to kill the HF-download flake (#376)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,15 +41,18 @@ jobs:
           key: embed-model-${{ runner.os }}-bge-small-en-v1.5
       # Pre-download the model in an isolated, retrying step so a transient HF
       # hub failure retries here (and fails fast with a clear error) instead of
-      # cascading into ~60 minutes of test timeouts (#376).
+      # cascading into ~60 minutes of test timeouts (#376). On a cache hit this
+      # is instant; on a cache miss the retries absorb transient CDN blips.
       - name: Warm up embedding model (retry transient HF hub failures)
+        env:
+          HF_HUB_DOWNLOAD_TIMEOUT: "60"
         run: |
-          for attempt in 1 2 3; do
+          for attempt in 1 2 3 4 5; do
             python -c "from vstash.embed import warmup; warmup('BAAI/bge-small-en-v1.5')" && exit 0
-            echo "::warning::embedding model warm-up attempt $attempt failed; retrying in 15s"
-            sleep 15
+            echo "::warning::embedding model warm-up attempt $attempt failed; retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
           done
-          echo "::error::embedding model download failed after 3 attempts (HF hub flake)"
+          echo "::error::embedding model download failed after 5 attempts (HF hub flake)"
           exit 1
       - name: Run tests with coverage
         run: pytest --tb=short -q --cov=vstash --cov-report=xml --cov-report=term

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,28 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[all,dev]"
+      # Cache the embedding model so most runs skip the HuggingFace download
+      # entirely. The default BGE-small model lands in the HF hub cache (and
+      # fastembed's own cache, depending on version); cache both.
+      - name: Cache embedding model
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/huggingface
+            ~/.cache/fastembed
+          key: embed-model-${{ runner.os }}-bge-small-en-v1.5
+      # Pre-download the model in an isolated, retrying step so a transient HF
+      # hub failure retries here (and fails fast with a clear error) instead of
+      # cascading into ~60 minutes of test timeouts (#376).
+      - name: Warm up embedding model (retry transient HF hub failures)
+        run: |
+          for attempt in 1 2 3; do
+            python -c "from vstash.embed import warmup; warmup('BAAI/bge-small-en-v1.5')" && exit 0
+            echo "::warning::embedding model warm-up attempt $attempt failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::embedding model download failed after 3 attempts (HF hub flake)"
+          exit 1
       - name: Run tests with coverage
         run: pytest --tb=short -q --cov=vstash --cov-report=xml --cov-report=term
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Closes #376.

## Problem
The `test (3.x)` matrix downloads `BAAI/bge-small-en-v1.5` from the HuggingFace hub at test runtime. When the hub stalls on a runner the job hangs ~60 min then fails with `Could not load model ... from any source` — a cascade of failures (every embed test + `watch_e2e` timeouts), not a code problem. Hit this on several PRs this cycle (a different Python version each time).

## Fix
- **Cache** `~/.cache/huggingface` + `~/.cache/fastembed` (`actions/cache@v4`) so most runs skip the download entirely.
- **Isolated, retrying warm-up** step (`vstash.embed.warmup`, 3 attempts with backoff) before pytest, so a transient hub failure retries here and **fails fast with a clear `::error::`** instead of cascading into ~60 min of test timeouts.

Validated: YAML parses; `warmup('BAAI/bge-small-en-v1.5')` works locally. The behaviour change is CI-only (no package code touched).