### PR TITLE
fix(embed): don't cache transient HF ONNX init failures + lock backend resolution

### DIFF
--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -97,3 +97,76 @@ class TestHFOnnxUnavailableConcurrency:
             assert 1 <= init_calls <= n_threads
         finally:
             embed_mod._hf_onnx_unavailable.discard("broken/model")
+
+
+class TestHFOnnxTransientFailures:
+    """A transient init failure (network down, cold cache) must NOT
+    permanently downgrade the model to the SentenceTransformer path;
+    only structural failures (broken export, missing repo entry) may
+    poison ``_hf_onnx_unavailable`` for the process."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_marker(self):
+        import vstash.embed as embed_mod
+
+        embed_mod._hf_onnx_unavailable.discard("some/model")
+        yield
+        embed_mod._hf_onnx_unavailable.discard("some/model")
+
+    def _embed_with_failing_init(self, monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+        import vstash.embed as embed_mod
+
+        def fail_init(model_name: str) -> tuple:
+            raise exc
+
+        monkeypatch.setattr(embed_mod, "_init_hf_onnx", fail_init)
+        monkeypatch.setattr(
+            embed_mod,
+            "_embed_hf_st",
+            lambda texts, model_name: [[0.0] for _ in texts],
+        )
+        embed_mod._embed_hf_onnx(["hello"], "some/model")
+
+    def test_transient_network_error_not_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import vstash.embed as embed_mod
+
+        self._embed_with_failing_init(monkeypatch, ConnectionError("connection reset"))
+        assert "some/model" not in embed_mod._hf_onnx_unavailable, (
+            "a transient network failure must not permanently downgrade the model"
+        )
+
+    def test_offline_cold_cache_not_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import vstash.embed as embed_mod
+
+        hub_errors = pytest.importorskip("huggingface_hub.errors")
+        self._embed_with_failing_init(
+            monkeypatch,
+            hub_errors.LocalEntryNotFoundError("offline and not in cache"),
+        )
+        assert "some/model" not in embed_mod._hf_onnx_unavailable
+
+    def test_structural_error_is_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import vstash.embed as embed_mod
+
+        self._embed_with_failing_init(monkeypatch, RuntimeError("broken ONNX export"))
+        assert "some/model" in embed_mod._hf_onnx_unavailable
+
+    def test_classifier_direct(self) -> None:
+        from vstash.embed import _hf_onnx_failure_is_permanent
+
+        # Transient: plain OSError family (requests errors subclass it).
+        assert _hf_onnx_failure_is_permanent(ConnectionError("reset")) is False
+        assert _hf_onnx_failure_is_permanent(TimeoutError("timed out")) is False
+        assert _hf_onnx_failure_is_permanent(OSError("disk hiccup")) is False
+        # Structural: anything raised constructing session/tokenizer.
+        assert _hf_onnx_failure_is_permanent(RuntimeError("bad protobuf")) is True
+        assert _hf_onnx_failure_is_permanent(ValueError("bad tokenizer json")) is True
+
+    def test_classifier_hub_errors(self) -> None:
+        hub_errors = pytest.importorskip("huggingface_hub.errors")
+
+        from vstash.embed import _hf_onnx_failure_is_permanent
+
+        # Offline cold-cache miss is transient even though it subclasses
+        # EntryNotFoundError.
+        assert _hf_onnx_failure_is_permanent(hub_errors.LocalEntryNotFoundError("offline")) is False

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -170,3 +170,25 @@ class TestHFOnnxTransientFailures:
         # Offline cold-cache miss is transient even though it subclasses
         # EntryNotFoundError.
         assert _hf_onnx_failure_is_permanent(hub_errors.LocalEntryNotFoundError("offline")) is False
+        # Permanent hub failures: these subclass HfHubHTTPError (and
+        # through requests, OSError), so they must win over the broad
+        # transient OSError bucket. Some of them require a response
+        # object to construct.
+        import requests
+
+        resp = requests.Response()
+        resp.status_code = 404
+        assert _hf_onnx_failure_is_permanent(hub_errors.EntryNotFoundError("no such file")) is True
+        assert (
+            _hf_onnx_failure_is_permanent(
+                hub_errors.RepositoryNotFoundError("no repo", response=resp)
+            )
+            is True
+        )
+        assert (
+            _hf_onnx_failure_is_permanent(hub_errors.GatedRepoError("gated", response=resp)) is True
+        )
+        assert (
+            _hf_onnx_failure_is_permanent(hub_errors.RevisionNotFoundError("no rev", response=resp))
+            is True
+        )

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -602,6 +602,7 @@ def _hf_onnx_failure_is_permanent(exc: BaseException) -> bool:
             EntryNotFoundError,
             LocalEntryNotFoundError,
             RepositoryNotFoundError,
+            RevisionNotFoundError,
         )
     except ImportError:
         return True
@@ -609,7 +610,12 @@ def _hf_onnx_failure_is_permanent(exc: BaseException) -> bool:
     # canonical *transient* case -- test it first.
     if isinstance(exc, LocalEntryNotFoundError):
         return False
-    if isinstance(exc, (EntryNotFoundError, RepositoryNotFoundError)):
+    # These subclass HfHubHTTPError (and through requests, OSError), so
+    # they must be classified BEFORE the broad OSError bucket below: a
+    # repo/revision/entry that doesn't resolve won't fix itself by
+    # retrying, and neither will gated access (GatedRepoError
+    # subclasses RepositoryNotFoundError).
+    if isinstance(exc, (EntryNotFoundError, RepositoryNotFoundError, RevisionNotFoundError)):
         return True
     # requests' ConnectionError / Timeout / HTTPError all subclass
     # OSError, as does anything filesystem-transient.  The permanent

--- a/vstash/embed.py
+++ b/vstash/embed.py
@@ -586,6 +586,39 @@ def _embed_hf_st(texts: list[str], model_name: str) -> list[list[float]]:
     return [list(map(float, v)) for v in vecs]
 
 
+def _hf_onnx_failure_is_permanent(exc: BaseException) -> bool:
+    """Classify an ``_init_hf_onnx`` failure as structural or transient.
+
+    Only structural failures (the repo genuinely lacks the artifact, or
+    the downloaded export itself is broken -- e.g. a ``model.onnx`` stub
+    whose external data file was never uploaded) may mark the model in
+    ``_hf_onnx_unavailable`` for the rest of the process.  Network-ish
+    failures (offline with a cold cache, connection reset, HTTP 5xx)
+    must NOT: the next call retries ONNX once the network recovers
+    instead of silently paying the SentenceTransformer path forever.
+    """
+    try:
+        from huggingface_hub.errors import (
+            EntryNotFoundError,
+            LocalEntryNotFoundError,
+            RepositoryNotFoundError,
+        )
+    except ImportError:
+        return True
+    # Offline / cold-cache miss subclasses EntryNotFoundError but is the
+    # canonical *transient* case -- test it first.
+    if isinstance(exc, LocalEntryNotFoundError):
+        return False
+    if isinstance(exc, (EntryNotFoundError, RepositoryNotFoundError)):
+        return True
+    # requests' ConnectionError / Timeout / HTTPError all subclass
+    # OSError, as does anything filesystem-transient.  The permanent
+    # HTTP cases (missing repo/entry, gated) were caught above.
+    # Anything else came from constructing the session/tokenizer out of
+    # already-downloaded files: structural.
+    return not isinstance(exc, OSError)
+
+
 def _embed_hf_onnx(texts: list[str], model_name: str) -> list[list[float]]:
     """Embed texts using a custom HF ONNX model with mean pooling.
 
