### PR TITLE
fix(watch): cancel pending debounce on delete (+ MCP journal docstring)

### DIFF
--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -27,6 +27,25 @@ class TestDebounceTimer:
         event.wait(timeout=2.0)
         assert result == ["/tmp/test.md"]
 
+    def test_cancel_prevents_pending_fire(self) -> None:
+        """cancel() stops a pending timer so its callback never fires.
+
+        This is the watch delete-race fix: a delete cancels a pending
+        create/modify debounce so the stale timer cannot re-enqueue the file
+        after it was removed from the store.
+        """
+        fired: list[str] = []
+        timer = _DebounceTimer(delay=0.2)
+        timer.trigger("/tmp/a.md", fired.append)
+        timer.cancel("/tmp/a.md")
+        time.sleep(0.35)  # well past the delay
+        assert fired == []
+        assert "/tmp/a.md" not in timer._timers
+
+    def test_cancel_unknown_path_is_noop(self) -> None:
+        timer = _DebounceTimer(delay=0.1)
+        timer.cancel("/tmp/nonexistent.md")  # must not raise
+
     def test_re_trigger_resets_timer(self) -> None:
         """A second trigger for the same path resets the delay; callback fires once."""
         result: list[str] = []

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -35,16 +35,29 @@ class TestDebounceTimer:
         after it was removed from the store.
         """
         fired: list[str] = []
-        timer = _DebounceTimer(delay=0.2)
+        timer = _DebounceTimer(delay=0.05)
         timer.trigger("/tmp/a.md", fired.append)
         timer.cancel("/tmp/a.md")
-        time.sleep(0.35)  # well past the delay
+        time.sleep(0.12)  # well past the delay
         assert fired == []
         assert "/tmp/a.md" not in timer._timers
 
     def test_cancel_unknown_path_is_noop(self) -> None:
         timer = _DebounceTimer(delay=0.1)
         timer.cancel("/tmp/nonexistent.md")  # must not raise
+
+    def test_cancel_prefix_cancels_files_under_dir(self) -> None:
+        """A directory delete cancels pending debounces for files inside it,
+        but leaves a sibling whose path merely shares the prefix string."""
+        fired: list[str] = []
+        timer = _DebounceTimer(delay=0.05)
+        timer.trigger("/tmp/proj/a.md", fired.append)
+        timer.trigger("/tmp/proj/sub/b.md", fired.append)
+        timer.trigger("/tmp/project/c.md", fired.append)  # sibling, NOT under /tmp/proj
+        timer.cancel_prefix("/tmp/proj")
+        time.sleep(0.12)
+        assert fired == ["/tmp/project/c.md"]
+        assert "/tmp/project/c.md" not in timer._timers  # fired + cleaned up
 
     def test_re_trigger_resets_timer(self) -> None:
         """A second trigger for the same path resets the delay; callback fires once."""

--- a/vstash/mcp.py
+++ b/vstash/mcp.py
@@ -1215,7 +1215,10 @@ def vstash_journal_save(
     Args:
         text: Content to save in the journal.
         title: Optional title (auto-generated with timestamp if omitted).
-        project: Project tag (auto-detected from cwd if omitted).
+        project: Project tag for the entry. Defaults to none (journal-wide) --
+            MCP tools are stateless and run in the server's process, so there is
+            no cwd auto-detection; pass it explicitly to scope. (The SDK's
+            Memory.journal_save scopes to the Memory's project instead.)
         tags: Comma-separated tags (journal tag added automatically).
         source: Source identifier (e.g. 'agent', 'session', 'mcp').
 

--- a/vstash/watch.py
+++ b/vstash/watch.py
@@ -83,6 +83,20 @@ class _DebounceTimer:
         if timer is not None:
             timer.cancel()
 
+    def cancel_prefix(self, prefix: str) -> None:
+        """Cancel all pending timers for paths under directory ``prefix``.
+
+        Used when a directory is deleted: any pending create/modify debounces
+        for files inside it would otherwise fire and try to re-enqueue files
+        that were just removed with the directory.
+        """
+        prefix_path = Path(prefix)
+        with self._lock:
+            matched = [p for p in self._timers if Path(p).is_relative_to(prefix_path)]
+            timers = [self._timers.pop(p) for p in matched]
+        for timer in timers:
+            timer.cancel()
+
     def cancel_all(self) -> None:
         """Cancel all pending timers."""
         with self._lock:
@@ -299,6 +313,9 @@ def start_watch(
         def on_deleted(self, event: FileSystemEvent) -> None:
             """Handle file or directory deletion — remove from store."""
             if event.is_directory:
+                # Cancel pending debounces for files inside the deleted dir so
+                # they cannot fire and re-enqueue files removed with it.
+                debounce.cancel_prefix(event.src_path)
                 _handle_dir_delete(event.src_path)
             elif _should_process(event.src_path, exts):
                 # Cancel any pending create/modify debounce for this path first,

--- a/vstash/watch.py
+++ b/vstash/watch.py
@@ -69,6 +69,20 @@ class _DebounceTimer:
             self._timers[path] = timer
             timer.start()
 
+    def cancel(self, path: str) -> None:
+        """Cancel a pending timer for a single path, if any.
+
+        Called when a delete event arrives for a path that has a pending
+        create/modify debounce: without this, that timer would fire *after* the
+        delete and re-enqueue a path that was just removed from the store,
+        reordering the delete behind a stale ingest (e.g. an editor's
+        delete-then-recreate atomic save).
+        """
+        with self._lock:
+            timer = self._timers.pop(path, None)
+        if timer is not None:
+            timer.cancel()
+
     def cancel_all(self) -> None:
         """Cancel all pending timers."""
         with self._lock:
@@ -287,6 +301,10 @@ def start_watch(
             if event.is_directory:
                 _handle_dir_delete(event.src_path)
             elif _should_process(event.src_path, exts):
+                # Cancel any pending create/modify debounce for this path first,
+                # so the delete is the last word and a stale timer can't
+                # re-enqueue the just-removed file after it fires.
+                debounce.cancel(event.src_path)
                 _handle_delete(event.src_path)
 
     observer = Observer()


### PR DESCRIPTION
Two correctness fixes from the audit (watch #8, adapter #12).

## Watch delete race
Create/modify events go through the debounce, but deletes ran **synchronously**. A modify-then-delete within the debounce window left the delete done immediately while the stale modify timer later fired and **re-enqueued the just-removed path** — reordering the delete behind a stale ingest (e.g. an editor's delete-then-recreate atomic save). 

Add `_DebounceTimer.cancel(path)` and call it in `on_deleted` so the delete is the last word for that path; a subsequent create reschedules a fresh ingest. ([watch.py](vstash/watch.py))

## MCP journal_save docstring
`vstash_journal_save` claimed `project` is *"auto-detected from cwd if omitted"*, but MCP tools are **stateless and run in the server's process** — there's no such detection (it defaults to journal-wide; only the SDK's `Memory.journal_save` scopes to a project). Corrected the docstring to match reality. ([mcp.py:1218](vstash/mcp.py#L1218))

## Verification
- `tests/test_watch.py`: `cancel()` stops a pending timer (fails without the new method); cancel of an unknown path is a no-op.
- `pytest tests/` → **1315 passed**; ruff clean.