### PR TITLE
perf: cheaper telemetry prune + bisect histogram bucketing (hot path)

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -101,6 +101,17 @@ class TestHistogram:
         assert buckets[5000.0] == 4
         assert buckets["+Inf"] == 5
 
+    def test_observe_custom_buckets_without_inf_does_not_crash(self):
+        """A value above all bounds in a custom (no +Inf) bucket set is counted
+        in sum/count but increments no bucket -- preserving the old loop's
+        fall-through (the bisect index would otherwise be out of range)."""
+        h = Histogram(buckets_ms=(1.0, 5.0))  # deliberately no +Inf sentinel
+        h.observe(100.0)  # above every bound
+        assert h.count() == 1
+        assert h.sum_ms() == 100.0
+        buckets = {b["le"]: b["count"] for b in h.snapshot()["buckets_ms"]}
+        assert buckets[5.0] == 0  # no bucket incremented, no IndexError
+
 
 # ------------------------------------------------------------------ #
 # MetricsRegistry                                                        #

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -86,6 +86,21 @@ class TestHistogram:
         assert set(snap.keys()) == {"count", "sum_ms", "mean_ms", "buckets_ms"}
         assert isinstance(snap["buckets_ms"], list)
 
+    def test_observe_boundary_values_land_in_le_bucket(self):
+        """A value exactly on a bucket boundary lands in that bucket (value <=
+        upper) -- the discriminating case for the bisect_left lookup vs the old
+        linear `<=` scan."""
+        h = Histogram()
+        for v in (1.0, 2.0, 5.0, 0.5, 7000.0):
+            h.observe(v)
+        buckets = {b["le"]: b["count"] for b in h.snapshot()["buckets_ms"]}
+        # cumulative: <=1.0 -> {1.0, 0.5}; +2.0; +5.0; the 7000.0 only at +Inf
+        assert buckets[1.0] == 2
+        assert buckets[2.0] == 3
+        assert buckets[5.0] == 4
+        assert buckets[5000.0] == 4
+        assert buckets["+Inf"] == 5
+
 
 # ------------------------------------------------------------------ #
 # MetricsRegistry                                                        #
@@ -200,6 +215,22 @@ class TestStoreInstrumentation:
         snap = registry.snapshot()
         assert "search_latency_ms" in snap["histograms"]
         assert snap["histograms"]["search_latency_ms"]["count"] == 1
+
+    def test_record_spread_prunes_to_last_50(self, sample_store: VstashStore):
+        """record_spread keeps a sliding window of the last 50 entries -- the
+        cheap range-delete that replaced the per-search NOT IN (subquery) prune
+        must keep the newest and drop the oldest."""
+        for i in range(60):
+            sample_store.record_spread(float(i))
+        spreads = [
+            r[0]
+            for r in sample_store._conn.execute(
+                "SELECT spread FROM search_stats ORDER BY id"
+            ).fetchall()
+        ]
+        assert len(spreads) == 50  # capped at the window size
+        assert spreads[-1] == 59.0  # newest kept
+        assert min(spreads) == 10.0  # oldest (0..9) pruned
 
     def test_idf_cache_hits_and_misses(self, sample_store: VstashStore):
         """The IDF cache should record exactly one miss per invalidation

--- a/vstash/metrics.py
+++ b/vstash/metrics.py
@@ -109,12 +109,16 @@ class Histogram:
         """
         self._sum += value_ms
         self._count += 1
-        # Buckets are sorted ascending with a final +Inf, so the index of the
-        # first upper bound >= value_ms (i.e. value_ms <= upper) is bisect_left.
-        # The +Inf sentinel guarantees the index is always in range. O(log b),
-        # in C, vs the previous O(b) Python scan -- this runs under the registry
-        # lock on every store.search().
-        self._bucket_counts[bisect.bisect_left(self._buckets_upper, value_ms)] += 1
+        # Buckets are sorted ascending, so the first upper bound >= value_ms
+        # (i.e. value_ms <= upper) is bisect_left -- O(log b) in C vs the previous
+        # O(b) Python scan, which runs under the registry lock on every
+        # store.search(). The default buckets end with +Inf so the index is
+        # always in range; the guard preserves the old loop's fall-through for a
+        # custom buckets_ms without an +Inf sentinel (value above all bounds is
+        # counted in sum/count but increments no bucket).
+        idx = bisect.bisect_left(self._buckets_upper, value_ms)
+        if idx < len(self._bucket_counts):
+            self._bucket_counts[idx] += 1
 
     def count(self) -> int:
         return self._count

