### PR TITLE
docs+cleanup: correct reindex isolation comment; drop redundant import

### DIFF
--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -439,8 +439,6 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
         if not documents:
             return []
 
-        from ..validation import validate_document_input
-
         doc_ids: list[str] = []
 
         with self._write_lock:
@@ -1909,11 +1907,14 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             try:
                 # Wrap the DROP/CREATE/INSERT in one explicit transaction so a
                 # failure mid-reindex rolls back to the original vec_chunks
-                # instead of an empty one. The connection runs in autocommit
-                # (isolation_level=None), so without this BEGIN the DROP TABLE
-                # would commit on its own and rollback() below could not undo
-                # it -- silently wiping the entire vector index. Mirrors every
-                # other write path in this module.
+                # instead of an empty one. The connection uses the stdlib default
+                # (deferred) isolation -- NOT autocommit -- where on Python
+                # 3.10/3.11 a bare DROP TABLE commits any open transaction first
+                # (legacy DDL-implicit-commit), so the rollback() below could not
+                # undo it and the vector index would be silently wiped. The
+                # explicit BEGIN IMMEDIATE makes the whole reindex atomic; it is
+                # safe because every write path commits before the next BEGIN, so
+                # in_transaction is False here. Mirrors every other write path.
                 self._conn.execute("BEGIN IMMEDIATE")
 
                 # Drop and recreate vec_chunks with new dimensions


### PR DESCRIPTION
Two small, **behavior-neutral** items from the class-by-class review.

## C1 — correct the misleading `isolation_level` comment
The reindex `BEGIN IMMEDIATE` comment (from #403) claimed the connection "runs in autocommit (`isolation_level=None`)". That's **false** — `_connect` calls `sqlite3.connect(...)` with no `isolation_level`, i.e. the stdlib default (**deferred**). The `BEGIN IMMEDIATE` is still correct and necessary (on 3.10/3.11 a bare `DROP TABLE` commits first via legacy DDL-implicit-commit, defeating rollback), so only the comment was wrong. Corrected to describe deferred mode + why the explicit BEGIN is safe.

> **Recommendation:** switching `_connect` to `isolation_level=None` (true autocommit) is the cleaner long-term model — it removes the latent "implicit transaction open at BEGIN" hazard the review flagged — but it's a connection-wide change (`executescript` + telemetry-insert atomicity) that deserves its **own focused PR** with verification. Tracked, not done here.

## S6 — redundant import
`add_documents_batch` re-imported `validate_document_input` locally despite the module-level import; removed.

`pytest tests/` → **1319 passed**; ruff clean.