### PR TITLE
fix(embed): cache daemon model mismatch (skip the wasted round-trip)

### DIFF
--- a/tests/test_embed_daemon.py
+++ b/tests/test_embed_daemon.py
@@ -85,7 +85,9 @@ def _reset_daemon_state():
     embed_mod._daemon_available = False
     embed_mod._daemon_url = None
     embed_mod._is_daemon = False
+    embed_mod._daemon_model_mismatch.clear()
     yield
+    embed_mod._daemon_model_mismatch.clear()
     (
         embed_mod._daemon_checked,
         embed_mod._daemon_available,
@@ -128,6 +130,38 @@ class TestDaemonClient:
     def test_model_mismatch_batch_returns_none(self, fake_daemon: str):
         result = embed_mod._daemon_embed_texts(["hello"], fake_daemon, "wrong-model")
         assert result is None
+
+    def test_model_mismatch_is_cached(self, fake_daemon: str):
+        """A mismatch records the (url, model) pair so future calls can skip the
+        daemon instead of re-paying the round-trip."""
+        embed_mod._daemon_embed_texts(["hello"], fake_daemon, "wrong-model")
+        assert (fake_daemon, "wrong-model") in embed_mod._daemon_model_mismatch
+
+    def test_embed_texts_skips_daemon_for_cached_mismatch(self, fake_daemon: str, monkeypatch):
+        """Once a model is known to mismatch, embed_texts must go straight to the
+        local backend without calling the daemon again."""
+        embed_mod._daemon_url = fake_daemon
+        embed_mod._daemon_available = True
+        embed_mod._daemon_checked = True
+        embed_mod._daemon_model_mismatch.add((fake_daemon, "cached-mismatch-model"))
+
+        called = {"daemon": 0}
+
+        def _should_not_run(*_a, **_k):
+            called["daemon"] += 1
+            return None
+
+        monkeypatch.setattr(embed_mod, "_daemon_embed_texts", _should_not_run)
+
+        class _FakeBackend:
+            def embed_batch(self, texts, model_name, backend):
+                return [[0.0, 0.0, 0.0, 0.0] for _ in texts]
+
+        monkeypatch.setattr(embed_mod, "_resolve_builtin_backend", lambda _m: _FakeBackend())
+
+        result = embed_mod.embed_texts(["x", "y"], "cached-mismatch-model")
+        assert called["daemon"] == 0  # daemon skipped via the mismatch cache
+        assert len(result) == 2
 
     def test_check_daemon_finds_server(self, fake_daemon: str):
         embed_mod._DAEMON_DEFAULT_URL = fake_daemon

--- a/tests/test_embed_daemon.py
+++ b/tests/test_embed_daemon.py
@@ -81,13 +81,17 @@ def _reset_daemon_state():
         embed_mod._is_daemon,
         embed_mod._DAEMON_DEFAULT_URL,
     )
+    _saved_mismatch = set(embed_mod._daemon_model_mismatch)
     embed_mod._daemon_checked = False
     embed_mod._daemon_available = False
     embed_mod._daemon_url = None
     embed_mod._is_daemon = False
     embed_mod._daemon_model_mismatch.clear()
     yield
+    # Restore the original cache contents (preserving object identity) so this
+    # fixture is symmetric with the other globals it save/restores.
     embed_mod._daemon_model_mismatch.clear()