@@ -604,12 +637,15 @@ def _embed_hf_onnx(texts: list[str], model_name: str) -> list[list[float]]:
     try:
         session, tokenizer, max_len = _init_hf_onnx(model_name)
     except Exception as exc:  # includes onnxruntime RuntimeException
+        permanent = _hf_onnx_failure_is_permanent(exc)
         _logger.warning(
-            "HF ONNX init failed for %s (%s); falling back to sentence-transformers.",
+            "HF ONNX init failed for %s (%s); falling back to sentence-transformers%s.",
             model_name,
             exc.__class__.__name__,
+            " for this process" if permanent else "; will retry ONNX on the next call",
         )
-        _hf_onnx_unavailable.add(model_name)
+        if permanent:
+            _hf_onnx_unavailable.add(model_name)
         return _embed_hf_st(texts, model_name)
     all_embeddings: list[list[float]] = []
     batch_size = 32
@@ -744,13 +780,23 @@ def _warmup_mlx(model_name: str) -> None:
 
 # Active backend — set once by warmup() or first call
 _active_backend: Literal["onnx", "mlx"] | None = None
+_active_backend_lock = threading.Lock()
 
 
 def _resolve(backend: BackendType = "auto") -> Literal["onnx", "mlx"]:
-    """Resolve and cache the active backend."""
+    """Resolve and cache the active backend.
+
+    Double-checked locking: concurrent first callers must not both run
+    ``resolve_backend`` (it probes optional imports like mlx and the
+    last writer would win, so two callers passing different ``backend``
+    hints could observe different resolutions for the same process).
+    The fast path stays lock-free once the backend is pinned.
+    """
     global _active_backend
     if _active_backend is None:
-        _active_backend = resolve_backend(backend)
+        with _active_backend_lock:
+            if _active_backend is None:
+                _active_backend = resolve_backend(backend)
     return _active_backend
 
 


### PR DESCRIPTION
## Summary

Two embed-module correctness fixes:

**1. Transient HF ONNX init failures were cached as permanent.** `_embed_hf_onnx` added the model to `_hf_onnx_unavailable` on ANY exception, so a network hiccup / cold HF cache / HTTP 5xx permanently downgraded the model to the slower SentenceTransformer path for the rest of the process. New `_hf_onnx_failure_is_permanent` classifier:

- **Transient (retry next call):** `LocalEntryNotFoundError` (offline + cold cache — tested first since it subclasses `EntryNotFoundError`), and the `OSError` family (requests' `ConnectionError`/`Timeout`/`HTTPError` all subclass it)
- **Permanent (cache the downgrade):** `EntryNotFoundError`/`RepositoryNotFoundError` (repo genuinely lacks the artifact) and anything raised constructing the session/tokenizer from already-downloaded files (e.g. the broken `model.onnx` stub that motivated the fallback)

**2. `_resolve` backend-init race.** The global `_active_backend` was set via unlocked check-then-set; concurrent first callers could both run `resolve_backend` (probes optional imports like mlx) with last-writer-wins. Now double-checked locking; the fast path stays lock-free.

## Verification

- New tests: transient `ConnectionError` / `LocalEntryNotFoundError` do NOT poison the marker (both **fail against the previous implementation**, verified by reverting), structural `RuntimeError` still does, plus direct classifier unit tests.
- The existing `TestHFOnnxUnavailableConcurrency` contract test is unchanged and passes.
- `test_embed` + `test_embed_daemon` + `test_builtin_backend_registry` + `test_encoder_resolver` (69) green; ruff clean.