### PR TITLE
fix(ivfpq): dim-check on load + don't downgrade a fitted index on a transient COUNT error

### DIFF
--- a/tests/test_snapvec_ivfpq_backend.py
+++ b/tests/test_snapvec_ivfpq_backend.py
@@ -93,6 +93,29 @@ class TestIVFPQBackendWrapper:
         with pytest.raises(ValueError, match="must divide embedding_dim"):
             IVFPQBackend(dim=384, nlist=16, M=10, K=32)  # 384 % 10 != 0
 
+    def test_load_dim_mismatch_starts_unfitted(self, tmp_path, caplog):
+        """A persisted index whose dim no longer matches the store's
+        (embedding model changed since the last fit) must NOT be
+        adopted -- searching it would feed mismatched-dim queries into
+        the quantizer. load() starts unfitted instead and warns."""
+        import logging
+
+        rng = np.random.default_rng(9)
+        vecs = _unit_vectors(rng, N, DIM)
+        path = str(tmp_path / "idx.snpi")
+        be = IVFPQBackend(dim=DIM, nlist=16, M=24, K=32, rerank_candidates=32)
+        be.fit(vecs)
+        be.add_batch(list(range(N)), vecs)
+        be.save(path)
+
+        with caplog.at_level(logging.WARNING, logger="vstash.vectorbackend"):
+            loaded = IVFPQBackend.load(path, dim=DIM * 2, nlist=16, M=24, K=32)
+        assert not loaded.fitted
+        assert len(loaded) == 0
+        assert any("dim" in r.message for r in caplog.records), (
+            f"dim-mismatch warning not emitted; got: {[r.message for r in caplog.records]}"
+        )
+
 
 class TestVstashStoreIVFPQIntegration:
     def test_backend_initialization(self, tmp_path):
@@ -444,3 +467,82 @@ class TestVstashStoreIVFPQIntegration:
         assert not store3._snap.fitted
         assert len(store3._snap) == 0
         store3.close()
+
+    def test_transient_count_error_does_not_downgrade_fitted_index(self, tmp_path, caplog):
+        """The staleness probe failing (transient lock, vec0 hiccup)
+        says nothing about the index itself. Previously a sqlite3.Error
+        on the COUNT defaulted ``sqlite_n = 0``, which always mismatched
+        a fitted index and silently downgraded it -- costing the user a
+        ~50s refit for a hiccup. The probe failure must keep the fitted
+        index and warn instead."""
+        import logging
+        import sqlite3
+
+        db_path = str(tmp_path / "count_fail.db")
+
+        store1 = VstashStore(
+            db_path,
+            embedding_dim=DIM,
+            vector_backend="snapvec-ivfpq",
+            ivfpq_M=24,
+            ivfpq_K=32,
+            ivfpq_nlist=16,
+        )
+        rng = np.random.default_rng(13)
+        vecs = _unit_vectors(rng, N, DIM)
+        store1.add_document(
+            path="/t/bulk.md",
+            title="bulk",
+            chunks=[f"c{i}" for i in range(N)],
+            embeddings=vecs.tolist(),
+            source_type="text",
+        )
+        store1.fit_ivfpq(training_sample=N)
+        store1.close()
+
+        class _FailingCountConn:
+            """Delegating proxy that fails ONLY the staleness COUNT."""
+
+            def __init__(self, real: sqlite3.Connection) -> None:
+                object.__setattr__(self, "_real", real)
+
+            def execute(self, sql: str, *args, **kwargs):
+                if "COUNT(*) FROM vec_chunks" in sql:
+                    raise sqlite3.OperationalError("simulated transient failure")
+                return self._real.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(object.__getattribute__(self, "_real"), name)
+
+            def __setattr__(self, name, value):
+                setattr(object.__getattribute__(self, "_real"), name, value)
+
+        real_connect = VstashStore._connect
+
+        def connect_with_failing_count(self):
+            return _FailingCountConn(real_connect(self))
+
+        try:
+            VstashStore._connect = connect_with_failing_count
+            with caplog.at_level(logging.WARNING, logger="vstash.store"):
+                store2 = VstashStore(
+                    db_path,
+                    embedding_dim=DIM,
+                    vector_backend="snapvec-ivfpq",
+                    ivfpq_M=24,
+                    ivfpq_K=32,
+                    ivfpq_nlist=16,
+                )
+        finally:
+            VstashStore._connect = real_connect
+
+        try:
+            assert store2._snap.fitted, (
+                "a transient COUNT failure must not downgrade a fitted index"
+            )
+            assert len(store2._snap) == N
+            assert any("keeping the fitted index" in r.message for r in caplog.records), (
+                f"probe-failure warning not emitted; got: {[r.message for r in caplog.records]}"
+            )
+        finally:
+            store2.close()

--- a/vstash/store/_index.py
+++ b/vstash/store/_index.py
@@ -126,7 +126,18 @@ class _IndexBackendMixin:
             try:
                 sqlite_n = int(self._conn.execute("SELECT COUNT(*) FROM vec_chunks").fetchone()[0])
             except sqlite3.Error:
