### PR TITLE
fix(mcp): vstash_ask surfaces reasoning channel + token usage

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,7 +8,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from vstash.models import ChunkInfo, DocumentInfo, IngestResult, SearchResult, StoreStats
+from vstash.models import (
+    AskResult,
+    ChunkInfo,
+    DocumentInfo,
+    IngestResult,
+    SearchResult,
+    StoreStats,
+)
 from vstash.mcp import (
     _error,
     _ok,
@@ -485,7 +492,7 @@ class TestVstashAsk:
         store_inst.expand_context.return_value = chunks
         _setup_mock_config(mock_config)
 
-        with patch("vstash.chat.ask", return_value="Python is great."):
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="Python is great.")):
             result = json.loads(vstash_ask("What is Python?"))
 
         assert result["answer"] == "Python is great."
@@ -493,6 +500,51 @@ class TestVstashAsk:
         assert result["sources"][0]["title"] == "PythonGuide"
         store_inst.record_search_event.assert_called_once()
         store_inst.expand_context.assert_called_once()
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_ask_surfaces_reasoning_and_usage(
+        self, mock_config: MagicMock, mock_store: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """vstash_ask goes through ask_full, so a backend's reasoning channel +
+        token usage reach the client (instead of being discarded by ask())."""
+        chunks = [_make_search_result("context", "Doc")]
+        store_inst = mock_store.return_value
+        store_inst.search.return_value = chunks
+        store_inst.last_best_distance = 0.5
+        store_inst.expand_context.return_value = chunks
+        _setup_mock_config(mock_config)
+
+        full = AskResult(content="42", reasoning="chain of thought", usage={"total_tokens": 10})
+        with patch("vstash.chat.ask_full", return_value=full):
+            result = json.loads(vstash_ask("meaning of life?"))
+
+        assert result["answer"] == "42"
+        assert result["reasoning"] == "chain of thought"
+        assert result["usage"] == {"total_tokens": 10}
+
+    @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
+    @patch("vstash.mcp._get_store")
+    @patch("vstash.mcp._get_config")
+    def test_ask_omits_reasoning_and_usage_when_absent(
+        self, mock_config: MagicMock, mock_store: MagicMock, mock_embed: MagicMock
+    ) -> None:
+        """When the backend surfaces no reasoning/usage, the keys are absent so
+        the payload stays minimal."""
+        chunks = [_make_search_result("context", "Doc")]
+        store_inst = mock_store.return_value
+        store_inst.search.return_value = chunks
+        store_inst.last_best_distance = 0.5
+        store_inst.expand_context.return_value = chunks
+        _setup_mock_config(mock_config)
+
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="plain")):
+            result = json.loads(vstash_ask("q"))
+
+        assert result["answer"] == "plain"
+        assert "reasoning" not in result
+        assert "usage" not in result
 
     @patch("vstash.mcp.embed_query", return_value=[0.1] * 384)
     @patch("vstash.mcp._get_store")
@@ -524,7 +576,7 @@ class TestVstashAsk:
         store_inst.expand_context.return_value = chunks
         _setup_mock_config(mock_config)
 
-        with patch("vstash.chat.ask", return_value="Answer."):
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="Answer.")):
             result = json.loads(vstash_ask("query"))
 
         assert len(result["sources"]) == 1  # deduplicated
@@ -555,7 +607,7 @@ class TestVstashAsk:
         store_inst.expand_context.return_value = chunks
         _setup_mock_config(mock_config)
 
-        with patch("vstash.chat.ask", return_value="answer"):
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="answer")):
             vstash_ask(
                 "query",
                 vec_weight=0.3,
@@ -588,7 +640,7 @@ class TestVstashAsk:
         _setup_mock_config(mock_config)
 
         # Weights as strings, no mode set (default hybrid).
-        with patch("vstash.chat.ask", return_value="answer"):
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="answer")):
             vstash_ask(
                 "query",
                 vec_weight="0.1",  # type: ignore[arg-type]
@@ -601,7 +653,7 @@ class TestVstashAsk:
 
         # retrieval_mode as a string coerces via _coerce_retrieval_mode.
         store_inst.search.reset_mock()
-        with patch("vstash.chat.ask", return_value="answer"):
+        with patch("vstash.chat.ask_full", return_value=AskResult(content="answer")):
             vstash_ask("query", retrieval_mode="fts_only")
         _, kwargs = store_inst.search.call_args
         assert kwargs["retrieval_mode"] == "fts_only"

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -524,7 +524,7 @@ def vstash_ask(
         JSON string with answer text and source documents.
     """
     try:
-        from .chat import ask
+        from .chat import ask_full
 
         top_k = int(top_k)
         cfg = _get_config()
@@ -582,8 +582,11 @@ def vstash_ask(
             result_count=len(chunks),
         )
 
-        # Get LLM answer
-        answer = ask(query, chunks, cfg)
+        # Get LLM answer via ask_full so the reasoning channel + token usage
+        # the backend produces (Cerebras gpt-oss message.reasoning, Ollama
+        # qwen3 message.thinking) reach the MCP client instead of being
+        # discarded by the plain ask() -> str wrapper (#303).
+        result = ask_full(query, chunks, cfg)
 
         # Build source list
         sources = [{"title": c.title, "path": c.path, "score": c.score} for c in chunks]
@@ -595,7 +598,15 @@ def vstash_ask(
                 seen.add(src["path"])
                 unique_sources.append(src)
 
-        return _ok({"answer": answer, "sources": unique_sources})
+        payload: dict[str, Any] = {"answer": result.content, "sources": unique_sources}
+        # Surface reasoning / usage only when the backend provided them, so the
+        # payload stays minimal for backends that don't (OpenAI-compat without a
+        # reasoning channel).
+        if result.reasoning:
+            payload["reasoning"] = result.reasoning
+        if result.usage:
+            payload["usage"] = result.usage
+        return _ok(payload)
 
     except FileNotFoundError:
         return _error("vstash database not found. Ingest documents first with vstash_add.")


### PR DESCRIPTION
Surgical correctness fix (one of the adapter-audit findings, verified).

## Problem
`vstash_ask` called `chat.ask() -> str`, **discarding** the reasoning channel and token usage the backend produces (Cerebras gpt-oss `message.reasoning`, Ollama qwen3 `message.thinking`). Surfacing those is the entire purpose of `ask_full()`/`AskResult` (#303), yet MCP clients (Claude Desktop) never received them — even though the SDK (`Memory.ask_full`) and CLI do.

## Fix
Route `vstash_ask` through `chat.ask_full()` and add `reasoning` / `usage` to the response **only when the backend provides them** (payload stays minimal otherwise). `answer`/`sources` shape unchanged. ([mcp.py:586](vstash/mcp.py#L586))

## Note on the audit's empty-telemetry claim
The audit also said `vstash_ask` skips empty-result telemetry *while `vstash_search` records it* — but on inspection **both** MCP tools return early on empty without recording (consistent). So I did **not** add empty-telemetry to `ask` alone (that would make it inconsistent with `search`); recording MCP misses for `vstash why` is a separate, both-tools change.

## Verification
- 5 existing `vstash_ask` tests updated (mock `chat.ask_full` → `AskResult`); 2 new tests assert reasoning/usage surfaced-when-present, omitted-when-absent.
- `pytest tests/` → **1300 passed**; ruff clean.