### PR TITLE
fix(cli): validate vstash search at the boundary (clean LimitError)

### DIFF
--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -28,6 +28,20 @@ def _patch_store(populated_store: VstashStore, monkeypatch) -> None:
     )
 
 
+class TestSearchValidation:
+    """`vstash search` validates at the boundary (parity with SDK/MCP/web)."""
+
+    def test_search_rejects_pathological_top_k(self) -> None:
+        result = runner.invoke(app, ["search", "python", "--top-k", "999999"])
+        # Clean LimitError (exit 2 + a readable message), not a deep SQLite crash.
+        assert result.exit_code == 2
+        assert "top_k" in result.output and "limit" in result.output.lower()
+
+    def test_search_accepts_valid_top_k(self) -> None:
+        result = runner.invoke(app, ["search", "python", "--top-k", "3"])
+        assert result.exit_code == 0
+
+
 class TestListCommand:
     """Test 'vstash list' command."""
 

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -37,6 +37,16 @@ class TestSearchValidation:
         assert result.exit_code == 2
         assert "top_k" in result.output and "limit" in result.output.lower()
 
+    def test_search_rejects_pathological_top_k_json(self) -> None:
+        result = runner.invoke(app, ["search", "python", "--top-k", "999999", "--json"])
+        assert result.exit_code == 2
+        # Under --json the error must be valid JSON (no Rich markup) so piped
+        # consumers like jq don't choke.
+        import json
+
+        payload = json.loads(result.output.strip())
+        assert "error" in payload and "top_k" in payload["error"]
+
     def test_search_accepts_valid_top_k(self) -> None:
         result = runner.invoke(app, ["search", "python", "--top-k", "3"])
         assert result.exit_code == 0

--- a/vstash/cli/_search.py
+++ b/vstash/cli/_search.py
@@ -17,6 +17,7 @@ from .. import chat as chat_module
 from ..embed import embed_query
 from ..services import search_with_embedding
 from ..store import relevance_tier
+from ..validation import LimitError, validate_search_input
 from ._app import (
     _get_store,
     _inference_hint,
@@ -335,6 +336,21 @@ def search(
 
     with store:
         k = top_k or cfg.chunking.top_k
+
+        # Validate at the CLI boundary (parity with the SDK/MCP/web adapters,
+        # which validate via services) so a pathological top_k or oversized query
+        # raises a clean LimitError here instead of crashing deep inside SQLite.
+        try:
+            validate_search_input(
+                query_text=query,
+                top_k=k,
+                distance_cutoff=cfg.limits.max_distance_cutoff,
+                recency_boost=0.0,
+                limits=cfg.limits,
+            )
+        except LimitError as exc:
+            console.print(f"[red]✗[/red] {_safe_exc(exc)}")
+            raise typer.Exit(code=2) from exc
 
         with console.status("[dim]Searching memory...[/dim]", spinner="dots"):
             q_embedding = embed_query(query, cfg.embeddings.model)

--- a/vstash/cli/_search.py
+++ b/vstash/cli/_search.py
@@ -349,7 +349,14 @@ def search(
                 limits=cfg.limits,
             )
         except LimitError as exc:
-            console.print(f"[red]✗[/red] {_safe_exc(exc)}")
+            # Honor --json: emit a JSON error object (not Rich markup) so piped
+            # consumers get valid JSON, matching the rest of this command.
+            if json_output:
+                import json as _json
+
+                print(_json.dumps({"error": str(exc)}))
+            else:
+                console.print(f"[red]✗[/red] {_safe_exc(exc)}")
             raise typer.Exit(code=2) from exc
 
         with console.status("[dim]Searching memory...[/dim]", spinner="dots"):


### PR DESCRIPTION
Correctness fix from the audit (adapter #2).

## Problem
`vstash search` called `store.search` directly, **skipping `validate_search_input`**. A pathological `--top-k` (e.g. 999999) or an oversized query then crashed deep inside SQLite instead of raising the clean `LimitError` that the SDK / MCP / web adapters return (they validate via `services`).

## Fix
The command can't trivially route through `search_with_embedding` (it passes `explain=` and pre-embeds `q_embedding` for the federated path), so **validate at the CLI boundary** before embedding and surface a readable error + `exit 2`. ([cli/_search.py:338](vstash/cli/_search.py#L338))

## Verification
- `--top-k 999999` → exit 2 with a clean message (unguarded pass without the fix); a valid `--top-k` still works.
- `pytest tests/` → **1312 passed**; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `vstash search` command now includes input validation for the `--top-k` parameter, rejecting excessively large values with informative error messages

* **Tests**
  * Added test coverage for search command parameter validation, verifying that invalid values are rejected with appropriate exit codes and error messages, while valid values succeed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->