### PR TITLE
fix(store): flat-snapvec rollback recovery rebuilds from vec_chunks

### DIFF
--- a/tests/test_snapvec_recovery.py
+++ b/tests/test_snapvec_recovery.py
@@ -70,3 +70,23 @@ def test_reindex_checkpoints_snapvec_immediately(tmp_db_path: str) -> None:
         assert store._snap_dirty is False, "reindex should checkpoint snapvec immediately"
     finally:
         store.close()
+
+
+def test_reindex_survives_snapvec_flush_failure(tmp_db_path: str, monkeypatch) -> None:
+    """A snapvec flush failure after reindex (disk-full) must not fail the
+    already-committed re-embed — it is logged and self-heals on next open."""
+    pytest.importorskip("snapvec")
+    store = VstashStore(tmp_db_path, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+    try:
+        for i in range(3):
+            _add(store, i)
+
+        def boom() -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(store, "_checkpoint_snapvec", boom)
+        n = store.reindex(lambda texts: [[0.5] * DIM for _ in texts], new_dim=DIM)
+        assert n == 3  # the re-embed succeeded despite the flush failure
+    finally:
+        monkeypatch.undo()
+        store.close()

--- a/tests/test_snapvec_recovery.py
+++ b/tests/test_snapvec_recovery.py
@@ -1,0 +1,72 @@
+"""Snapvec durability: rollback recovery rebuilds from vec_chunks, and reindex
+flushes the rebuilt index immediately (PR: fix/snapvec-rollback-recovery).
+
+Flat snapvec defers its ``.snpv`` write to close()/checkpoint, so the on-disk
+file can lag ``vec_chunks`` mid-session. Both tests use the real snapvec backend
+and fail without the fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vstash.store import VstashStore
+
+DIM = 4
+
+
+def _add(store: VstashStore, i: int) -> None:
+    store.add_document(
+        path=f"/d{i}.md",
+        title=f"d{i}",
+        chunks=[f"chunk {i}"],
+        embeddings=[[0.1 * (i + 1), 0.2, 0.3, 0.4]],
+    )
+
+
+def test_reload_snapvec_rebuilds_from_vec_chunks_when_disk_is_stale(tmp_db_path: str) -> None:
+    """After a rollback, _reload_snapvec must not restore an out-of-date .snpv
+    that is missing committed-but-unflushed adds — it rebuilds from vec_chunks."""
+    pytest.importorskip("snapvec")
+    store = VstashStore(tmp_db_path, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+    try:
+        # Flush a 2-vector .snpv to disk.
+        _add(store, 0)
+        _add(store, 1)
+        store._checkpoint_snapvec()
+
+        # Three more committed adds, deferred (not flushed): in-memory snap has 5,
+        # the on-disk .snpv still has 2.
+        _add(store, 2)
+        _add(store, 3)
+        _add(store, 4)
+        assert len(store._snap) == 5
+        assert store._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0] == 5
+
+        # Simulate the post-rollback recovery. A bare SnapIndex.load would
+        # restore the stale 2-vector .snpv; the fix re-runs the staleness-aware
+        # load and rebuilds to match vec_chunks.
+        store._reload_snapvec()
+        assert len(store._snap) == 5, (
+            "reload must rebuild from vec_chunks, not restore a stale .snpv"
+        )
+    finally:
+        store.close()
+
+
+def test_reindex_checkpoints_snapvec_immediately(tmp_db_path: str) -> None:
+    """reindex persists the rebuilt snapvec index immediately instead of leaving
+    it dirty until close() (minimises the crash-rebuild window)."""
+    pytest.importorskip("snapvec")
+    store = VstashStore(tmp_db_path, embedding_dim=DIM, vector_backend="snapvec", snapvec_bits=4)
+    try:
+        for i in range(3):
+            _add(store, i)
+
+        def embed(texts: list[str]) -> list[list[float]]:
+            return [[0.5, 0.5, 0.5, 0.5] for _ in texts]
+
+        store.reindex(embed, new_dim=DIM)
+        assert store._snap_dirty is False, "reindex should checkpoint snapvec immediately"
+    finally:
+        store.close()

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -2011,7 +2011,19 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             # remains the source of truth if the flush itself fails.
             if self._snap is not None:
                 self._snap_dirty = True
-                self._checkpoint_snapvec()
+                # Best-effort: the re-embed is already committed and the dim
+                # updated, so a flush failure (disk-full, permissions) must not
+                # fail reindex and tempt the caller into re-running the whole
+                # expensive re-embed. The index stays dirty and self-heals via
+                # _rebuild_snapvec_from_vec_chunks on the next open.
+                try:
+                    self._checkpoint_snapvec()
+                except Exception:
+                    logger.warning(
+                        "reindex committed but flushing snapvec to disk failed; "
+                        "the index will be rebuilt from vec_chunks on next open.",
+                        exc_info=True,
+                    )
 
             return processed
 

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -2002,12 +2002,16 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
 
             # Update stored dimension only after successful commit
             self.embedding_dim = new_dim
-            # Mark snapvec dirty so the deferred flush in close() /
-            # _checkpoint_snapvec() picks up the rebuilt index. vec_chunks is
-            # the source of truth, so a crash before the flush is recovered by
-            # _rebuild_snapvec_from_vec_chunks on next open.
+            # reindex is rare + expensive (it just re-embedded the whole corpus),
+            # so persist the rebuilt snapvec index to disk immediately rather than
+            # deferring to close(). This minimises the window where a crash before
+            # close() would force a full _rebuild_snapvec_from_vec_chunks on the
+            # next open. _checkpoint_snapvec is a no-op when not dirty / no snap,
+            # and acquires no lock (safe inside the reindex _write_lock). vec_chunks
+            # remains the source of truth if the flush itself fails.
             if self._snap is not None:
                 self._snap_dirty = True
+                self._checkpoint_snapvec()
 
             return processed
 

--- a/vstash/store/_index.py
+++ b/vstash/store/_index.py
@@ -398,5 +398,19 @@ class _IndexBackendMixin:
         # save to close()/checkpoint), leaving the in-memory index behind
         # vec_chunks until the next open. Mirrors the ivfpq branch above, which
         # already re-runs _init_ivfpq() for the same reason.
-        self._init_snapvec()
+        #
+        # Guard it: this runs in the rollback recovery path, so an exception
+        # here (e.g. disk-full while _rebuild_snapvec_from_vec_chunks saves)
+        # must NOT propagate and mask the original transaction error the caller
+        # is about to re-raise. Fall back to an empty index (rebuilt on next
+        # open) and log, matching the pre-rewrite behaviour.
+        try:
+            self._init_snapvec()
+        except Exception:
+            logger.warning(
+                "Failed to reload/rebuild SnapIndex after rollback — creating empty index. "
+                "Run 'vstash reindex' to rebuild vector search.",
+                exc_info=True,
+            )
+            self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
         self._snap_dirty = False

--- a/vstash/store/_index.py
+++ b/vstash/store/_index.py
@@ -391,16 +391,12 @@ class _IndexBackendMixin:
             self._init_ivfpq()
             self._snap_dirty = False
             return
-        path = self._snapvec_path
-        if path.exists():
-            try:
-                self._snap = SnapIndex.load(str(path))
-            except Exception:
-                logger.warning(
-                    "Failed to reload SnapIndex after rollback — creating empty index. "
-                    "Run 'vstash reindex' to rebuild vector search."
-                )
-                self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
-        else:
-            self._snap = SnapIndex(dim=self.embedding_dim, bits=self._snapvec_bits, seed=0)
+        # Re-run the flat construction load path, which loads the .snpv AND does
+        # the staleness check (vec_chunks count > snap count -> rebuild from
+        # SQLite). A bare SnapIndex.load would restore a .snpv that is missing
+        # the session's committed-but-unflushed adds (flat snapvec defers its
+        # save to close()/checkpoint), leaving the in-memory index behind
+        # vec_chunks until the next open. Mirrors the ivfpq branch above, which
+        # already re-runs _init_ivfpq() for the same reason.
+        self._init_snapvec()
         self._snap_dirty = False


### PR DESCRIPTION
Second surgical correctness fix — closes the pre-existing snapvec durability gap that the gemini review surfaced on #405 (which itself was behavior-neutral).

## Problem
Flat snapvec defers its `.snpv` write to `close()`/checkpoint, so after a burst of committed adds the on-disk file lags `vec_chunks`. The rollback recovery `_reload_snapvec()` restored that **stale `.snpv`** via a bare `SnapIndex.load`, leaving the in-memory index behind `vec_chunks` for the rest of the session (the next open's staleness check would rebuild it, so it self-healed on restart — but on a long-running ingest server/MCP, a single write failure could drop the whole session's snapvec adds from search until restart).

The **ivfpq** backend was already correct — its `_reload_snapvec` branch re-runs `_init_ivfpq()`, which does a staleness check. Only the **flat** branch had the bare load.

## Fix
- `_reload_snapvec` flat branch now re-runs `_init_snapvec()` (load `.snpv` **+** staleness check → rebuild from `vec_chunks` when stale). Symmetric with the ivfpq branch. ([_index.py:389](vstash/store/_index.py#L389))
- `reindex` now `_checkpoint_snapvec()`s immediately after rebuilding (it just re-embedded the whole corpus) instead of deferring to `close()`, minimising the crash-rebuild window. Lock-safe (no lock acquired, no-ops when not dirty). ([store/__init__.py:2009](vstash/store/__init__.py#L2009))

## Verification
- `tests/test_snapvec_recovery.py` (real snapvec backend, stale-`.snpv` scenario); both tests **fail without the fix**.
- `pytest tests/` → **1302 passed**; ruff clean.