### PR TITLE
feat(ingest): Tier-0 content-hash dedup on remember (byte-identical NOOP)

### DIFF
--- a/tests/test_remember.py
+++ b/tests/test_remember.py
@@ -202,6 +202,126 @@ class TestGenerateTitle:
         assert match is not None
 
 
+class TestRememberContentHashDedup:
+    """Tier-0 write-time dedup (memory-manager design doc, Phase 1
+    precursor): a byte-identical re-remember of the same (collection,
+    title) is a NOOP -- no chunking, no embedding, no store write.
+    Changed text still replaces; legacy rows without a stored hash and
+    partial copies are never wrongly skipped."""
+
+    TEXT = "The aardvark memo: decision record about local coder models."
+
+    def _remember(self, mem, text: str):
+        return mem.remember(text, title="dedup-note")
+
+    def test_identical_re_remember_is_skipped(self, tmp_path) -> None:
+        from tests.conftest import requires_sqlite_vec  # noqa: F401
+        from vstash.memory import Memory
+
+        with Memory(db=tmp_path / "t.db") as mem:
+            r1 = self._remember(mem, self.TEXT)
+            assert r1.status == "ok"
+            chunk_count_before = mem._store._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[
+                0
+            ]
+
+            # The skip path must not touch the embed pipeline at all.
+            with patch(
+                "vstash.ingest._embed_with_progress",
+                side_effect=AssertionError("dedup skip must not embed"),
+            ):
+                r2 = self._remember(mem, self.TEXT)
+            assert r2.status == "skipped"
+            assert r2.source == "text://dedup-note"
+
+            chunk_count_after = mem._store._conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[
+                0
+            ]
+            assert chunk_count_after == chunk_count_before
+
+    def test_changed_text_replaces(self, tmp_path) -> None:
+        from vstash.memory import Memory
+
+        with Memory(db=tmp_path / "t.db") as mem:
+            assert self._remember(mem, self.TEXT).status == "ok"
+            r2 = self._remember(mem, self.TEXT + " Updated with a zebra clause.")
+            assert r2.status == "ok"
+            texts = [
+                row[0] for row in mem._store._conn.execute("SELECT text FROM chunks").fetchall()
+            ]
+            assert any("zebra" in t for t in texts), "changed text must replace the old copy"
+
+    def test_legacy_row_without_hash_is_not_skipped(self, tmp_path) -> None:
+        """Rows written before the content_hash column (or by paths
+        that don't set it) must never be treated as identical."""
+        from vstash.memory import Memory
+
+        with Memory(db=tmp_path / "t.db") as mem:
+            assert self._remember(mem, self.TEXT).status == "ok"
+            # Fake a legacy row: NULL the stored hash.
+            mem._store._conn.execute("UPDATE documents SET content_hash = NULL")
+            mem._store._conn.commit()
+
+            r2 = self._remember(mem, self.TEXT)
+            assert r2.status == "ok", "legacy row must re-ingest, not skip"
+            # The re-ingest stored the hash, so the THIRD call skips.
+            r3 = self._remember(mem, self.TEXT)
+            assert r3.status == "skipped"
+
+    def test_partial_copy_is_healed_not_skipped(self, tmp_path) -> None:
+        """A hash match on a PARTIAL copy (crash mid-ingest) must fall
+        through to re-ingest, mirroring the file-ingest healing path."""
+        from vstash.memory import Memory
+
+        with Memory(db=tmp_path / "t.db") as mem:
+            assert self._remember(mem, self.TEXT).status == "ok"
+            # Simulate a torn ingest: declared chunk_count no longer
+            # matches the actual chunk rows.
+            mem._store._conn.execute("UPDATE documents SET chunk_count = chunk_count + 1")
+            mem._store._conn.commit()
+            assert (
+                mem._store.doc_completeness("text://dedup-note", collection="default") == "partial"
+            )
+
+            r2 = self._remember(mem, self.TEXT)
+            assert r2.status == "ok", "partial copy must heal via re-ingest"
+            assert (
+                mem._store.doc_completeness("text://dedup-note", collection="default") == "complete"
+            )
+
+    def test_content_hash_column_migrates_on_open(self, tmp_path) -> None:
+        """An existing DB without the content_hash column gains it on
+        the next open (additive ALTER migration)."""
+        import sqlite3
+
+        from vstash.memory import Memory
+
+        if sqlite3.sqlite_version_info < (3, 35, 0):
+            import pytest
+
+            pytest.skip("ALTER TABLE DROP COLUMN needs sqlite >= 3.35")
+
+        db = tmp_path / "t.db"
+        with Memory(db=db) as mem:
+            assert self._remember(mem, self.TEXT).status == "ok"
+        # Strip the column to fake a pre-migration DB.
+        conn = sqlite3.connect(str(db))
+        conn.execute("ALTER TABLE documents DROP COLUMN content_hash")
+        conn.commit()
+        conn.close()
+
+        with Memory(db=db) as mem:
+            cols = {
+                row[1]
+                for row in mem._store._conn.execute("PRAGMA table_info(documents)").fetchall()
+            }
+            assert "content_hash" in cols
+            # Hash is NULL post-migration, so the same text re-ingests
+            # (no false skip) and re-stamps the hash.
+            assert self._remember(mem, self.TEXT).status == "ok"
+            assert self._remember(mem, self.TEXT).status == "skipped"
+
+
 class TestRememberCLI:
     """Test the vstash remember CLI command."""
 

