### PR TITLE
fix(store): schema-version check before stamping + created_at backfill inside the ALTER txn

### DIFF
--- a/tests/test_schema_versioning.py
+++ b/tests/test_schema_versioning.py
@@ -276,6 +276,142 @@ class TestSchemaVersionMismatch:
         # what range this build can read.
         assert "1" in str(exc_info.value)
 
+    def test_refused_open_does_not_mutate_store_meta(self, tmp_path: Path) -> None:
+        """Refusing to open a future DB must leave its store_meta
+        untouched. Previously the meta pair was stamped BEFORE the
+        KNOWN_SCHEMA_VERSIONS check, so an old build refusing a newer
+        DB still overwrote the newer build's vstash_version row."""
+        import sqlite3
+
+        db = tmp_path / "future.db"
+        store = VstashStore(str(db), embedding_dim=4)
+        try:
+            now = datetime.now(timezone.utc).isoformat()
+            # Simulate a DB written by a future build.
+            store._conn.execute(
+                "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
+                ["schema_version", "999", now],
+            )
+            store._conn.execute(
+                "INSERT OR REPLACE INTO store_meta (key, value, updated_at) VALUES (?, ?, ?)",
+                ["vstash_version", "9.9.9", now],
+            )
+            store._conn.commit()
+        finally:
+            store.close()
+
+        with pytest.raises(SchemaVersionError):
+            VstashStore(str(db), embedding_dim=4)
+
+        conn = sqlite3.connect(str(db))
+        try:
+            rows = dict(
+                conn.execute(
+                    "SELECT key, value FROM store_meta "
+                    "WHERE key IN ('schema_version', 'vstash_version')"
+                ).fetchall()
+            )
+        finally:
+            conn.close()
+        assert rows["schema_version"] == "999"
+        assert rows["vstash_version"] == "9.9.9", (
+            "refused open overwrote the future build's vstash_version"
+        )
+
+
+class TestMigrationAtomicity:
+    """The legacy ALTER batch and the created_at backfill must commit
+    atomically: the backfill only runs in the call that ADDS the
+    column, so committing the ALTER separately means a crash between
+    the two leaves legacy rows NULL forever (the reopen sees the
+    column exists and never backfills)."""
+
+    @staticmethod
+    def _chunk_columns(db: Path) -> set[str]:
+        import sqlite3
+
+        conn = sqlite3.connect(str(db))
+        try:
+            return {row[1] for row in conn.execute("PRAGMA table_info(chunks)").fetchall()}
+        finally:
+            conn.close()
+
+    def test_backfill_failure_rolls_back_the_alter(self, tmp_path: Path) -> None:
+        import sqlite3
+
+        if sqlite3.sqlite_version_info < (3, 35, 0):
+            pytest.skip("ALTER TABLE DROP COLUMN needs sqlite >= 3.35")
+
+        # 1. Build a normal store with one chunk, then strip created_at
+        # to fake a pre-migration legacy DB.
+        db = tmp_path / "legacy.db"
+        store = VstashStore(str(db), embedding_dim=4)
+        try:
+            store.add_document(
+                path="/t/doc.md",
+                title="t",
+                chunks=["legacy chunk"],
+                embeddings=[[0.1] * 4],
+            )
+        finally:
+            store.close()
+        conn = sqlite3.connect(str(db))
+        try:
+            conn.execute("ALTER TABLE chunks DROP COLUMN created_at")
+            conn.commit()
+        finally:
+            conn.close()
+        assert "created_at" not in self._chunk_columns(db)
+
+        # 2. Reopen with a connection proxy that fails ONLY the
+        # backfill UPDATE, simulating a crash mid-migration. The proxy
+        # must wrap the raw sqlite3.connect result (not
+        # VstashStore._connect) because _create_tables -- and with it
+        # the whole migration -- runs INSIDE _connect on the raw
+        # connection.
+        from unittest.mock import patch
+
+        class _FailBackfillConn:
+            def __init__(self, real: sqlite3.Connection) -> None:
+                object.__setattr__(self, "_real", real)
+
+            def execute(self, sql: str, *args, **kwargs):
+                if "SET created_at" in sql:
+                    raise sqlite3.OperationalError("simulated crash during backfill")
+                return object.__getattribute__(self, "_real").execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(object.__getattribute__(self, "_real"), name)
+
+            def __setattr__(self, name, value):
+                setattr(object.__getattribute__(self, "_real"), name, value)
+
+        real_sqlite_connect = sqlite3.connect
+
+        def failing_connect(*args, **kwargs):
+            return _FailBackfillConn(real_sqlite_connect(*args, **kwargs))
+
+        with patch("sqlite3.connect", new=failing_connect):
+            with pytest.raises(sqlite3.OperationalError, match="simulated crash"):
+                VstashStore(str(db), embedding_dim=4)
+
+        # 3. Atomicity: the ALTER must have rolled back WITH the failed
+        # backfill, so the next open retries the whole migration.
+        assert "created_at" not in self._chunk_columns(db), (
+            "ALTER committed without its backfill -- a reopen would now "
+            "skip the backfill and leave legacy rows NULL forever"
+        )
+
+        # 4. A clean reopen completes the migration: column present AND
+        # every legacy row backfilled from its document's added_at.
+        store2 = VstashStore(str(db), embedding_dim=4)
+        try:
+            rows = store2._conn.execute("SELECT created_at FROM chunks").fetchall()
+            assert rows
+            assert all(r[0] is not None for r in rows), "legacy rows left NULL"
+        finally:
+            store2.close()
+
 
 # ------------------------------------------------------------------ #
 # Config forward compatibility                                         #

