### PR TITLE
⚡ Bolt: lazy evaluation of L2 norms in MMR dedup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2026-06-08 - Lazily evaluate L2 norms in MMR deduplication
+**Learning:** In MMR deduplication, calculating `math.hypot` eagerly for all candidate embeddings before the loop takes unnecessary O(N) computations. We can compute these norms lazily, and only for documents with more than one chunk (since cross-document redundancy isn't penalized).
+**Action:** Lazily evaluate L2 norms only when a chunk is actually compared against a selected sibling, rather than eagerly precomputing them for all candidates. Additionally, bypass similarity penalty updates entirely if the selected chunk is the only one from its document (`len(doc_indices) <= 1`).

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,8 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Precompute L2 norms lazily for cosine similarity to avoid eager O(N) computation.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,15 +1648,29 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+
+            doc_indices = doc_to_indices[new_doc_key]
+            if len(doc_indices) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+                new_norm = chunk_norms[best_idx]
+                if new_norm is None:
+                    new_norm = math.hypot(*new_emb)
+                    chunk_norms[best_idx] = new_norm
+
+                for idx in doc_indices:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
+                            idx_norm = chunk_norms[idx]
+                            if idx_norm is None:
+                                idx_norm = math.hypot(*idx_emb)
+                                chunk_norms[idx] = idx_norm
+
                             sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
+                                idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
                             )
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1650,31 +1650,26 @@ class _SearchEngineMixin:
             new_doc_key = doc_keys[best_idx]
 
             doc_indices = doc_to_indices[new_doc_key]
-            if len(doc_indices) <= 1:
-                continue
+            if len(doc_indices) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = math.hypot(*new_emb)
+                        chunk_norms[best_idx] = new_norm
 
-            new_emb = chunk_embs[best_idx]
-            if new_emb is not None:
-                new_norm = chunk_norms[best_idx]
-                if new_norm is None:
-                    new_norm = math.hypot(*new_emb)
-                    chunk_norms[best_idx] = new_norm
+                    for idx in doc_indices:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = math.hypot(*idx_emb)
+                                    chunk_norms[idx] = idx_norm
 
-                for idx in doc_indices:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            idx_norm = chunk_norms[idx]
-                            if idx_norm is None:
-                                idx_norm = math.hypot(*idx_emb)
-                                chunk_norms[idx] = idx_norm
-
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
-
+                                sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
         return selected
 
     # ------------------------------------------------------------------ #

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1667,7 +1667,9 @@ class _SearchEngineMixin:
                                     idx_norm = math.hypot(*idx_emb)
                                     chunk_norms[idx] = idx_norm
 
-                                sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
                                 if sim > max_sims[idx]:
                                     max_sims[idx] = sim
         return selected


### PR DESCRIPTION
**💡 What**
In the greedy loop of `_mmr_dedup`, `math.hypot` is computed lazily for each candidate embedding *only when* it participates in a sibling penalty update. We also bypass penalty updates completely if a newly selected chunk is the only one retrieved from its document (since `max_sims` only considers cross-chunk similarity from the same source). 

**🎯 Why**
Previously, `math.hypot(*emb)` was eagerly computed in an $O(N)$ pass for *every* fetched candidate before the MMR loop began, even though MMR intra-document diversity selection only evaluates pairs of chunks that originate from the *same* document. If a candidate is never evaluated against a same-document sibling (or if no siblings are even fetched for that document), computing its norm is entirely wasted.

**📊 Impact**
Reduces wasted pure-Python operations (`math.hypot(*emb)`) during MMR deduplication from $O(N)$ (where $N$ is the number of fetched candidates) down to $O(S)$ where $S$ is the number of times siblings from the same document actually compete in the diversity loop. In queries returning few same-document candidate duplicates, it approaches zero math cost in the penalty loop.

**🔬 Measurement**
Run tests for MMR deduplication (`pytest tests/test_store.py -k "mmr"`) to confirm selection sets and rankings remain byte-for-byte identical. Observe reduced redundant operations during MMR trace debugging.

---
*PR created automatically by Jules for task [12311558367473713059](https://jules.google.com/task/12311558367473713059) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved search performance and responsiveness by optimizing duplicate-document handling, reducing unnecessary computations and skipping redundant similarity checks—resulting in faster result ranking and lower latency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->