--- a/vstash/ingest.py
+++ b/vstash/ingest.py
@@ -9,6 +9,7 @@ Progress: Rich bars at every stage — never looks frozen.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import time
 from pathlib import Path
@@ -711,6 +712,28 @@ def ingest_text(
     source_path = f"text://{title}"
     char_count = len(text)
 
+    # Tier-0 write-time dedup (memory-manager design doc, Phase 1
+    # precursor): hash the text EXACTLY as the caller sent it (before
+    # frontmatter stripping), so a byte-identical re-remember of the
+    # same (collection, title) is a NOOP -- no chunking, no embedding,
+    # no store write. Only an exact hash match on a COMPLETE existing
+    # copy short-circuits: changed text replaces as before, a legacy
+    # row without a stored hash is never treated as identical, and a
+    # partial copy falls through so the re-ingest heals it.
+    content_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    existing_hash = store.get_document_content_hash(source_path, collection=collection)
+    if (
+        existing_hash == content_hash
+        and store.doc_completeness(source_path, collection=collection) == "complete"
+    ):
+        return IngestResult(
+            status="skipped",
+            source=source_path,
+            title=title,
+            chars=char_count,
+            elapsed_s=round(time.time() - start_time, 2),
+        )
+
     # Extract frontmatter if present
     frontmatter = _extract_frontmatter(text)
     fm_project = project or frontmatter.get("project")
@@ -761,6 +784,7 @@ def ingest_text(
         project=fm_project,
         layer=fm_layer,
         tags=fm_tags,
+        content_hash=content_hash,
     )
 
     elapsed = round(time.time() - start_time, 2)

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -298,6 +298,7 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
         project: str | None = None,
         layer: str | None = None,
         tags: str | None = None,
+        content_hash: str | None = None,
     ) -> str:
         """Add a document and its chunks to the store.
 
@@ -313,6 +314,9 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             project: Project identifier from frontmatter.
             layer: Layer/category from frontmatter.
             tags: Comma-separated tags from frontmatter.
+            content_hash: SHA-256 hex of the raw ingested text, used for
+                Tier-0 write-time dedup (``ingest_text`` sets it; file
+                ingest leaves it None for now).
 
         Returns:
             The generated document ID (32-char hex hash).
@@ -352,9 +356,9 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 self._conn.execute(
                     """INSERT INTO documents
                        (id, path, title, source_type, collection,
-                        project, layer, tags,
+                        project, layer, tags, content_hash,
                         char_count, chunk_count, added_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                     [
                         doc_id,
                         path,
@@ -364,6 +368,7 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                         project,
                         layer,
                         stored_tags,
+                        content_hash,
                         sum(len(c) for c in chunks),
                         len(chunks),
                         datetime.now(timezone.utc).isoformat(),
@@ -476,6 +481,7 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                     project = doc.get("project")
                     layer = doc.get("layer")
                     tags = doc.get("tags")
+                    content_hash = doc.get("content_hash")
 
                     validate_document_input(
                         path=path,
@@ -499,9 +505,9 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                     self._conn.execute(
                         """INSERT INTO documents
                            (id, path, title, source_type, collection,
-                            project, layer, tags,
+                            project, layer, tags, content_hash,
                             char_count, chunk_count, added_at)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                         [
                             doc_id,
                             path,
@@ -511,6 +517,7 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                             project,
                             layer,
                             stored_tags,
+                            content_hash,
                             sum(len(c) for c in chunks),
                             len(chunks),
                             now_iso,
@@ -674,6 +681,23 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 return "partial"
 
         return "complete"
+
+    def get_document_content_hash(self, path: str, collection: str = "default") -> str | None:
+        """Stored content hash for the exact ``(collection, path)`` copy.
+
+        Returns ``None`` when the document is missing OR when the row
+        predates the ``content_hash`` column / was written by a path
+        that doesn't set it (file ingest, ``Memory.update``). ``None``
+        deliberately never matches: a legacy row is re-ingested rather
+        than wrongly skipped.
+        """
+        doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
+        row = self._conn.execute(
+            "SELECT content_hash FROM documents WHERE id = ?", [doc_id]
+        ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return str(row[0])
 
     def delete_document(self, path: str, collection: str | None = None) -> bool:
         """Remove a document and all its chunks from the store.

--- a/vstash/store/_schema.py
+++ b/vstash/store/_schema.py
@@ -36,19 +36,24 @@ class _SchemaManagerMixin:
         """Initialize database schema if not present."""
         # Create tables first (without indexes on new columns)
         conn.executescript(f"""
-            -- Document metadata
+            -- Document metadata.  content_hash is the SHA-256 hex of the
+            -- raw ingested text (text:// ingest only for now); NULL for
+            -- file/url docs and rows written by older builds.  Used for
+            -- Tier-0 write-time dedup: a byte-identical re-remember is a
+            -- NOOP instead of a re-embed.
             CREATE TABLE IF NOT EXISTS documents (
-                id          TEXT PRIMARY KEY,
-                path        TEXT NOT NULL,
-                title       TEXT NOT NULL,
-                source_type TEXT NOT NULL DEFAULT 'file',
-                collection  TEXT NOT NULL DEFAULT 'default',
-                project     TEXT,
-                layer       TEXT,
-                tags        TEXT,
-                char_count  INTEGER DEFAULT 0,
-                chunk_count INTEGER DEFAULT 0,
-                added_at    TEXT NOT NULL
+                id           TEXT PRIMARY KEY,
+                path         TEXT NOT NULL,
+                title        TEXT NOT NULL,
+                source_type  TEXT NOT NULL DEFAULT 'file',
+                collection   TEXT NOT NULL DEFAULT 'default',
+                project      TEXT,
+                layer        TEXT,
+                tags         TEXT,
+                content_hash TEXT,
+                char_count   INTEGER DEFAULT 0,
+                chunk_count  INTEGER DEFAULT 0,
+                added_at     TEXT NOT NULL
             );
 
             -- Chunk text + position
@@ -353,6 +358,8 @@ class _SchemaManagerMixin:
             migrations.append("ALTER TABLE documents ADD COLUMN layer TEXT")
         if "tags" not in doc_columns:
             migrations.append("ALTER TABLE documents ADD COLUMN tags TEXT")
+        if "content_hash" not in doc_columns:
+            migrations.append("ALTER TABLE documents ADD COLUMN content_hash TEXT")
 
         # miss_hint column on search_events (issue #157 part 3, 2026-04-21)
         event_columns = {


### PR DESCRIPTION
## Summary

First shippable slice of the memory-manager design doc (Tier 0): the write path stops being a blind append for the cheapest, safest case — a **byte-identical re-remember of the same (collection, title) is a NOOP** instead of a full re-chunk + re-embed + replace.

- `documents` gains a nullable `content_hash` column (SHA-256 hex of the raw ingested text, hashed exactly as the caller sent it, before frontmatter stripping). Fresh DDL + additive ALTER migration for existing DBs (no schema-version bump needed; older builds just leave it NULL).
- `add_document` / `add_documents_batch` accept an optional `content_hash`; only `ingest_text` sets it for now (file/url ingest unchanged — it already has `doc_completeness`-based idempotency + `force`).
- `ingest_text` short-circuits to `status="skipped"` when the incoming hash matches the stored hash **and** the existing copy is `complete`.

Conservative by design (the failure asymmetry from the design doc):
- a NULL hash (legacy row, `Memory.update` rewrite) **never matches** → nothing is ever wrongly skipped
- a partial copy (crash mid-ingest) falls through and heals via re-ingest, mirroring file ingest
- changed text replaces exactly as before
- auto-generated titles embed a timestamp (unique path per call), so dedup engages only for explicit titles — the case where silent duplicate re-embeds actually happen
- cross-title duplicate detection is deliberately NOT here — that's the manager's Tier 0 cosine + relations work (Phase 1), which needs the review/undo machinery first

`Memory.remember` / CLI `remember` / MCP inherit the behavior through `ingest_text`.

## Verification

- 5 new tests: identical-skip (asserts the embed pipeline is never invoked), changed-text-replaces, legacy-row-not-skipped (then re-stamps + third call skips), partial-copy-heals, column-migration-on-open. The load-bearing ones **fail against the previous implementation** (verified by reverting).
- **Full suite (1324) green**; ruff clean.