### PR TITLE
perf(search): added_at index + drop per-query numpy alloc in cache key

### DIFF
--- a/tests/test_hotpath_optims.py
+++ b/tests/test_hotpath_optims.py
@@ -1,0 +1,65 @@
+"""Tests for the search/store hot-path optimizations (PR: perf/search-hotpath).
+
+- added_at index: the dominant ORDER BY / range column now has an index.
+- cache key: the query cache key hashes the embedding as a tuple (no numpy
+  alloc per search) and must still produce stable hits for identical queries.
+"""
+
+from __future__ import annotations
+
+from vstash.config import CacheConfig
+from vstash.store import VstashStore
+
+
+def test_added_at_index_exists(sample_store: VstashStore) -> None:
+    """idx_documents_added_at must be created (idempotently) on store open."""
+    rows = sample_store._conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_documents_added_at'"
+    ).fetchall()
+    assert rows, "idx_documents_added_at should be created on store open"
+
+
+def test_cache_key_is_stable_for_identical_queries(populated_store: VstashStore) -> None:
+    """The tuple-based cache key is deterministic: identical query params yield
+    the same key (so the LRU cache still hits)."""
+    args = dict(
+        query_text="python",
+        top_k=5,
+        vec_weight=None,
+        fts_weight=None,
+        distance_cutoff=1.3225,
+        collection=None,
+        project=None,
+        layer=None,
+        adaptive_rrf=True,
+        recency_boost=0.0,
+        added_after=None,
+        added_before=None,
+        tags=None,
+        mmr_lambda=0.5,
+        retrieval_mode="hybrid",
+        cache_epoch=0,
+    )
+    emb = [0.1, 0.2, 0.3, 0.4]
+    k1 = populated_store._compute_search_cache_key(query_embedding=emb, **args)
+    k2 = populated_store._compute_search_cache_key(query_embedding=list(emb), **args)
+    assert k1 == k2, "identical query params (incl. embedding) must produce the same cache key"
+    # A different embedding must produce a different key.
+    k3 = populated_store._compute_search_cache_key(query_embedding=[0.9, 0.8, 0.7, 0.6], **args)
+    assert k3 != k1
+
+
+def test_cache_hits_on_repeated_search(tmp_db_path: str) -> None:
+    """End-to-end: a repeated identical search hits the query cache (exercises
+    the new key on the real search path)."""
+    store = VstashStore(tmp_db_path, embedding_dim=4, cache=CacheConfig(query_cache_size=16))
+    try:
+        store.add_document(
+            path="/a.md", title="A", chunks=["alpha beta"], embeddings=[[0.1, 0.2, 0.3, 0.4]]
+        )
+        q = [0.1, 0.2, 0.3, 0.4]
+        r1 = store.search(query_embedding=q, query_text="alpha", top_k=3)
+        r2 = store.search(query_embedding=list(q), query_text="alpha", top_k=3)
+        assert [r.chunk_id for r in r1] == [r.chunk_id for r in r2]
+    finally:
+        store.close()

--- a/vstash/store/_schema.py
+++ b/vstash/store/_schema.py
@@ -78,6 +78,12 @@ class _SchemaManagerMixin:
 
             CREATE INDEX IF NOT EXISTS idx_chunks_doc ON chunks(doc_id);
             CREATE INDEX IF NOT EXISTS idx_documents_path ON documents(path);
+            -- added_at is the dominant ORDER BY / range-filter column
+            -- (list_documents, find_document, export_chunks, prune_documents,
+            -- get_*_added_at). Without this index every such query does a
+            -- filesort. Created here (idempotent) so existing DBs pick it up on
+            -- next open.
+            CREATE INDEX IF NOT EXISTS idx_documents_added_at ON documents(added_at);
 
             -- Search statistics for adaptive relevance threshold
             CREATE TABLE IF NOT EXISTS search_stats (

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -80,10 +80,13 @@ class _SearchEngineMixin:
         the same text. ``tags`` is normalized to a tuple so the same
         filter expressed as ``"a,b"`` and ``["a", "b"]`` shares a key.
         """
-        emb_bytes = np.array(query_embedding, dtype=np.float32).tobytes()
+        # Hash the embedding as a float tuple rather than allocating a numpy
+        # array + bytes blob on every search. embed_query is deterministic, so
+        # the same query yields the same list and thus the same key; query_text
+        # is also in the key, so distinct queries never collide.
         return hash(
             (
-                emb_bytes,
+                tuple(query_embedding),
                 query_text,
                 top_k,
                 vec_weight,


### PR DESCRIPTION
Second improvement PR. Two **ranking-neutral** hot-path wins, plus an honest note on three audit suggestions I deliberately **didn't** take.

## Changes
- **Index `documents.added_at`** ([_schema.py:79](vstash/store/_schema.py#L79)). It's the dominant ORDER BY / range-filter column (`list_documents`, `find_document`, `export_chunks`, `prune_documents`, `get_*_added_at`) and had no index → filesort on every such query. Created idempotently on open, so existing DBs get it on next open. Real win on large stores.
- **Cache key: drop the per-query numpy allocation** ([_search.py:83](vstash/store/_search.py#L83)). `_compute_search_cache_key` built `np.array(emb).tobytes()` on every cacheable search; now hashes the embedding as a float tuple. Deterministic + `query_text` is in the key, so cache hits/identity are unchanged.

## Deferred (with reasons)
- **COUNT(\*) dedup** (the audit's #1): **unsafe**. Reusing `_idf_cache[1]` would read `total=0` on a non-empty store whenever the IDF cache took the graceful-degradation path (missing `fts5vocab`), shrinking `candidate_pool` and breaking search. Left as-is.
- **`_skip_validation` kwarg**: adds public API surface to save ~10 comparisons. Not worth it.
- **Split query once vs 3×**: nanosecond-scale; not worth touching the hot path.

## Verification
- `tests/test_hotpath_optims.py` (index presence, cache-key determinism, end-to-end cache hit).
- `pytest tests/` → **1298 passed**; `test_query_cache` confirms hit behaviour unchanged; ruff clean.