+    embed_mod._daemon_model_mismatch.update(_saved_mismatch)
     (
         embed_mod._daemon_checked,
         embed_mod._daemon_available,

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -928,6 +928,13 @@ _is_daemon: bool = os.getenv("_VSTASH_IS_DAEMON") == "1"
 _DAEMON_DEFAULT_URL = "http://127.0.0.1:8585"
 _DAEMON_TIMEOUT = 0.3  # seconds -- fast fail for localhost
 
+# (url, model) pairs the running daemon cannot serve -- it only has its own warm
+# model loaded. Cached on the first mismatch so a non-default model does not pay
+# a full-batch HTTP round-trip on *every* embed call just to discard the result
+# and re-embed locally. Cleared by _mark_daemon_unavailable (a daemon restart
+# may load a different model).
+_daemon_model_mismatch: set[tuple[str, str]] = set()
+
 
 def _check_daemon() -> str | None:
     """Probe the daemon URL once. Returns URL if reachable, else None.
@@ -967,6 +974,8 @@ def _mark_daemon_unavailable() -> None:
     global _daemon_checked, _daemon_available
     _daemon_available = False
     _daemon_checked = False
+    # A restarted daemon may serve a different model, so re-evaluate mismatches.
+    _daemon_model_mismatch.clear()
 
 
 def _daemon_embed_query(text: str, url: str, model_name: str) -> list[float] | None:
@@ -983,10 +992,12 @@ def _daemon_embed_query(text: str, url: str, model_name: str) -> list[float] | N
             result = json.loads(resp.read())
             if result.get("model") != model_name:
                 _logger.warning(
-                    "Daemon model mismatch: requested %s, got %s. Falling back to local.",
+                    "Daemon model mismatch: requested %s, got %s. Falling back to "
+                    "local and caching the mismatch so this model skips the daemon.",
                     model_name,
                     result.get("model"),
                 )
+                _daemon_model_mismatch.add((url, model_name))
                 return None
             return result.get("embedding")
     except Exception:
@@ -1008,10 +1019,12 @@ def _daemon_embed_texts(texts: list[str], url: str, model_name: str) -> list[lis
             result = json.loads(resp.read())
             if result.get("model") != model_name:
                 _logger.warning(
-                    "Daemon model mismatch: requested %s, got %s. Falling back to local.",
+                    "Daemon model mismatch: requested %s, got %s. Falling back to "
+                    "local and caching the mismatch so this model skips the daemon.",
                     model_name,
                     result.get("model"),
                 )
+                _daemon_model_mismatch.add((url, model_name))
                 return None
             return result.get("embeddings")
     except Exception:
@@ -1051,7 +1064,7 @@ def embed_texts(
         return _embed_via_custom(texts, custom)
 
     url = _check_daemon()
-    if url is not None:
+    if url is not None and (url, model_name) not in _daemon_model_mismatch:
         result = _daemon_embed_texts(texts, url, model_name)
         if result is not None and len(result) == len(texts):
             return result
@@ -1084,7 +1097,7 @@ def embed_query(
         return vecs[0]
 
     url = _check_daemon()
-    if url is not None:
+    if url is not None and (url, model_name) not in _daemon_model_mismatch:
         result = _daemon_embed_query(text, url, model_name)
         if result is not None:
             return result


### PR DESCRIPTION
Contained correctness/perf fix from the audit (embed #5).

## Problem
With a `vstash serve` daemon running but serving a *different* model than requested, the client POSTed the full batch, saw the model mismatch, discarded the result, and re-embedded locally — on **every** `embed_texts`/`embed_query` call. For any non-default model that's a wasted full-batch HTTP round-trip per call (the mismatch returned `None` but never recorded itself). ([embed.py:1009](vstash/embed.py#L1009))

## Fix
Cache the mismatched `(url, model)` pair on first detection; `embed_texts`/`embed_query` then skip the daemon for that model and go straight to local embedding. Cleared by `_mark_daemon_unavailable` (a daemon restart may load a different model) and reset between tests.

## Verification
- `tests/test_embed_daemon.py`: a mismatch is cached; `embed_texts` skips the daemon for a cached mismatch.
- `pytest tests/` → **1307 passed**; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon embedding resilience by tracking model mismatches and automatically falling back to local embeddings for known problematic daemon/model pairs, reducing failed round-trips and improving performance.

* **Tests**
  * Enhanced test isolation for daemon caching; added test coverage for model mismatch detection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->