--- a/vstash/metrics.py
+++ b/vstash/metrics.py
@@ -19,6 +19,7 @@ Design:
 
 from __future__ import annotations
 
+import bisect
 import threading
 import time
 from collections import defaultdict
@@ -108,10 +109,12 @@ class Histogram:
         """
         self._sum += value_ms
         self._count += 1
-        for i, upper in enumerate(self._buckets_upper):
-            if value_ms <= upper:
-                self._bucket_counts[i] += 1
-                return
+        # Buckets are sorted ascending with a final +Inf, so the index of the
+        # first upper bound >= value_ms (i.e. value_ms <= upper) is bisect_left.
+        # The +Inf sentinel guarantees the index is always in range. O(log b),
+        # in C, vs the previous O(b) Python scan -- this runs under the registry
+        # lock on every store.search().
+        self._bucket_counts[bisect.bisect_left(self._buckets_upper, value_ms)] += 1
 
     def count(self) -> int:
         return self._count

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -1600,10 +1600,13 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 "INSERT INTO search_stats (spread, created_at) VALUES (?, ?)",
                 [spread, now_iso],
             )
-            # Prune to keep only the last 50 entries
+            # Prune to keep only the last 50 entries. A range delete below the
+            # 50th-newest id (an index scan + MIN) is far cheaper than
+            # `NOT IN (subquery)`, which materialises the keep-set and tests
+            # every row -- this runs on every search.
             self._conn.execute(
-                "DELETE FROM search_stats WHERE id NOT IN "
-                "(SELECT id FROM search_stats ORDER BY id DESC LIMIT 50)"
+                "DELETE FROM search_stats WHERE id < "
+                "(SELECT MIN(id) FROM (SELECT id FROM search_stats ORDER BY id DESC LIMIT 50))"
             )
             self._conn.commit()
 
@@ -1669,10 +1672,12 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 "VALUES (?, ?, ?, ?, 0, ?, ?)",
                 [query, best_distance, relevance_tier, result_count, now_iso, hint_json],
             )
-            # Prune to keep only the last 1000 entries
+            # Prune to keep only the last 1000 entries (cheap range delete; see
+            # record_spread). `NOT IN (subquery)` re-tested every row on every
+            # search.
             self._conn.execute(
-                "DELETE FROM search_events WHERE id NOT IN "
-                "(SELECT id FROM search_events ORDER BY id DESC LIMIT 1000)"
+                "DELETE FROM search_events WHERE id < "
+                "(SELECT MIN(id) FROM (SELECT id FROM search_events ORDER BY id DESC LIMIT 1000))"
             )
             self._conn.commit()
             return cursor.lastrowid  # type: ignore[return-value]


### PR DESCRIPTION
First batch from the class-by-class review — two **behavior-preserving** hot-path wins (verified equivalent, ranking-neutral).

## Changes
- **Telemetry prune** ([store/__init__.py:1603,1672](vstash/store/__init__.py#L1672)): `record_search_event`/`record_spread` pruned with `DELETE ... WHERE id NOT IN (SELECT id ORDER BY id DESC LIMIT N)` on **every search** — a full anti-join. Now a **range delete** below the Nth-newest id (index scan + bounded range delete). Same sliding-window semantics.
- **Histogram bucketing** ([metrics.py:103](vstash/metrics.py#L103)): `observe` walked the 13 sorted buckets linearly **under the registry lock on every search**. Now `bisect_left` (O(log b), in C); the `+Inf` sentinel guarantees an in-range index. Identical assignment.

## Tests
Equivalence tests pin the preserved behavior (boundary bucketing matches the old `<=` scan; the cap keeps the newest 50, drops the oldest). `pytest tests/` → **1318 passed**; ruff clean.

## Deferred from the review (reasons)
- **MMR `math.hypot(*emb)` → `sqrt(dot)`**: touches the eval-gated `_mmr_dedup` (#363) and isn't bit-identical in float → could shift a near-tie; needs the BEIR gate, not worth it here.
- **snapshot formatting outside the registry lock**: more involved for a benefit that only appears under heavy concurrent scrape+search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for histogram observation at exact bucket boundaries, ensuring accurate value distribution tracking.
  * Enhanced spread recording instrumentation tests with validation of data retention limits and pruning behavior.

* **Refactor**
  * Optimized histogram bucket lookup mechanism for faster observation processing.
  * Improved telemetry data pruning operations for more efficient storage management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->