-                sqlite_n = 0
+                # The staleness probe itself failed (transient lock,
+                # vec0 hiccup) — that says nothing about the index, so
+                # do NOT downgrade a fitted index on it. A real parity
+                # problem will surface via integrity_check(); a real DB
+                # problem will surface loudly on first search.
+                logger.warning(
+                    "Could not verify IVFPQ staleness for %s (COUNT on "
+                    "vec_chunks failed); keeping the fitted index.",
+                    self._ivfpq_path,
+                    exc_info=True,
+                )
+                return
             snap_n = len(self._snap)
             if sqlite_n != snap_n:
                 logger.warning(

--- a/vstash/vectorbackend/snapvec_ivfpq.py
+++ b/vstash/vectorbackend/snapvec_ivfpq.py
@@ -198,15 +198,17 @@ class IVFPQBackend:
         )
         if Path(path).exists():
             loaded = IVFPQSnapIndex.load(path)
-            loaded_dim = getattr(loaded, "dim", None)
-            if loaded_dim is not None and int(loaded_dim) != dim:
+            # Direct attribute access on purpose: a corrupt index missing
+            # ``dim`` raises AttributeError, which the caller's
+            # failed-to-load handler turns into the unfitted fallback.
+            if int(loaded.dim) != dim:
                 logger.warning(
                     "IVFPQ index at %s was built for dim=%s but the store "
                     "needs dim=%d (embedding model changed?). Starting "
                     "unfitted; run 'vstash snapvec fit' to rebuild from "
                     "current vec_chunks.",
                     path,
-                    loaded_dim,
+                    loaded.dim,
                     dim,
                 )
                 return backend

--- a/vstash/vectorbackend/snapvec_ivfpq.py
+++ b/vstash/vectorbackend/snapvec_ivfpq.py
@@ -23,10 +23,13 @@ Lifecycle:
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class IVFPQBackend:
@@ -174,6 +177,12 @@ class IVFPQBackend:
         between an index file and a sidecar flag getting out of sync
         after a crash. Constructor validation (dim % M) still runs via
         the normal ``__init__`` path.
+
+        A persisted index whose dimension does not match ``dim`` (the
+        embedding model changed since the last ``snapvec fit``) is NOT
+        adopted: searching it would feed mismatched-dim queries into
+        the quantizer. The backend starts unfitted instead, so search
+        falls back to sqlite-vec until the user refits.
         """
         from snapvec import IVFPQSnapIndex
 
@@ -188,6 +197,19 @@ class IVFPQBackend:
             nprobe=nprobe,
         )
         if Path(path).exists():
-            backend._index = IVFPQSnapIndex.load(path)
+            loaded = IVFPQSnapIndex.load(path)
+            loaded_dim = getattr(loaded, "dim", None)
+            if loaded_dim is not None and int(loaded_dim) != dim:
+                logger.warning(
+                    "IVFPQ index at %s was built for dim=%s but the store "
+                    "needs dim=%d (embedding model changed?). Starting "
+                    "unfitted; run 'vstash snapvec fit' to rebuild from "
+                    "current vec_chunks.",
+                    path,
+                    loaded_dim,
+                    dim,
+                )
+                return backend
+            backend._index = loaded
             backend._fitted = True
         return backend


### PR DESCRIPTION
## Summary

Two robustness fixes on the IVFPQ open path:

**1. `IVFPQBackend.load` adopted any existing `.snpi` blindly.** If the embedding model changed since the last `vstash snapvec fit` (dim 384 → 768, say), searches would feed mismatched-dim queries into the quantizer. `load()` now compares the persisted index's `dim` with the requested one and starts unfitted on mismatch — search falls back to sqlite-vec until refit — with a warning naming both dims. (Consistent with the existing staleness-downgrade philosophy: never auto-refit on open, sqlite-vec is correct in the interim.)

**2. A transient `COUNT` failure silently downgraded a fitted index.** The staleness probe in `_init_ivfpq` defaulted `sqlite_n = 0` when the `COUNT(*) FROM vec_chunks` raised `sqlite3.Error`. Zero never matches a fitted index's count, so a transient lock or vec0 hiccup downgraded a healthy fitted index — costing the user a ~50s refit for nothing. A probe failure now keeps the fitted index and warns; a real parity problem still surfaces via `integrity_check()`, and a real DB problem surfaces loudly on first search.

## Verification

- New tests: `test_load_dim_mismatch_starts_unfitted` (wrapper level) and `test_transient_count_error_does_not_downgrade_fitted_index` (store open path, connection proxy failing only the staleness COUNT). **Both fail against the previous implementation** (verified by reverting).
- Both existing staleness-downgrade tests (#329 + the delete-side asymmetry) unchanged and green.
- `test_snapvec_ivfpq_backend` + `test_snapvec_backend` + `test_vectorbackend` (48) green; ruff clean.