### PR TITLE
⚡ Bolt: Lazy L2 norm computation and early single-doc exits in MMR

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-06-05 - Lazy L2 Norms in MMR Dedup
+**Learning:** Eagerly evaluating mathematical computations like `math.hypot` for all items upfront in O(N) operations is wasteful if greedy algorithms (like MMR selection) terminate early or avoid comparisons.
+**Action:** Always prefer lazy evaluation of metrics (like L2 norm caching) alongside fast-path exits (like bypassing single-document sibling loops entirely) to avoid redundant computation on unvisited nodes in ranking loops.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1589,8 +1589,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily compute L2 norms for cosine similarity to avoid O(N) math.hypot calls
+        # for chunks that are never compared.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1645,13 +1646,26 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+            doc_indices = doc_to_indices[new_doc_key]
+
+            # Fast path: if this is the only chunk from this doc, no siblings to penalize
+            if len(doc_indices) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
+
             if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+                if chunk_norms[best_idx] is None:
+                    chunk_norms[best_idx] = math.hypot(*new_emb)
+                new_norm = chunk_norms[best_idx]
+
+                for idx in doc_indices:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
+                            if chunk_norms[idx] is None:
+                                chunk_norms[idx] = math.hypot(*idx_emb)
+
                             sim = _cosine_sim(
                                 idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
                             )


### PR DESCRIPTION
💡 What: 
- Delays L2 norm computation via `math.hypot` inside `_mmr_dedup` until a chunk is actually selected and compared.
- Exits early from the similarity loop for documents that have no other competing chunks in the candidates list (`len(doc_indices) <= 1`).

🎯 Why: 
Eagerly calculating `math.hypot` for all chunks before entering the MMR dedup loop results in O(N) wasteful mathematical operations, especially because the algorithm only computes similarity penalties for chunks from the same document. Single-chunk documents previously also iterated over empty lists redundantly. Lazy evaluation prevents evaluating chunks that are never compared.

📊 Impact: 
Reduces pure-python mathematical overhead and redundant list iteration in ranking loops.

🔬 Measurement: 
Run the test suite `pytest tests/test_store.py -k mmr` to verify the order and selection logic of MMR deduplication remain strictly identical with the lazy evaluations in place.

---
*PR created automatically by Jules for task [17577649913193009278](https://jules.google.com/task/17577649913193009278) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized deduplication processing through refined computation strategies and improved execution shortcuts.

* **Documentation**
  * Added technical notes documenting optimization approaches for norm computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->