--- a/vstash/store/_schema.py
+++ b/vstash/store/_schema.py
@@ -185,6 +185,19 @@ class _SchemaManagerMixin:
         else:
             existing = stored_version
 
+        # Reject unknown versions BEFORE stamping anything: refusing to
+        # open a future DB must leave its store_meta untouched (the
+        # newer build's vstash_version row in particular), so the
+        # refused open is a pure no-op on the file.
+        if existing not in KNOWN_SCHEMA_VERSIONS:
+            msg = (
+                f"Database at {self.db_path} declares schema_version={existing!r}, "
+                f"which this build of vstash ({_vstash_version}) does not recognize. "
+                f"Known versions: {sorted(KNOWN_SCHEMA_VERSIONS)}. "
+                f"Upgrade vstash or restore the DB from a compatible backup."
+            )
+            raise SchemaVersionError(msg)
+
         now_iso = datetime.now(timezone.utc).isoformat()
         # Autocommit mode: stamp both meta rows in one explicit transaction so
         # a failure between them can't leave schema_version written without the
@@ -204,15 +217,6 @@ class _SchemaManagerMixin:
         except Exception:
             conn.rollback()
             raise
-
-        if existing not in KNOWN_SCHEMA_VERSIONS:
-            msg = (
-                f"Database at {self.db_path} declares schema_version={existing!r}, "
-                f"which this build of vstash ({_vstash_version}) does not recognize. "
-                f"Known versions: {sorted(KNOWN_SCHEMA_VERSIONS)}. "
-                f"Upgrade vstash or restore the DB from a compatible backup."
-            )
-            raise SchemaVersionError(msg)
 
     def _migrate_v1_to_v2(self, conn: sqlite3.Connection) -> bool:
         """In-place migrate a v1 DB's ``vec_chunks`` to cosine metric.
@@ -370,37 +374,39 @@ class _SchemaManagerMixin:
         if "created_at" not in chunk_columns:
             migrations.append("ALTER TABLE chunks ADD COLUMN created_at TEXT")
 
-        # Autocommit mode: run the ALTER TABLE batch in one explicit
-        # transaction so a failure partway through doesn't leave the schema
-        # half-migrated (in deferred mode the implicit transaction grouped
-        # them).
+        # Autocommit mode: run the ALTER TABLE batch AND the created_at
+        # backfill in ONE explicit transaction. The backfill only runs in
+        # the call that ADDS the column (guard below uses the pre-ALTER
+        # column snapshot), so committing the ALTER separately would mean
+        # a crash between the two leaves legacy rows NULL forever -- the
+        # reopen sees the column exists and never backfills.
         if migrations:
             conn.execute("BEGIN IMMEDIATE")
             try:
                 for sql in migrations:
                     conn.execute(sql)
+                # Backfill created_at from parent document's added_at
+                if "created_at" not in chunk_columns:
+                    conn.execute("""
+                        UPDATE chunks SET created_at = (
+                            SELECT d.added_at FROM documents d WHERE d.id = chunks.doc_id
+                        ) WHERE created_at IS NULL
+                    """)
                 conn.commit()
             except Exception:
                 conn.rollback()
                 raise
 
-        # Backfill created_at from parent document's added_at
-        if "created_at" not in chunk_columns:
-            conn.execute("""
-                UPDATE chunks SET created_at = (
-                    SELECT d.added_at FROM documents d WHERE d.id = chunks.doc_id
-                ) WHERE created_at IS NULL
-            """)
-            conn.commit()
-
         # Fix v0.5.0 data: ingestion set access_count=1 for chunks that were
-        # never actually searched. Detect by access_count=1 + no last_accessed_at.
+        # never actually searched. Detect by access_count=1 + no
+        # last_accessed_at. Independent of the ALTER batch (the column
+        # already existed); a single UPDATE is atomic on its own under
+        # autocommit.
         if "access_count" in chunk_columns:
             conn.execute("""
                 UPDATE chunks SET access_count = 0
                 WHERE access_count = 1 AND last_accessed_at IS NULL
             """)
-            conn.commit()
 
     # ------------------------------------------------------------------ #
     # Store metadata (key/value)                                            #


### PR DESCRIPTION
## Summary

Two pre-existing issues coderabbit flagged while reviewing #423 (both predate the autocommit switch — that PR only wrapped the existing order in explicit transactions):

**1. Stamp-before-check in `_check_schema_version`.** The `schema_version`/`vstash_version` meta pair was written and committed BEFORE the `KNOWN_SCHEMA_VERSIONS` validation, so an old build refusing to open a future DB still overwrote the newer build's `vstash_version` row. The check now runs first: a refused open is a pure no-op on the file.

**2. `created_at` backfill outside the ALTER transaction in `_migrate_schema`.** The legacy ALTER batch committed, then the backfill ran as a separate commit. The backfill only runs in the call that ADDS the column (the guard uses the pre-ALTER column snapshot), so a crash between the two left legacy rows NULL **forever** — the reopen sees the column exists and never backfills. The backfill now commits atomically with its ALTER batch. The v0.5.0 `access_count` data fix stays outside the txn: it targets DBs where the column already existed, and a single UPDATE is atomic on its own under autocommit.

## Verification

- `test_refused_open_does_not_mutate_store_meta`: future DB (`schema_version=999`, `vstash_version=9.9.9`) → `SchemaVersionError` AND both meta rows unchanged.
- `test_backfill_failure_rolls_back_the_alter`: connection proxy fails only the backfill UPDATE → the ALTER rolls back with it (column still absent), and a clean reopen completes the migration with every legacy row backfilled.
- **Both fail against the previous implementation** (verified by reverting).
- `test_schema_versioning` + `test_store` + `test_integrity` (145) green; ruff clean.