### PR TITLE
refactor: remove dead _save_snapvec no-op + deprecated ScoringConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ search_events (id, query, best_distance, relevance_tier, result_count, dismissed
 
 `vstash.toml` resolution order: `$VSTASH_CONFIG` -> `./vstash.toml` -> `~/.vstash/vstash.toml` -> defaults.
 
-Key sections: `[inference]`, `[cerebras]`, `[ollama]`, `[openai]`, `[embeddings]`, `[chunking]`, `[scoring]`, `[storage]`.
+Key sections: `[inference]`, `[cerebras]`, `[ollama]`, `[openai]`, `[embeddings]`, `[chunking]`, `[recency]`, `[storage]`.
 
 ## Common tasks
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,9 +217,9 @@ Use this when FTS5 stemming / lowercasing would eat a term you care about (code 
 
 ---
 
-## `[scoring]` (deprecated)
+## `[scoring]` (removed)
 
-The `[scoring]` section from v0.5–v0.17 is still parsed for backward compatibility — existing `vstash.toml` files won't error. However, all scoring parameters are ignored. The frequency+decay scoring pipeline was removed in v0.18.0 and replaced by the simpler `[recency]` boost in v0.19.0.
+The frequency+decay scoring pipeline was removed in v0.18.0 (replaced by the simpler `[recency]` boost in v0.19.0), and its config model was dropped entirely afterwards — all `[scoring]` parameters had been silently ignored since v0.18.0. A `[scoring]` section in an existing `vstash.toml` is now reported as an unknown section (warn-on-unknown), not an error, so old files still load. Use `mmr_lambda` per-call on `search()` for intra-document dedup tuning.
 
 ---
 

--- a/vstash/config.py
+++ b/vstash/config.py
@@ -208,50 +208,6 @@ class StorageConfig(BaseModel):
         return value
 
 
-class ScoringConfig(BaseModel):
-    """Frequency + decay memory scoring configuration.
-
-    When enabled, search results are re-ranked post-RRF using a formula
-    that combines semantic relevance with access frequency and temporal decay:
-
-        final_score = alpha * normalized_rrf + beta * log(1 + access_count * e^(-lambda * days_ago))
-    """
-
-    model_config = ConfigDict(frozen=True)
-
-    enabled: bool = Field(default=True, description="Enable frequency+decay re-ranking")
-    alpha: float = Field(
-        default=0.8, ge=0, le=1, description="Weight for semantic similarity (RRF)"
-    )
-    beta: float = Field(default=0.2, ge=0, le=1, description="Weight for access history")
-    decay_lambda: float = Field(default=0.05, gt=0, description="Decay rate (0.05=weeks, 0.1=days)")
-    over_fetch: int = Field(
-        default=50, gt=0, description="Candidates to retrieve before re-ranking"
-    )
-    track_access: bool = Field(
-        default=True,
-        description="Record access counts on search (enabled by default when scoring is on)",
-    )
-    mmr_lambda: float = Field(
-        default=0.5,
-        ge=0,
-        le=1,
-        description=(
-            "MMR diversity parameter for intra-document dedup. "
-            "1.0 = hard dedup (at most one chunk per document), "
-            "0.0 = maximum diversity (no relevance weight). "
-            "Default 0.5 balances relevance and diversity."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def _validate_weights(self) -> ScoringConfig:
-        if self.alpha + self.beta > 1.0:
-            msg = f"alpha ({self.alpha}) + beta ({self.beta}) must be <= 1.0"
-            raise ValueError(msg)
-        return self
-
-
 class RecencyConfig(BaseModel):
     """Temporal recency boost for agentic memory.
 
@@ -263,6 +219,11 @@ class RecencyConfig(BaseModel):
     Designed for agentic memory where recent context matters more than
     old context.  Off by default for pure retrieval; the SDK's
     ``Memory.search()`` can enable it per call.
+
+    NOTE: ``boost`` is documented as the default for ``recency_boost`` but is
+    not yet wired into the search path — only the per-call ``recency_boost``
+    argument is honored today. Wiring the config default end-to-end across the
+    adapters (a public-default change) is tracked separately.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -447,7 +408,6 @@ class VstashConfig(BaseModel):
     embeddings: EmbeddingsConfig = Field(default_factory=EmbeddingsConfig)
     chunking: ChunkingConfig = Field(default_factory=ChunkingConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
-    scoring: ScoringConfig = Field(default_factory=ScoringConfig)
     recency: RecencyConfig = Field(default_factory=RecencyConfig)
     observability: ObservabilityConfig = Field(default_factory=ObservabilityConfig)
     limits: LimitsConfig = Field(default_factory=LimitsConfig)

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -412,9 +412,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                     self._deferred_fts_rows.extend(fts_data)
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
-                # Persist snapvec AFTER successful SQLite commit
-                if self._snap_dirty:
-                    self._save_snapvec()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()
@@ -566,8 +563,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                     self._deferred_fts_rows.extend(pending_fts)
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
-                if self._snap_dirty:
-                    self._save_snapvec()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()
@@ -605,8 +600,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 self._conn.commit()
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
-                if self._snap_dirty:
-                    self._save_snapvec()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()
@@ -715,9 +708,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 self._conn.commit()
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
-                # Persist snapvec AFTER successful SQLite commit
-                if self._snap_dirty:
-                    self._save_snapvec()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()
@@ -896,8 +886,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 self._conn.commit()
                 self._invalidate_idf_cache()
                 self._bump_cache_epoch()
-                if self._snap_dirty:
-                    self._save_snapvec()
             except Exception:
                 self._conn.rollback()
                 self._reload_snapvec()
@@ -2014,17 +2002,12 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
 
             # Update stored dimension only after successful commit
             self.embedding_dim = new_dim
-            # Persist snapvec AFTER successful SQLite commit; failures here
-            # cannot be rolled back via SQLite, so we log them.
+            # Mark snapvec dirty so the deferred flush in close() /
+            # _checkpoint_snapvec() picks up the rebuilt index. vec_chunks is
+            # the source of truth, so a crash before the flush is recovered by
+            # _rebuild_snapvec_from_vec_chunks on next open.
             if self._snap is not None:
                 self._snap_dirty = True
-                try:
-                    self._save_snapvec()
-                except Exception:
-                    logger.exception(
-                        "Failed to persist snapvec after successful reindex; "
-                        "run 'vstash reindex' again to rebuild."
-                    )
 
             return processed
 

--- a/vstash/store/_index.py
+++ b/vstash/store/_index.py
@@ -370,36 +370,6 @@ class _IndexBackendMixin:
         logger.info("Rebuilt flat snapvec index with %d vectors", total)
         return total
 
-    def _save_snapvec(self) -> None:
-        """Mark the in-memory snapvec index dirty; flush deferred to
-        ``close()`` / ``_checkpoint_snapvec()``.
-
-        Historically the flat backend wrote ``.snpv`` on every call
-        (typically one per ``add_document``). That is a full-file
-        rewrite and costs ~1.25 ms/MB on Apple Silicon (memory
-        bandwidth). In tight per-doc ingest loops the OS page cache
-        hides the cost at small N, but once the file grows past the
-        kernel's dirty-page absorption budget (roughly a few tens of
-        MB in practice), every save starts paying real disk I/O and
-        the sum becomes quadratic. Observed on 2026-04-19: a 100k
-        per-doc ingest on flat snapvec took 40+ minutes of pure
-        ``.snpv`` rewrites.
-
-        Fix: mirror the ivfpq pattern and defer the flush for both
-        backends. ``vec_chunks`` is the SQLite source of truth, so a
-        process crash before the deferred flush runs is recoverable
-        via ``_rebuild_snapvec_from_vec_chunks`` (``_init_snapvec``
-        detects the staleness on next open and rebuilds
-        automatically).
-
-        Callers that want a synchronous flush can invoke
-        ``_checkpoint_snapvec()`` directly (``close()`` does this on
-        teardown).
-        """
-        if self._snap is None:
-            return
-        self._snap_dirty = True
-
     def _checkpoint_snapvec(self) -> None:
         """Flush the in-memory snapvec index to disk if dirty."""
         if self._snap is None or not self._snap_dirty:


### PR DESCRIPTION
Third improvement PR. Two dead-code removals; **no behavior change** (full suite 1298 passed). Also documents two things I deliberately did **not** remove after verifying they're intentional.

## Removed
- **`_save_snapvec`** (+ all 6 call sites). It became a pure `self._snap_dirty = True` flag-setter when the flat-backend flush was deferred to `close()`/`_checkpoint_snapvec` (#250). Every call site was `if self._snap_dirty: self._save_snapvec()` — a tautology (the flag is already set by the preceding snap mutation), and the reindex site wrapped the no-op in a pointless try/except. The deferred-flush contract is unchanged; this also kills the misleading name that invited reintroducing the O(N²) per-doc `.snpv` rewrite.
- **`ScoringConfig`** (+ `VstashConfig.scoring` field). The frequency+decay pipeline was removed in v0.18.0; the config model survived as never-read fields whose docstring still described the removed `alpha*rrf + beta*...` formula. Docs already marked `[scoring]` deprecated/ignored; a `[scoring]` toml section is now warn-on-unknown. Per-call `mmr_lambda` remains. (docs/configuration.md + CLAUDE.md updated.)

## Deliberately kept (verified intentional — the audit's suggestion was wrong)
- **`BackendError`**: never raised, but `test_errors.py` explicitly codifies its shape (`not issubclass(..., ValueError/RuntimeError)`) — forward-looking API for when backends adopt it, not accidental dead code. Demoting/wiring it would reverse a tested design decision.
- **`RecencyConfig`**: kept. `[recency] boost` is documented in **three** places as the default for `recency_boost` but is in fact **unwired** — a real bug. Wiring it end-to-end is a public-default change (recency_boost semantics across all adapters), so it belongs in a deliberate PR, not a cleanup. Added a NOTE on the model.

## Verification
- `pytest tests/` → **1298 passed**; ruff clean; config loads (recency intact, scoring gone).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guide to reflect removal of the deprecated `[scoring]` section, which was unused since v0.18.0.
  * Clarified that existing `[scoring]` configurations will now trigger a warning instead of being silently ignored.
  * Redirected users to `[recency]` configuration and per-call `mmr_lambda` for tuning search behavior.

* **Chores**
  * Removed legacy scoring configuration model from codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->