### PR TITLE
fix(store): run the DB connection in autocommit + explicit BEGIN IMMEDIATE

### DIFF
--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -252,6 +252,16 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             conn = sqlite_vec.Connection(str(self.db_path))
             conn.row_factory = sqlite3.Row
 
+        # Autocommit mode (isolation_level=None): the driver no longer opens
+        # an implicit transaction before DML, so every write path manages
+        # atomicity explicitly with ``BEGIN IMMEDIATE`` ... ``COMMIT`` /
+        # ``ROLLBACK``. This removes the latent hazard where a prior
+        # implicit transaction left open by the legacy deferred driver made
+        # a subsequent ``BEGIN IMMEDIATE`` raise "cannot start a transaction
+        # within a transaction". Set as an attribute so it applies to both
+        # the standard connection and the sqlite_vec.Connection fallback.
+        conn.isolation_level = None
+
         # WAL mode — safe concurrent reads + single writer
         conn.execute("PRAGMA journal_mode=WAL")
         conn.execute("PRAGMA synchronous=NORMAL")
@@ -1594,19 +1604,28 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
         """
         now_iso = datetime.now(timezone.utc).isoformat()
         with self._write_lock:
-            self._conn.execute(
-                "INSERT INTO search_stats (spread, created_at) VALUES (?, ?)",
-                [spread, now_iso],
-            )
-            # Prune to keep only the last 50 entries. A range delete below the
-            # 50th-newest id (an index scan + MIN) is far cheaper than
-            # `NOT IN (subquery)`, which materialises the keep-set and tests
-            # every row -- this runs on every search.
-            self._conn.execute(
-                "DELETE FROM search_stats WHERE id < "
-                "(SELECT MIN(id) FROM (SELECT id FROM search_stats ORDER BY id DESC LIMIT 50))"
-            )
-            self._conn.commit()
+            try:
+                # Autocommit mode: the INSERT + prune DELETE need an explicit
+                # transaction so a failure between them can't leave the new
+                # row uncapped (in deferred mode the implicit transaction
+                # used to batch them).
+                self._conn.execute("BEGIN IMMEDIATE")
+                self._conn.execute(
+                    "INSERT INTO search_stats (spread, created_at) VALUES (?, ?)",
+                    [spread, now_iso],
+                )
+                # Prune to keep only the last 50 entries. A range delete below
+                # the 50th-newest id (an index scan + MIN) is far cheaper than
+                # `NOT IN (subquery)`, which materialises the keep-set and tests
+                # every row -- this runs on every search.
+                self._conn.execute(
+                    "DELETE FROM search_stats WHERE id < "
+                    "(SELECT MIN(id) FROM (SELECT id FROM search_stats ORDER BY id DESC LIMIT 50))"
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
 
     def adaptive_relevance_threshold(self, fallback: float = 0.15) -> float:
         """Compute a per-corpus adaptive relevance threshold.
@@ -1664,20 +1683,28 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
         now_iso = datetime.now(timezone.utc).isoformat()
         hint_json = json.dumps(miss_hint) if miss_hint is not None else None
         with self._write_lock:
