### PR TITLE
fix(retrain): _promote_candidate survives a partial cross-device move

### DIFF
--- a/tests/test_promote_candidate.py
+++ b/tests/test_promote_candidate.py
@@ -1,0 +1,64 @@
+"""Regression test for _promote_candidate cross-device rollback.
+
+shutil.move across filesystems is copy-then-delete, so a mid-copy failure leaves
+final_path as a partial directory. The rollback must remove that partial and
+restore the previous model from backup instead of stranding it in .old.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vstash.retrain import _promote_candidate
+
+
+def test_promote_rolls_back_partial_cross_device_move(tmp_path: Path, monkeypatch) -> None:
+    final = tmp_path / "model"
+    final.mkdir()
+    (final / "weights.txt").write_text("ORIGINAL")
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "weights.txt").write_text("NEW")
+
+    def fake_move(src: str, dst: str) -> None:
+        # Simulate a cross-device copy that fails partway, leaving a partial dst.
+        d = Path(dst)
+        d.mkdir(exist_ok=True)
+        (d / "weights.txt.partial").write_text("HALF")
+        raise OSError("cross-device link failed mid-copy")
+
+    monkeypatch.setattr("vstash.retrain.shutil.move", fake_move)
+
+    with pytest.raises(OSError, match="cross-device"):
+        _promote_candidate(candidate, final)
+
+    # The previous model must be restored intact, not left as the partial move,
+    # and the .old backup must be gone (rolled back into place).
+    assert final.exists()
+    assert (final / "weights.txt").read_text() == "ORIGINAL"
+    assert not (final / "weights.txt.partial").exists()
+    assert not final.with_name("model.old").exists()
+
+
+def test_promote_first_time_train_cleans_partial(tmp_path: Path, monkeypatch) -> None:
+    """No prior model: a failed move must not leave a partial final behind, and
+    must not crash trying to restore a nonexistent backup."""
+    final = tmp_path / "model"  # does not exist (first train)
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / "weights.txt").write_text("NEW")
+
+    def fake_move(src: str, dst: str) -> None:
+        Path(dst).mkdir(exist_ok=True)
+        raise OSError("cross-device link failed mid-copy")
+
+    monkeypatch.setattr("vstash.retrain.shutil.move", fake_move)
+
+    with pytest.raises(OSError, match="cross-device"):
+        _promote_candidate(candidate, final)
+    # No backup existed, so there's nothing to restore; the rollback must not
+    # raise a second (masking) exception, and the partial garbage is removed.
+    assert not final.exists()
+    assert not final.with_name("model.old").exists()

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -455,13 +455,30 @@ def _promote_candidate(candidate_path: Path, final_path: Path) -> None:
     final_path.parent.mkdir(parents=True, exist_ok=True)
     if backup_path.exists():
         shutil.rmtree(backup_path)
+    final_existed = final_path.exists()
+    backed_up = False
     try:
-        if final_path.exists():
+        if final_existed:
             final_path.rename(backup_path)
+            backed_up = True
         shutil.move(str(candidate_path), str(final_path))
     except Exception:
-        if backup_path.exists() and not final_path.exists():
+        # shutil.move across filesystems is copy-then-delete, so a mid-copy
+        # failure can leave final_path as a *partial* directory. The old guard
+        # ``not final_path.exists()`` then skipped the rollback, stranding the
+        # user's previous model in .old behind a corrupt final.
+        if backed_up:
+            # Prior model is safe in backup; whatever sits at final_path now is
+            # the failed move -- remove it, then restore the previous model.
+            if final_path.exists():
+                shutil.rmtree(final_path)
             backup_path.rename(final_path)
+        elif not final_existed and final_path.exists():
+            # First-time train (no prior model) and the move left a partial dir
+            # -- remove the garbage so it is not mistaken for a real model.
+            shutil.rmtree(final_path)
+        # else: the backup rename itself failed, so final_path is still the
+        # untouched original model -- leave it.
         raise
     else:
         if backup_path.exists():

--- a/vstash/retrain.py
+++ b/vstash/retrain.py
@@ -467,18 +467,30 @@ def _promote_candidate(candidate_path: Path, final_path: Path) -> None:
         # failure can leave final_path as a *partial* directory. The old guard
         # ``not final_path.exists()`` then skipped the rollback, stranding the
         # user's previous model in .old behind a corrupt final.
-        if backed_up:
-            # Prior model is safe in backup; whatever sits at final_path now is
-            # the failed move -- remove it, then restore the previous model.
-            if final_path.exists():
+        #
+        # Guard the rollback itself: a secondary failure here (locked file,
+        # permissions) must be logged, not propagated, so the ORIGINAL move
+        # error still reaches the caller for diagnosis.
+        try:
+            if backed_up:
+                # Prior model is safe in backup; whatever sits at final_path now
+                # is the failed move -- remove it, then restore the prior model.
+                if final_path.exists():
+                    shutil.rmtree(final_path)
+                backup_path.rename(final_path)
+            elif not final_existed and final_path.exists():
+                # First-time train (no prior model) and the move left a partial
+                # dir -- remove the garbage so it is not mistaken for a model.
                 shutil.rmtree(final_path)
-            backup_path.rename(final_path)
-        elif not final_existed and final_path.exists():
-            # First-time train (no prior model) and the move left a partial dir
-            # -- remove the garbage so it is not mistaken for a real model.
-            shutil.rmtree(final_path)
-        # else: the backup rename itself failed, so final_path is still the
-        # untouched original model -- leave it.
+            # else: the backup rename itself failed, so final_path is still the
+            # untouched original model -- leave it.
+        except Exception:
+            logger.warning(
+                "Failed to roll back model promotion after a failed move; the "
+                "previous model may remain at %s. Re-raising the original error.",
+                backup_path,
+                exc_info=True,
+            )
         raise
     else:
         if backup_path.exists():


### PR DESCRIPTION
Contained correctness fix from the audit (retrain #9).

## Problem
`_promote_candidate` does `final_path.rename(backup)` then `shutil.move(candidate, final)`. `shutil.move` **across filesystems is copy-then-delete**, so a mid-copy failure leaves `final_path` as a **partial directory**. The rollback guard `if backup_path.exists() and not final_path.exists()` then saw the partial `final_path`, **skipped the restore**, and stranded the user's previous model in `<name>.old` behind a corrupt final — the exact data-loss the docstring promises to prevent.

## Fix
Track `backed_up` (did we move the prior model to backup?) and `final_existed`, then on failure:
- **backed_up** → remove the partial `final_path`, restore the backup;
- **first-time train** (no prior model) with a partial → remove the garbage;
- **backup rename failed** → leave `final_path` (still the untouched original).

## Verification
- `tests/test_promote_candidate.py`: strand-the-good-model + first-train-cleanup; both **fail without the fix**.
- `pytest tests/` → **1305 passed**; ruff clean.