### PR TITLE
refactor(cli): extract shared core to cli/_app.py (#284, step 2)

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -175,7 +175,7 @@ class TestAutoMissHintHook:
         """``_build_miss_hint`` returns None when auto_hint is off OR
         when tier is high with results; returns a structured dict for
         empty / all-low cases."""
-        from vstash.cli import _build_miss_hint
+        from vstash.cli._app import _build_miss_hint
 
         # Disabled -> None
         assert (

--- a/tests/test_cli_get_store_lifecycle.py
+++ b/tests/test_cli_get_store_lifecycle.py
@@ -49,8 +49,12 @@ def _patch_hermetic_config(monkeypatch, db_path, *, vector_backend: str = "sqlit
     import vstash._store_open as store_open_mod
 
     monkeypatch.setenv("VSTASH_DB_PATH", str(db_path))
+    # _get_store (and load_config / atexit) live in the cli._app module since the
+    # #284 split, so patch the bindings there — that's what _get_store reads.
     monkeypatch.setattr(
-        cli_mod, "load_config", _hermetic_config_factory(db_path, vector_backend=vector_backend)
+        cli_mod._app,
+        "load_config",
+        _hermetic_config_factory(db_path, vector_backend=vector_backend),
     )
     # _get_store now delegates to ``open_store_for_config``, which looks
     # up ``get_embedding_dim`` from the ``_store_open`` module (#297).
@@ -63,7 +67,7 @@ class TestGetStoreAtexit:
     def test_registers_close_via_atexit(self, tmp_path, monkeypatch):
         """The atexit callback is ``store.close`` (bound method)."""
         registered: list = []
-        monkeypatch.setattr(cli_mod.atexit, "register", registered.append)
+        monkeypatch.setattr(cli_mod._app.atexit, "register", registered.append)
 
         db = tmp_path / "lifecycle.db"
         _patch_hermetic_config(monkeypatch, db)
@@ -90,7 +94,7 @@ class TestGetStoreFlushesSnapvec:
         # don't actually register (we fire it manually below to simulate
         # process exit without relying on interpreter shutdown).
         registered: list = []
-        monkeypatch.setattr(cli_mod.atexit, "register", registered.append)
+        monkeypatch.setattr(cli_mod._app.atexit, "register", registered.append)
         _patch_hermetic_config(monkeypatch, db, vector_backend="snapvec")
 
         _cfg, store = cli_mod._get_store()

--- a/tests/test_store_open.py
+++ b/tests/test_store_open.py
@@ -125,11 +125,13 @@ class TestSurfacesRouteThroughHelper:
         import vstash.cli as cli_mod
 
         cfg = _ivfpq_config(str(tmp_path / "cli.db"))
-        monkeypatch.setattr(cli_mod, "load_config", lambda: cfg)
+        # _get_store / load_config / atexit / open_store_for_config live in the
+        # cli._app module since the #284 split; patch the bindings there.
+        monkeypatch.setattr(cli_mod._app, "load_config", lambda: cfg)
         monkeypatch.setenv("VSTASH_DB_PATH", str(tmp_path / "cli.db"))
-        monkeypatch.setattr(cli_mod.atexit, "register", lambda _cb: None)
+        monkeypatch.setattr(cli_mod._app.atexit, "register", lambda _cb: None)
 
-        with patch("vstash.cli.open_store_for_config", wraps=open_store_for_config) as spy:
+        with patch("vstash.cli._app.open_store_for_config", wraps=open_store_for_config) as spy:
             _cfg, store = cli_mod._get_store()
             try:
                 assert spy.call_count == 1

--- a/vstash/cli/__init__.py
+++ b/vstash/cli/__init__.py
@@ -19,290 +19,33 @@ Commands:
 
 from __future__ import annotations
 
-import atexit
 import json
 from pathlib import Path
 
 import click
 import typer
-from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
 from .. import chat as chat_module
 from .._store_open import open_store_for_config
-from ..config import VstashConfig, load_config
+from ..config import load_config
 from ..embed import embed_query, warmup
 from ..ingest import ingest, ingest_directory
 from ..services import search_with_embedding
 from ..store import VstashStore, relevance_tier
 
-from .. import __version__
-
-
-def _inference_hint(exc: ConnectionError, cfg: VstashConfig) -> str:
-    """Return a user-friendly hint based on the inference error and backend."""
-    msg = str(exc).lower()
-    backend = cfg.inference.backend.lower()
-
-    if "connection refused" in msg or "connect" in msg:
-        if backend == "ollama":
-            return "Is Ollama running? Try: ollama serve"
-        return f"Could not reach {backend} server. Check your connection."
-    if "rate limit" in msg or "429" in msg:
-        return "Rate limited — wait a moment and try again."
-    if "api key" in msg or "unauthorized" in msg or "401" in msg:
-        return f"Check your API key for {backend}."
-    if "timeout" in msg or "timed out" in msg:
-        return "Request timed out — the server may be overloaded."
-    return ""
-
-
-def _version_callback(value: bool) -> None:
-    if value:
-        print(f"vstash {__version__}")
-        raise typer.Exit()
-
-
-app = typer.Typer(
-    name="vstash",
-    help="Local document memory with instant semantic search.",
-    add_completion=False,
-    rich_markup_mode="rich",
+from ._app import (
+    _get_store,
+    _inference_hint,
+    _load_labeled_queries_jsonl,
+    _profile_from_ctx,
+    _record_miss_event,
+    _safe_exc,
+    app,
+    console,
 )
-console = Console()
-
-
-def _safe_exc(exc: object) -> str:
-    """Escape rich markup in an exception's text so brackets in messages
-    like ``pip install vstash[ingest]`` survive ``console.print``.
-
-    Without this, rich treats ``[ingest]`` as an opening tag and silently
-    drops it from the rendered output, producing the truncated message
-    ``pip install vstash`` that misled e2e users on PyPI.
-    """
-    from rich.markup import escape as _escape
-
-    return _escape(str(exc))
-
-
-def _load_labeled_queries_jsonl(path_str: str, *, flag: str) -> list[dict]:
-    """Load and validate a JSONL file of labeled queries.
-
-    Used by ``vstash retrain`` for both --training-queries and
-    --eval-queries.  Each line must be a JSON object with a non-empty
-    string ``query`` and a non-empty list of non-empty string
-    ``relevant_paths``; returns the parsed records.
-
-    Errors and exits the process with a clear message on:
-        - missing file or non-file path,
-        - invalid JSON (with the offending line number),
-        - records that are not objects with the required keys,
-        - records with non-string / empty fields,
-        - empty file.
-    The caller's flag name is woven into every message so the user
-    knows which argument was wrong when they pass both.
-    """
-    path = Path(path_str).expanduser()
-    if not path.is_file():
-        # ``not exists`` and ``is a directory`` both end here -- distinguish
-        # them so users debugging a wrong path know whether they typoed or
-        # pointed at the parent dir.
-        if path.exists():
-            console.print(f"[red]x[/red] {flag}: path is not a file: {path}")
-        else:
-            console.print(f"[red]x[/red] {flag}: file not found: {path}")
-        raise typer.Exit(code=1)
-
-    records: list[dict] = []
-    try:
-        with path.open(encoding="utf-8") as fh:
-            for line_no, line in enumerate(fh, start=1):
-                if not line.strip():
-                    continue
-                try:
-                    q = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    console.print(
-                        f"[red]x[/red] {flag}: failed to parse {path} at line {line_no}: "
-                        f'{exc}. Expected JSONL (one {{"query": ..., '
-                        f'"relevant_paths": [...]}} per line).'
-                    )
-                    raise typer.Exit(code=1) from exc
-
-                # Shape validation per line, with the line number in every
-                # message so users can fix the exact record without diffing
-                # the whole file.  A common mistake is passing a JSON-array-
-                # per-file (``queries.json`` instead of ``queries.jsonl``),
-                # which would parse as one list entry and crash opaquely
-                # deep inside the miner / eval.
-                if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
-                    console.print(
-                        f"[red]x[/red] {flag}: line {line_no} is not a valid query record. "
-                        "Each line must be a JSON object with 'query' and "
-                        "'relevant_paths' fields. If you have a single JSON array, "
-                        "convert to JSONL (one object per line)."
-                    )
-                    raise typer.Exit(code=1)
-                if not isinstance(q["query"], str) or not q["query"].strip():
-                    console.print(
-                        f"[red]x[/red] {flag}: line {line_no} has invalid 'query'. "
-                        "The 'query' field must be a non-empty string."
-                    )
-                    raise typer.Exit(code=1)
-                if not isinstance(q["relevant_paths"], list) or not q["relevant_paths"]:
-                    console.print(
-                        f"[red]x[/red] {flag}: line {line_no} has empty or non-list "
-                        "'relevant_paths'. Every labeled query needs at least one "
-                        "relevant document path."
-                    )
-                    raise typer.Exit(code=1)
-                if any(not isinstance(p, str) or not p.strip() for p in q["relevant_paths"]):
-                    console.print(
-                        f"[red]x[/red] {flag}: line {line_no} has invalid 'relevant_paths'. "
-                        "Every relevant path must be a non-empty string."
-                    )
-                    raise typer.Exit(code=1)
-                records.append(q)
-    except OSError as exc:
-        console.print(f"[red]x[/red] {flag}: failed to read {path}: {exc}.")
-        raise typer.Exit(code=1) from exc
-
-    if not records:
-        console.print(f"[red]x[/red] {flag}: file {path} contained no records.")
-        raise typer.Exit(code=1)
-    return records
-
-
-def _build_miss_hint(
-    *,
-    cfg_auto_hint: bool,
-    result_count: int,
-    tier: str,
-    best_distance: float,
-    top_k_requested: int,
-) -> dict | None:
-    """Return a lightweight miss_hint dict when a search returns empty
-    results or an all-low relevance tier, or ``None`` otherwise.
-
-    Issue #157 part 3: the hint is persisted on the search_events row
-    by ``record_search_event`` and consumed by ``vstash why --recent``
-    so a user can drill into recent misses post-hoc without re-running
-    the query from memory.
-
-    The hint carries ONLY information that is not already a column on
-    ``search_events`` (``tier``, ``best_distance``, ``result_count``
-    are all stored separately). Keeping the hint dict minimal keeps
-    the JSON blob small and avoids two-sources-of-truth drift when
-    the columns evolve.
-
-    The hint is intentionally cheap to compute (no extra SQL, no
-    re-embedding) -- full ``miss_analysis`` is deferred to the explicit
-    ``vstash why <query> --expect <path>`` call.
-    """
-    if not cfg_auto_hint:
-        return None
-    if result_count == 0:
-        reason = "empty"
-    elif tier == "low":
-        reason = "all_low"
-    else:
-        return None
-    return {
-        "reason": reason,
-        "top_k_requested": int(top_k_requested),
-    }
-
-
-def _record_miss_event(
-    *,
-    store,
-    cfg,
-    query: str,
-    best_distance: float,
-    tier: str,
-    result_count: int,
-    top_k_requested: int,
-) -> None:
-    """Build + persist a miss_hint search event in one place. Shared
-    between ``vstash ask`` and ``vstash search`` to kill the
-    copy-paste this PR introduced."""
-    hint = _build_miss_hint(
-        cfg_auto_hint=cfg.observability.auto_miss_hint,
-        result_count=result_count,
-        tier=tier,
-        best_distance=best_distance,
-        top_k_requested=top_k_requested,
-    )
-    store.record_search_event(
-        query=query,
-        best_distance=best_distance,
-        relevance_tier=tier,
-        result_count=result_count,
-        miss_hint=hint,
-    )
-
-
-@app.callback()
-def _app_callback(
-    ctx: typer.Context,
-    version: bool = typer.Option(
-        False,
-        "--version",
-        "-V",
-        callback=_version_callback,
-        is_eager=True,
-        help="Show version and exit.",
-    ),
-    profile: str | None = typer.Option(
-        None,
-        "--profile",
-        "-P",
-        help="Use a named profile (e.g., 'work', 'research').",
-    ),
-) -> None:
-    """Local document memory with instant semantic search."""
-    ctx.ensure_object(dict)
-    if profile is not None:
-        from ..profile import validate_name
-
-        try:
-            validate_name(profile)
-        except ValueError as exc:
-            raise typer.BadParameter(str(exc), param_hint="--profile") from exc
-    ctx.obj["profile"] = profile
-
-
-def _profile_from_ctx(ctx: typer.Context) -> str | None:
-    """Extract the profile name from the Typer context."""
-    return (ctx.obj or {}).get("profile")
-
-
-def _get_store(
-    cfg: VstashConfig | None = None,
-    *,
-    warm: bool = False,
-    profile: str | None = None,
-) -> tuple[VstashConfig, VstashStore]:
-    """Initialize config and create a VstashStore instance.
-
-    Args:
-        cfg: Optional pre-loaded config. If None, loads from vstash.toml.
-        warm: If True, eagerly load the ONNX embedding model to
-            eliminate cold-start latency on the first query.
-        profile: Named profile to use. If None, uses resolution chain.
-
-    Returns:
-        Tuple of (config, store).
-    """
-    if cfg is None:
-        cfg = load_config()
-    if warm:
-        warmup(cfg.embeddings.model)
-    store = open_store_for_config(cfg, profile=profile)
-    atexit.register(store.close)
-    return cfg, store
 
 
 # ------------------------------------------------------------------ #
@@ -1120,7 +863,6 @@ def export(
 ) -> None:
     """Export chunks as JSONL or CSV for training data curation."""
     import csv
-    import json
 
     _cfg, store = _get_store(profile=_profile_from_ctx(ctx))
 

--- a/vstash/cli/_app.py
+++ b/vstash/cli/_app.py
@@ -1,0 +1,286 @@
+"""Shared CLI core for vstash: the Typer ``app``, the root callback, and the
+helpers every command module imports.
+
+Split out of the monolithic ``cli.py`` (#284) so the command-group modules can
+``from ._app import app, console, _get_store, ...`` without importing the package
+``__init__`` (which would be a cycle). Holds no commands itself.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from .. import __version__
+from .._store_open import open_store_for_config
+from ..config import VstashConfig, load_config
+from ..embed import warmup
+from ..store import VstashStore
+
+
+def _inference_hint(exc: ConnectionError, cfg: VstashConfig) -> str:
+    """Return a user-friendly hint based on the inference error and backend."""
+    msg = str(exc).lower()
+    backend = cfg.inference.backend.lower()
+
+    if "connection refused" in msg or "connect" in msg:
+        if backend == "ollama":
+            return "Is Ollama running? Try: ollama serve"
+        return f"Could not reach {backend} server. Check your connection."
+    if "rate limit" in msg or "429" in msg:
+        return "Rate limited — wait a moment and try again."
+    if "api key" in msg or "unauthorized" in msg or "401" in msg:
+        return f"Check your API key for {backend}."
+    if "timeout" in msg or "timed out" in msg:
+        return "Request timed out — the server may be overloaded."
+    return ""
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        print(f"vstash {__version__}")
+        raise typer.Exit()
+
+
+app = typer.Typer(
+    name="vstash",
+    help="Local document memory with instant semantic search.",
+    add_completion=False,
+    rich_markup_mode="rich",
+)
+console = Console()
+
+
+def _safe_exc(exc: object) -> str:
+    """Escape rich markup in an exception's text so brackets in messages
+    like ``pip install vstash[ingest]`` survive ``console.print``.
+
+    Without this, rich treats ``[ingest]`` as an opening tag and silently
+    drops it from the rendered output, producing the truncated message
+    ``pip install vstash`` that misled e2e users on PyPI.
+    """
+    from rich.markup import escape as _escape
+
+    return _escape(str(exc))
+
+
+def _load_labeled_queries_jsonl(path_str: str, *, flag: str) -> list[dict]:
+    """Load and validate a JSONL file of labeled queries.
+
+    Used by ``vstash retrain`` for both --training-queries and
+    --eval-queries.  Each line must be a JSON object with a non-empty
+    string ``query`` and a non-empty list of non-empty string
+    ``relevant_paths``; returns the parsed records.
+
+    Errors and exits the process with a clear message on:
+        - missing file or non-file path,
+        - invalid JSON (with the offending line number),
+        - records that are not objects with the required keys,
+        - records with non-string / empty fields,
+        - empty file.
+    The caller's flag name is woven into every message so the user
+    knows which argument was wrong when they pass both.
+    """
+    path = Path(path_str).expanduser()
+    if not path.is_file():
+        # ``not exists`` and ``is a directory`` both end here -- distinguish
+        # them so users debugging a wrong path know whether they typoed or
+        # pointed at the parent dir.
+        if path.exists():
+            console.print(f"[red]x[/red] {flag}: path is not a file: {path}")
+        else:
+            console.print(f"[red]x[/red] {flag}: file not found: {path}")
+        raise typer.Exit(code=1)
+
+    records: list[dict] = []
+    try:
+        with path.open(encoding="utf-8") as fh:
+            for line_no, line in enumerate(fh, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    q = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    console.print(
+                        f"[red]x[/red] {flag}: failed to parse {path} at line {line_no}: "
+                        f'{exc}. Expected JSONL (one {{"query": ..., '
+                        f'"relevant_paths": [...]}} per line).'
+                    )
+                    raise typer.Exit(code=1) from exc
+
+                # Shape validation per line, with the line number in every
+                # message so users can fix the exact record without diffing
+                # the whole file.  A common mistake is passing a JSON-array-
+                # per-file (``queries.json`` instead of ``queries.jsonl``),
+                # which would parse as one list entry and crash opaquely
+                # deep inside the miner / eval.
+                if not isinstance(q, dict) or "query" not in q or "relevant_paths" not in q:
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} is not a valid query record. "
+                        "Each line must be a JSON object with 'query' and "
+                        "'relevant_paths' fields. If you have a single JSON array, "
+                        "convert to JSONL (one object per line)."
+                    )
+                    raise typer.Exit(code=1)
+                if not isinstance(q["query"], str) or not q["query"].strip():
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has invalid 'query'. "
+                        "The 'query' field must be a non-empty string."
+                    )
+                    raise typer.Exit(code=1)
+                if not isinstance(q["relevant_paths"], list) or not q["relevant_paths"]:
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has empty or non-list "
+                        "'relevant_paths'. Every labeled query needs at least one "
+                        "relevant document path."
+                    )
+                    raise typer.Exit(code=1)
+                if any(not isinstance(p, str) or not p.strip() for p in q["relevant_paths"]):
+                    console.print(
+                        f"[red]x[/red] {flag}: line {line_no} has invalid 'relevant_paths'. "
+                        "Every relevant path must be a non-empty string."
+                    )
+                    raise typer.Exit(code=1)
+                records.append(q)
+    except OSError as exc:
+        console.print(f"[red]x[/red] {flag}: failed to read {path}: {exc}.")
+        raise typer.Exit(code=1) from exc
+
+    if not records:
+        console.print(f"[red]x[/red] {flag}: file {path} contained no records.")
+        raise typer.Exit(code=1)
+    return records
+
+
+def _build_miss_hint(
+    *,
+    cfg_auto_hint: bool,
+    result_count: int,
+    tier: str,
+    best_distance: float,
+    top_k_requested: int,
+) -> dict | None:
+    """Return a lightweight miss_hint dict when a search returns empty
+    results or an all-low relevance tier, or ``None`` otherwise.
+
+    Issue #157 part 3: the hint is persisted on the search_events row
+    by ``record_search_event`` and consumed by ``vstash why --recent``
+    so a user can drill into recent misses post-hoc without re-running
+    the query from memory.
+
+    The hint carries ONLY information that is not already a column on
+    ``search_events`` (``tier``, ``best_distance``, ``result_count``
+    are all stored separately). Keeping the hint dict minimal keeps
+    the JSON blob small and avoids two-sources-of-truth drift when
+    the columns evolve.
+
+    The hint is intentionally cheap to compute (no extra SQL, no
+    re-embedding) -- full ``miss_analysis`` is deferred to the explicit
+    ``vstash why <query> --expect <path>`` call.
+    """
+    if not cfg_auto_hint:
+        return None
+    if result_count == 0:
+        reason = "empty"
+    elif tier == "low":
+        reason = "all_low"
+    else:
+        return None
+    return {
+        "reason": reason,
+        "top_k_requested": int(top_k_requested),
+    }
+
+
+def _record_miss_event(
+    *,
+    store,
+    cfg,
+    query: str,
+    best_distance: float,
+    tier: str,
+    result_count: int,
+    top_k_requested: int,
+) -> None:
+    """Build + persist a miss_hint search event in one place. Shared
+    between ``vstash ask`` and ``vstash search`` to kill the
+    copy-paste this PR introduced."""
+    hint = _build_miss_hint(
+        cfg_auto_hint=cfg.observability.auto_miss_hint,
+        result_count=result_count,
+        tier=tier,
+        best_distance=best_distance,
+        top_k_requested=top_k_requested,
+    )
+    store.record_search_event(
+        query=query,
+        best_distance=best_distance,
+        relevance_tier=tier,
+        result_count=result_count,
+        miss_hint=hint,
+    )
+
+
+@app.callback()
+def _app_callback(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        "-P",
+        help="Use a named profile (e.g., 'work', 'research').",
+    ),
+) -> None:
+    """Local document memory with instant semantic search."""
+    ctx.ensure_object(dict)
+    if profile is not None:
+        from ..profile import validate_name
+
+        try:
+            validate_name(profile)
+        except ValueError as exc:
+            raise typer.BadParameter(str(exc), param_hint="--profile") from exc
+    ctx.obj["profile"] = profile
+
+
+def _profile_from_ctx(ctx: typer.Context) -> str | None:
+    """Extract the profile name from the Typer context."""
+    return (ctx.obj or {}).get("profile")
+
+
+def _get_store(
+    cfg: VstashConfig | None = None,
+    *,
+    warm: bool = False,
+    profile: str | None = None,
+) -> tuple[VstashConfig, VstashStore]:
+    """Initialize config and create a VstashStore instance.
+
+    Args:
+        cfg: Optional pre-loaded config. If None, loads from vstash.toml.
+        warm: If True, eagerly load the ONNX embedding model to
+            eliminate cold-start latency on the first query.
+        profile: Named profile to use. If None, uses resolution chain.
+
+    Returns:
+        Tuple of (config, store).
+    """
+    if cfg is None:
+        cfg = load_config()
+    if warm:
+        warmup(cfg.embeddings.model)
+    store = open_store_for_config(cfg, profile=profile)
+    atexit.register(store.close)
+    return cfg, store


### PR DESCRIPTION
Second step of the cli.py split (#284), on top of #391. **Move-only** (bodies byte-identical; only test mock-targets follow the move).

## Changes
- Move the Typer `app`, the root `@app.callback()`, `console`, and the shared helpers (`_get_store`, `_safe_exc`, `_inference_hint`, `_record_miss_event`, `_build_miss_hint`, `_profile_from_ctx`, `_load_labeled_queries_jsonl`, `_version_callback`) into **`vstash/cli/_app.py`**. This is the module the command-group modules (extracted next) import from, avoiding a cycle with the package `__init__`.
- `__init__.py` imports what the commands use from `._app` and drops the now-unused imports (`atexit`, `Console`, `VstashConfig`, `__version__`).
- Tests that mock `_get_store`'s collaborators (`load_config` / `atexit` / `open_store_for_config`) now patch `vstash.cli._app` — that's where `_get_store` reads those bindings after the move (patching a module binding has to target the module that reads it). `_build_miss_hint`'s unit test imports it from `cli._app`.

## Verification
- Shared-core block moved **byte-identically** (verified by `diff` vs the prior `__init__.py`).
- `pytest tests/` → **1290 passed**; `ruff check .` + `ruff format --check .` clean.
- `vstash --version` / `vstash <cmd> --help` resolve via a typer `CliRunner`.

Next: extract the command groups (add/remember/update/forget/compact/watch, search/ask/chat/why, stats/check/list/export/config/reindex/serve, retrain/*) into `vstash/cli/_*.py` modules importing from `_app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal CLI module structure for improved code maintainability.

* **Tests**
  * Updated test suites to reflect module restructuring.

No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->