-            cursor = self._conn.execute(
-                "INSERT INTO search_events (query, best_distance, relevance_tier, "
-                "result_count, dismissed, created_at, miss_hint) "
-                "VALUES (?, ?, ?, ?, 0, ?, ?)",
-                [query, best_distance, relevance_tier, result_count, now_iso, hint_json],
-            )
-            # Prune to keep only the last 1000 entries (cheap range delete; see
-            # record_spread). `NOT IN (subquery)` re-tested every row on every
-            # search.
-            self._conn.execute(
-                "DELETE FROM search_events WHERE id < "
-                "(SELECT MIN(id) FROM (SELECT id FROM search_events ORDER BY id DESC LIMIT 1000))"
-            )
-            self._conn.commit()
+            try:
+                # Autocommit mode: keep the INSERT + prune DELETE in one
+                # explicit transaction (in deferred mode the implicit
+                # transaction batched them; see record_spread).
+                self._conn.execute("BEGIN IMMEDIATE")
+                cursor = self._conn.execute(
+                    "INSERT INTO search_events (query, best_distance, relevance_tier, "
+                    "result_count, dismissed, created_at, miss_hint) "
+                    "VALUES (?, ?, ?, ?, 0, ?, ?)",
+                    [query, best_distance, relevance_tier, result_count, now_iso, hint_json],
+                )
+                # Prune to keep only the last 1000 entries (cheap range delete;
+                # see record_spread). `NOT IN (subquery)` re-tested every row on
+                # every search.
+                self._conn.execute(
+                    "DELETE FROM search_events WHERE id < "
+                    "(SELECT MIN(id) FROM (SELECT id FROM search_events ORDER BY id DESC LIMIT 1000))"
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
             return cursor.lastrowid  # type: ignore[return-value]
 
     def recent_miss_hints(self, limit: int = 10) -> list[dict]:
@@ -1907,14 +1934,13 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             try:
                 # Wrap the DROP/CREATE/INSERT in one explicit transaction so a
                 # failure mid-reindex rolls back to the original vec_chunks
-                # instead of an empty one. The connection uses the stdlib default
-                # (deferred) isolation -- NOT autocommit -- where on Python
-                # 3.10/3.11 a bare DROP TABLE commits any open transaction first
-                # (legacy DDL-implicit-commit), so the rollback() below could not
-                # undo it and the vector index would be silently wiped. The
-                # explicit BEGIN IMMEDIATE makes the whole reindex atomic; it is
-                # safe because every write path commits before the next BEGIN, so
-                # in_transaction is False here. Mirrors every other write path.
+                # instead of an empty one. The connection runs in autocommit
+                # mode (isolation_level=None), so no implicit transaction is
+                # ever open here and BEGIN IMMEDIATE always starts cleanly --
+                # without the explicit BEGIN a bare DROP TABLE would autocommit
+                # on the spot and the rollback() below could not undo it,
+                # silently wiping the vector index. Mirrors every other write
+                # path.
                 self._conn.execute("BEGIN IMMEDIATE")
 
                 # Drop and recreate vec_chunks with new dimensions

--- a/vstash/store/_integrity.py
+++ b/vstash/store/_integrity.py
@@ -210,11 +210,11 @@ class _IntegrityMixin:
         check_by_name = {c.name: c for c in checks}
 
         with self._write_lock:
-            # The fts_index_parity probe inside integrity_check() is a
-            # DML statement (``INSERT INTO fts(fts) VALUES(...)``), so
-            # the stdlib sqlite3 driver opens an implicit transaction
-            # for it.  Commit any pending state before BEGIN IMMEDIATE
-            # so the explicit transaction below isn't preempted.
+            # Under autocommit (isolation_level=None) the fts_index_parity
+            # probe inside integrity_check() autocommits on the spot, so no
+            # transaction should be open here. The guard stays defensive: if
+            # any caller left one open, commit it before BEGIN IMMEDIATE so
+            # the explicit transaction below isn't preempted.
             if self._conn.in_transaction:
                 self._conn.commit()
             try:

--- a/vstash/store/_schema.py
+++ b/vstash/store/_schema.py
@@ -186,15 +186,24 @@ class _SchemaManagerMixin:
             existing = stored_version
 
         now_iso = datetime.now(timezone.utc).isoformat()
-        conn.execute(
-            "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
-            ["schema_version", existing, now_iso],
-        )
-        conn.execute(
-            "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
-            ["vstash_version", _vstash_version, now_iso],
-        )
-        conn.commit()
+        # Autocommit mode: stamp both meta rows in one explicit transaction so
+        # a failure between them can't leave schema_version written without the
+        # matching vstash_version (in deferred mode the implicit transaction
+        # batched the pair).
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
+                ["schema_version", existing, now_iso],
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
+                ["vstash_version", _vstash_version, now_iso],
+            )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
 
         if existing not in KNOWN_SCHEMA_VERSIONS:
             msg = (
@@ -361,10 +370,19 @@ class _SchemaManagerMixin:
         if "created_at" not in chunk_columns:
             migrations.append("ALTER TABLE chunks ADD COLUMN created_at TEXT")
 
-        for sql in migrations:
-            conn.execute(sql)
+        # Autocommit mode: run the ALTER TABLE batch in one explicit
+        # transaction so a failure partway through doesn't leave the schema
+        # half-migrated (in deferred mode the implicit transaction grouped
+        # them).
         if migrations:
-            conn.commit()
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                for sql in migrations:
+                    conn.execute(sql)
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
 
         # Backfill created_at from parent document's added_at
         if "created_at" not in chunk_columns:


### PR DESCRIPTION
## What

Switch the SQLite connection in `_connect` to `isolation_level=None` (true autocommit). The stdlib deferred driver used to open an implicit transaction before DML, so a prior open transaction could make a subsequent `BEGIN IMMEDIATE` raise *"cannot start a transaction within a transaction"* — the latent hazard several write paths already worked around defensively (`integrity_repair`'s pre-`BEGIN` commit guard, the `reindex` comment, etc.).

## Why

Removes the implicit-transaction footgun connection-wide. With autocommit, `BEGIN IMMEDIATE` always starts cleanly (`in_transaction` is reliably `False` between writes), and atomicity becomes explicit instead of relying on the driver's legacy implicit-transaction behaviour.

## How

Audited every `.commit()` in the `store/` package and classified each write path. The paths already wrapped in explicit `BEGIN IMMEDIATE … COMMIT/ROLLBACK` (`add_document`, `add_documents_batch`, `delete_*`, `update_metadata`, `prune_documents`, `_flush_deferred_fts`, `reindex`, `_migrate_v1_to_v2`, `integrity_repair`) are unaffected — they work identically and get safer.

Four paths relied on the **implicit** transaction to batch multiple statements atomically and needed explicit transactions added:

- `_check_schema_version` — the `schema_version` + `vstash_version` meta pair
- `_migrate_schema` — the `ALTER TABLE` batch on legacy DBs
- `record_spread` — `INSERT` + prune `DELETE` (per-search hot path)
- `record_search_event` — `INSERT` + prune `DELETE` (per-search hot path)

Also refreshed the now-stale deferred-isolation comments in `reindex` and `integrity_repair` (the `in_transaction` commit guard stays, now documented as defensive).

## Verification

- `ruff check` + `ruff format --check` clean
- Full suite: **1319 passed**, 6 deselected (benchmark markers)
- 8-thread write-path concurrency probe: 0 errors, telemetry caps held exactly (50 / 1000), `integrity_check` clean, `isolation_level is None` confirmed
- Legacy-schema `ALTER` migration probe: missing columns added + `created_at` backfill correct under the new explicit transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database transaction handling to ensure atomic updates to metadata and schema migrations
  * Improved telemetry data persistence reliability
  * Better protection against data inconsistencies during concurrent operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->