### PR TITLE
fix(memory): make the content-update path atomic via add_documents_batch

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -630,6 +630,51 @@ class TestMemoryUpdate:
             )
             assert {d.collection for d in after} == {"default", "research"}
 
+    @requires_sqlite_vec
+    def test_update_text_failure_rolls_back_all_collections(self, tmp_path: Path) -> None:
+        """A failure while re-adding any collection's copy must roll the
+        WHOLE content update back. The old delete-then-add-loop left a
+        torn state here: the doc was already deleted (and possibly
+        re-added into collection 1) when collection 2's add failed.
+        Now the replace runs in one ``add_documents_batch`` transaction."""
+        doc = tmp_path / "shared.md"
+        doc.write_text("Original aardvark content shared by the two collections.")
+        db = tmp_path / "test.db"
+        with Memory(db=db, collection="default") as mem:
+            mem.add(doc, collection="default")
+            mem.add(doc, collection="research")
+            resolved = str(doc.resolve())
+
+            from vstash.validation import validate_document_input as real_validate
+
+            calls = {"n": 0}
+
+            def fail_on_second(*args: object, **kwargs: object) -> None:
+                calls["n"] += 1
+                if calls["n"] >= 2:
+                    raise RuntimeError("boom: simulated failure on the 2nd collection")
+                real_validate(*args, **kwargs)
+
+            with patch("vstash.store.validate_document_input", side_effect=fail_on_second):
+                with pytest.raises(RuntimeError, match="boom"):
+                    mem.update(
+                        doc,
+                        text="Replacement zebra content that must NOT survive.",
+                        collection=None,
+                    )
+
+            # Both original copies must survive, with the ORIGINAL content.
+            after = [d for d in mem.list(collection=None) if d.path == resolved]
+            assert len(after) == 2, (
+                f"failed update tore the store: {[(d.collection, d.title) for d in after]}"
+            )
+            assert {d.collection for d in after} == {"default", "research"}
+            assert any("aardvark" in r.text.lower() for r in mem.search("aardvark original"))
+            for hit in mem.search("zebra replacement"):
+                assert "zebra" not in hit.text.lower(), (
+                    f"half-committed update leaked new content: {hit.text!r}"
+                )
+
 
 class TestMemoryPruneAndCompact:
     """Test Memory.prune and Memory.compact."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -669,10 +669,24 @@ class TestMemoryUpdate:
                 f"failed update tore the store: {[(d.collection, d.title) for d in after]}"
             )
             assert {d.collection for d in after} == {"default", "research"}
-            assert any("aardvark" in r.text.lower() for r in mem.search("aardvark original"))
-            for hit in mem.search("zebra replacement"):
-                assert "zebra" not in hit.text.lower(), (
-                    f"half-committed update leaked new content: {hit.text!r}"
+            # Assert against the stored chunks per collection (not via
+            # search, whose ranking/dedup could mask a half-commit
+            # limited to one collection).
+            for coll in ("default", "research"):
+                texts = [
+                    row[0]
+                    for row in mem._store._conn.execute(
+                        "SELECT c.text FROM chunks c JOIN documents d ON c.doc_id = d.id "
+                        "WHERE d.path = ? AND d.collection = ?",
+                        [resolved, coll],
+                    ).fetchall()
+                ]
+                assert texts, f"collection {coll!r} lost its chunks"
+                assert all("aardvark" in t.lower() for t in texts), (
+                    f"collection {coll!r} lost the original content: {texts!r}"
+                )
+                assert all("zebra" not in t.lower() for t in texts), (
+                    f"half-committed update leaked new content into {coll!r}: {texts!r}"
                 )
 
 

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -971,26 +971,31 @@ class Memory:
             }
         new_embeddings = embed_texts(new_chunks, self._cfg.embeddings.model)
 
-        # Delete-then-add, scoped to the same set of collections we
+        # Replace-in-place, scoped to the same set of collections we
         # just listed. Re-add into *each* existing collection so a
         # multi-collection update does not silently collapse the doc
-        # into a single collection. Not strictly atomic (the doc is
-        # briefly missing between the two steps), but the same window
-        # already exists in the ``force=True`` re-ingest path used by
-        # ``add()`` and the watch worker.
-        self._store.delete_document(source_str, collection=col)
-        for existing in existing_docs:
-            self._store.add_document(
-                path=source_str,
-                title=title if title is not None else existing.title,
-                chunks=new_chunks,
-                embeddings=new_embeddings,
-                source_type=existing.source_type,
-                collection=existing.collection,
-                project=existing.project,
-                layer=existing.layer,
-                tags=tags if tags is not None else existing.tags,
-            )
+        # into a single collection. ``add_documents_batch`` replaces
+        # each (collection, path) copy inside ONE transaction (its
+        # per-doc ``_delete_by_doc_id`` covers exactly the rows the
+        # listing above matched), so a failure on any collection rolls
+        # the whole update back -- no window where the document is
+        # missing or replaced in one collection but not another.
+        self._store.add_documents_batch(
+            [
+                {
+                    "path": source_str,
+                    "title": title if title is not None else existing.title,
+                    "chunks": new_chunks,
+                    "embeddings": new_embeddings,
+                    "source_type": existing.source_type,
+                    "collection": existing.collection,
+                    "project": existing.project,
+                    "layer": existing.layer,
+                    "tags": tags if tags is not None else existing.tags,
+                }
+                for existing in existing_docs
+            ]
+        )
         fields = [k for k, v in (("text", text), ("title", title), ("tags", tags)) if v is not None]
         return {
             "status": "updated",


### PR DESCRIPTION
## Summary

`Memory.update(text=...)` used `delete_document` + a per-collection `add_document` loop. A failure while re-adding any collection's copy left the store **torn**: the document already deleted everywhere (and possibly re-added into the first collection) with no way back. The old comment acknowledged the window ("Not strictly atomic").

`add_documents_batch` already replaces each `(collection, path)` copy via `_delete_by_doc_id` inside ONE `BEGIN IMMEDIATE` transaction, so the delete-then-loop collapses into a single batch call:

- a failure on **any** collection rolls the whole update back (prior content survives untouched, snapvec reloaded via the existing rollback path)
- the per-doc replace covers exactly the rows the listing matched, so the explicit upfront `delete_document` was redundant
- no window where the doc is missing or replaced in one collection but not another

## Verification

- New regression test `test_update_text_failure_rolls_back_all_collections`: simulates a failure on the 2nd collection's re-add, asserts both copies survive with the original content. **Fails against the previous implementation** (verified by reverting `memory.py`).
- Full `tests/test_memory.py` (59) green; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved document update reliability when updating across multiple collections—updates now complete atomically and prevent partial replacements if an error occurs during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->