### PR TITLE
fix(ingest): make chunk helpers self-contained via _sep_tokens()

### DIFF
--- a/tests/test_sep_tokens.py
+++ b/tests/test_sep_tokens.py
@@ -1,0 +1,38 @@
+"""The chunking helpers must not depend on a prior _token_count having set the
+_SEPARATOR_TOKENS global as a side effect.
+
+_SEPARATOR_TOKENS was only populated inside _get_enc(), and the helpers read it
+directly. In the live call paths _token_count happens to run first, but that is
+a fragile implicit ordering. _sep_tokens() makes the helpers self-contained:
+they load the encoder themselves. Each test monkeypatches _token_count so it
+does NOT load the encoder, so without _sep_tokens() the separator math hits
+``None + int`` -> TypeError.
+"""
+
+from __future__ import annotations
+
+import vstash.ingest as ing
+
+
+def test_sep_tokens_loads_encoder(monkeypatch) -> None:
+    monkeypatch.setattr(ing, "_enc", None)
+    monkeypatch.setattr(ing, "_SEPARATOR_TOKENS", None)
+    n = ing._sep_tokens()
+    assert isinstance(n, int) and n > 0
+
+
+def test_split_by_paragraphs_self_contained(monkeypatch) -> None:
+    monkeypatch.setattr(ing, "_enc", None)
+    monkeypatch.setattr(ing, "_SEPARATOR_TOKENS", None)
+    # A _token_count that never loads the encoder, so only _sep_tokens() can.
+    monkeypatch.setattr(ing, "_token_count", lambda text: len(text.split()))
+    result = ing._split_by_paragraphs("alpha beta\n\ngamma delta", chunk_size=100, overlap=0)
+    assert result
+
+
+def test_merge_small_chunks_self_contained(monkeypatch) -> None:
+    monkeypatch.setattr(ing, "_enc", None)
+    monkeypatch.setattr(ing, "_SEPARATOR_TOKENS", None)
+    monkeypatch.setattr(ing, "_token_count", lambda text: len(text.split()))
+    result = ing._merge_small_chunks(["one two", "three four"], chunk_size=100)
+    assert result

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -83,6 +83,7 @@ def _sep_tokens() -> int:
     forces the encoder to load first.
     """
     _get_enc()
+    assert _SEPARATOR_TOKENS is not None  # populated by _get_enc on first load
     return _SEPARATOR_TOKENS
 
 
@@ -231,6 +232,7 @@ def _split_by_paragraphs(
     result: list[str] = []
     current: list[str] = []
     current_tokens = 0
+    sep_tokens = _sep_tokens()
 
     for para in paragraphs:
         para = para.strip()
@@ -249,7 +251,7 @@ def _split_by_paragraphs(
             continue
 
         # Account for "\n\n" separator tokens when joining paragraphs
-        separator_cost = _sep_tokens() if current else 0
+        separator_cost = sep_tokens if current else 0
 
         # Would adding this paragraph overflow?
         if current_tokens + separator_cost + para_tokens > chunk_size and current:
@@ -318,16 +320,17 @@ def _merge_small_chunks(chunks: list[str], chunk_size: int) -> list[str]:
     merged: list[str] = []
     current = chunks[0]
     current_tokens = _token_count(current)
+    sep_tokens = _sep_tokens()
 
     for chunk in chunks[1:]:
         chunk_tokens = _token_count(chunk)
 
-        can_merge = current_tokens + _sep_tokens() + chunk_tokens <= chunk_size
+        can_merge = current_tokens + sep_tokens + chunk_tokens <= chunk_size
 
         # Merge if EITHER side is small (bidirectional merging)
         if can_merge and (current_tokens < _MIN_CHUNK_TOKENS or chunk_tokens < _MIN_CHUNK_TOKENS):
             current = current + "\n\n" + chunk
-            current_tokens += _sep_tokens() + chunk_tokens
+            current_tokens += sep_tokens + chunk_tokens
         else:
             merged.append(current)
             current = chunk

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -73,6 +73,19 @@ def _token_count(text: str) -> int:
     return len(_get_enc().encode(text, disallowed_special=()))
 
 
+def _sep_tokens() -> int:
+    """Token count of the paragraph separator (``\\n\\n``).
+
+    ``_SEPARATOR_TOKENS`` is populated as a side effect of ``_get_enc()``, so
+    reading the global directly would be ``None`` if a chunking helper
+    (``_split_by_paragraphs`` / ``_merge_small_chunks``) runs before any
+    tokenization in the process -- a ``None + int`` TypeError. This accessor
+    forces the encoder to load first.
+    """
+    _get_enc()
+    return _SEPARATOR_TOKENS
+
+
 # ------------------------------------------------------------------ #
 # Chunking                                                            #
 # ------------------------------------------------------------------ #
@@ -236,7 +249,7 @@ def _split_by_paragraphs(
             continue
 
         # Account for "\n\n" separator tokens when joining paragraphs
-        separator_cost = _SEPARATOR_TOKENS if current else 0
+        separator_cost = _sep_tokens() if current else 0
 
         # Would adding this paragraph overflow?
         if current_tokens + separator_cost + para_tokens > chunk_size and current:
@@ -309,12 +322,12 @@ def _merge_small_chunks(chunks: list[str], chunk_size: int) -> list[str]:
     for chunk in chunks[1:]:
         chunk_tokens = _token_count(chunk)
 
-        can_merge = current_tokens + _SEPARATOR_TOKENS + chunk_tokens <= chunk_size
+        can_merge = current_tokens + _sep_tokens() + chunk_tokens <= chunk_size
 
         # Merge if EITHER side is small (bidirectional merging)
         if can_merge and (current_tokens < _MIN_CHUNK_TOKENS or chunk_tokens < _MIN_CHUNK_TOKENS):
             current = current + "\n\n" + chunk
-            current_tokens += _SEPARATOR_TOKENS + chunk_tokens
+            current_tokens += _sep_tokens() + chunk_tokens
         else:
             merged.append(current)
             current = chunk


### PR DESCRIPTION
Defensive correctness fix from the audit (ingest #4).

## Problem
`_SEPARATOR_TOKENS` is populated only as a side effect of `_get_enc()`, but `_split_by_paragraphs` and `_merge_small_chunks` read the module global directly. The live call paths run `_token_count` (which loads the encoder) *before* the separator math, so it works today — but that's a **fragile implicit ordering**. Call a helper before any tokenization (unit test, future refactor) and the separator math hits `None + int` → TypeError.

## Fix
Add a `_sep_tokens()` accessor that loads the encoder itself, used at the three read sites. The helpers are now self-contained. ([ingest.py](vstash/ingest.py))

## Verification
- `tests/test_sep_tokens.py` monkeypatches `_token_count` so it does *not* load the encoder, exposing the latent dependency — both helper tests **TypeError without the fix**.
- `pytest tests/` → **1310 passed**; ruff clean.