### PR TITLE
fix(models): freeze all result models (protect the query LRU cache)

### DIFF
--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -51,6 +51,21 @@ class TestQueryCache:
         r2 = cached_store.search(q_emb, "python", top_k=2)
         assert r1 is not r2
 
+    def test_cache_hit_results_are_immutable(self, cached_store: VstashStore):
+        """The cache copies only the LIST on a hit; the SearchResult
+        instances inside are shared with the cached entry. They must be
+        frozen: a caller mutating ``r.score`` would otherwise silently
+        poison every later hit for that query."""
+        import pydantic
+
+        q_emb = [0.1] * cached_store.embedding_dim
+        r1 = cached_store.search(q_emb, "python", top_k=2)
+        original_score = r1[0].score
+        with pytest.raises(pydantic.ValidationError):
+            r1[0].score = 999.0
+        r2 = cached_store.search(q_emb, "python", top_k=2)
+        assert r2[0].score == original_score, "mutation leaked into the cached entry"
+
     def test_cache_miss_on_different_query(self, cached_store: VstashStore):
         dim = cached_store.embedding_dim
         r1 = cached_store.search([0.1] * dim, "python", top_k=2)

--- a/vstash/models.py
+++ b/vstash/models.py
@@ -4,17 +4,26 @@ models.py — Typed result models for vstash operations.
 All structured data flowing between modules uses Pydantic BaseModel
 instead of raw dicts. This ensures validation, type safety, and
 clear contracts between layers.
+
+All models are frozen (immutable). This is load-bearing for the v0.31
+query LRU cache, which returns the SAME SearchResult instances on a
+cache hit: a caller mutating ``r.score`` would otherwise silently
+poison every later hit for that query. Use
+``result.model_copy(update={...})`` to derive a modified instance
+(see ``profile.federated_search`` for the canonical example).
 """
 
 from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class IngestResult(BaseModel):
     """Result of ingesting a single document."""
+
+    model_config = ConfigDict(frozen=True)
 
     status: Literal["ok", "empty", "skipped", "error"] = Field(description="Ingestion outcome")
     source: str = Field(description="Original file path or URL")
@@ -28,6 +37,8 @@ class IngestResult(BaseModel):
 
 class ExplainInfo(BaseModel):
     """Diagnostic breakdown of why a chunk ranked where it did."""
+
+    model_config = ConfigDict(frozen=True)
 
     vec_rank: int | None = Field(default=None, description="Rank in vector search (0-based)")
     vec_distance: float | None = Field(default=None, description="Cosine distance from query")
@@ -71,6 +82,8 @@ class SearchResult(BaseModel):
     for the current index state — it may change on re-ingest.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     chunk_id: int = Field(
         description="Database row ID of the chunk (valid for current index state; may change on re-ingest)"
     )
@@ -96,6 +109,8 @@ class SearchResult(BaseModel):
 class DocumentInfo(BaseModel):
     """Metadata about an ingested document."""
 
+    model_config = ConfigDict(frozen=True)
+
     path: str = Field(description="Absolute file path or URL")
     title: str = Field(description="Document title")
     source_type: str = Field(description="Type: pdf, docx, code, url, etc.")
@@ -110,6 +125,8 @@ class DocumentInfo(BaseModel):
 
 class ChunkInfo(BaseModel):
     """A single chunk retrieved by ID."""
+
+    model_config = ConfigDict(frozen=True)
 
     chunk_id: int = Field(description="Database row ID of the chunk")
     doc_id: str = Field(description="Parent document hash ID")
@@ -129,6 +146,8 @@ class IntegrityCheck(BaseModel):
     crash or suspected corruption.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     name: str = Field(description="Short identifier for the check")
     description: str = Field(description="Human-readable explanation of what the check verifies")
     passed: bool = Field(description="True if the invariant holds")
@@ -145,6 +164,8 @@ class IntegrityCheck(BaseModel):
 class IntegrityRepair(BaseModel):
     """Result of one repair action attempted by ``VstashStore.integrity_repair()``."""
 
+    model_config = ConfigDict(frozen=True)
+
     name: str = Field(description="Short identifier of the check that was repaired")
     success: bool = Field(description="True if the repair completed without error")
     affected_count: int = Field(default=0, description="Rows / documents touched by the repair")
@@ -153,6 +174,8 @@ class IntegrityRepair(BaseModel):
 
 class StoreStats(BaseModel):
     """Aggregate statistics about the vstash memory store."""
+
+    model_config = ConfigDict(frozen=True)
 
     documents: int = Field(description="Total document count")
     chunks: int = Field(description="Total chunk count")
@@ -172,6 +195,8 @@ class StageVerdict(BaseModel):
     Used by miss analysis to explain *why* an expected document did
     not appear in the top-k of a query.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     stage: Literal[
         "vector_search",
@@ -200,6 +225,8 @@ class StageVerdict(BaseModel):
 class MissAnalysisActualResult(BaseModel):
     """A chunk that DID appear in the top-k, included for context."""
 
+    model_config = ConfigDict(frozen=True)
+
     rank: int
     chunk_id: int
     path: str
@@ -213,6 +240,8 @@ class MissAnalysis(BaseModel):
     See ``VstashStore.miss_analysis()`` for the full pipeline trace.
     Returned by ``Memory.miss_analysis()`` and the CLI ``--miss`` flag.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     query: str = Field(description="The search query that was run")
     expected_path: str | None = Field(
@@ -286,6 +315,8 @@ class AskResult(BaseModel):
         / ``openai``) post local-resolve.
       - ``model``: resolved model name actually called.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     content: str = Field(description="Model response text")
     reasoning: str | None = Field(


### PR DESCRIPTION
## Summary

The v0.31 query LRU cache copies only the **list** on a hit (`list(self._query_cache[_cache_key])` at `store/_search.py:523`); the `SearchResult` instances inside are shared with the cached entry. A caller assigning `r.score` would silently poison every later hit for that query.

All models in `models.py` now carry `model_config = ConfigDict(frozen=True)`, matching the existing `config.py` convention and the project-wide "Pydantic v2 (frozen=True)" rule in CLAUDE.md.

Safety check done before freezing:
- no internal attribute assignment / `setattr` on result instances anywhere in `vstash/`
- no test mutates results
- `profile.federated_search` already uses the immutable `model_copy(update={"score": ...})` pattern (which keeps working on frozen models)

Module docstring now documents the cache invariant and points at `model_copy` for derivation.

## Verification

- New regression test `test_cache_hit_results_are_immutable`: mutating a cache-hit result raises `ValidationError` and the next hit still returns the original score.
- **Full suite (1320 tests) green**; ruff clean.