### PR TITLE
feat(store): replace_document_content primitive — row discovery inside the txn

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -636,7 +636,8 @@ class TestMemoryUpdate:
         WHOLE content update back. The old delete-then-add-loop left a
         torn state here: the doc was already deleted (and possibly
         re-added into collection 1) when collection 2's add failed.
-        Now the replace runs in one ``add_documents_batch`` transaction."""
+        Now the replace runs in one ``replace_document_content``
+        transaction."""
         doc = tmp_path / "shared.md"
         doc.write_text("Original aardvark content shared by the two collections.")
         db = tmp_path / "test.db"
@@ -645,17 +646,21 @@ class TestMemoryUpdate:
             mem.add(doc, collection="research")
             resolved = str(doc.resolve())
 
-            from vstash.validation import validate_document_input as real_validate
+            # The replacement text fits one chunk, so ``_serialize``
+            # runs exactly once per collection inside the replace
+            # transaction -- failing the 2nd call simulates a crash
+            # while re-adding the 2nd collection's copy.
+            from vstash.store import _serialize as real_serialize
 
             calls = {"n": 0}
 
-            def fail_on_second(*args: object, **kwargs: object) -> None:
+            def fail_on_second(emb):
                 calls["n"] += 1
                 if calls["n"] >= 2:
                     raise RuntimeError("boom: simulated failure on the 2nd collection")
-                real_validate(*args, **kwargs)
+                return real_serialize(emb)
 
-            with patch("vstash.store.validate_document_input", side_effect=fail_on_second):
+            with patch("vstash.store._serialize", side_effect=fail_on_second):
                 with pytest.raises(RuntimeError, match="boom"):
                     mem.update(
                         doc,
@@ -688,6 +693,34 @@ class TestMemoryUpdate:
                 assert all("zebra" not in t.lower() for t in texts), (
                     f"half-committed update leaked new content into {coll!r}: {texts!r}"
                 )
+
+    @requires_sqlite_vec
+    def test_update_does_not_resurrect_concurrently_deleted_doc(self, tmp_path: Path) -> None:
+        """The matched set is discovered INSIDE the store's replace
+        transaction. If the doc is deleted in the embed window (after
+        the advisory probe), the update must report not_found and write
+        NOTHING -- the previous SDK-level snapshot (SELECT before the
+        batch) replayed stale rows and resurrected the deleted doc."""
+        doc = tmp_path / "racy.md"
+        doc.write_text("Original content for the resurrection race test.")
+        db = tmp_path / "test.db"
+        with Memory(db=db) as mem:
+            mem.add(doc)
+            resolved = str(doc.resolve())
+
+            def embed_and_delete(texts, model):
+                # Simulate a concurrent writer deleting the doc in the
+                # window between the probe and the store call.
+                mem._store.delete_document(resolved)
+                return [[0.1] * 384 for _ in texts]
+
+            with patch("vstash.embed.embed_texts", side_effect=embed_and_delete):
+                result = mem.update(resolved, text="Replacement that must not resurrect the doc.")
+
+            assert result["status"] == "not_found", f"update replayed a stale snapshot: {result!r}"
+            assert [d for d in mem.list(collection=None) if d.path == resolved] == [], (
+                "update resurrected a concurrently-deleted document"
+            )
 
 
 class TestMemoryPruneAndCompact:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2164,3 +2164,142 @@ class TestSearchExactMatch:
         empty_result = populated_store.search(q, "python", top_k=5, exact_match="")
         assert [r.path for r in base] == [r.path for r in none_result]
         assert [r.path for r in base] == [r.path for r in empty_result]
+
+
+@requires_sqlite_vec
+class TestReplaceDocumentContent:
+    """replace_document_content: discovery + replace inside ONE write
+    lock + BEGIN IMMEDIATE (closes the SDK-level SELECT-then-act race
+    flagged on #424)."""
+
+    DIM = 4
+
+    def _store_with_two_collections(self, tmp_path) -> VstashStore:
+        store = VstashStore(str(tmp_path / "replace.db"), embedding_dim=self.DIM)
+        store.add_document(
+            path="/d.md",
+            title="Default Title",
+            chunks=["original default text"],
+            embeddings=[[0.1] * self.DIM],
+            source_type="markdown",
+            collection="default",
+            project="proj-a",
+            layer="layer-a",
+            tags="alpha",
+        )
+        store.add_document(
+            path="/d.md",
+            title="Research Title",
+            chunks=["original research text"],
+            embeddings=[[0.2] * self.DIM],
+            source_type="markdown",
+            collection="research",
+            project="proj-b",
+            layer="layer-b",
+            tags="beta",
+        )
+        return store
+
+    def _doc_rows(self, store: VstashStore) -> dict[str, dict]:
+        rows = store._conn.execute(
+            "SELECT collection, title, project, layer, tags, source_type, content_hash "
+            "FROM documents WHERE path = '/d.md'"
+        ).fetchall()
+        return {row["collection"]: dict(row) for row in rows}
+
+    def _chunk_texts(self, store: VstashStore, collection: str) -> list[str]:
+        return [
+            row[0]
+            for row in store._conn.execute(
+                "SELECT c.text FROM chunks c JOIN documents d ON c.doc_id = d.id "
+                "WHERE d.path = '/d.md' AND d.collection = ?",
+                [collection],
+            ).fetchall()
+        ]
+
+    def test_replaces_every_collection_preserving_metadata(self, tmp_path) -> None:
+        store = self._store_with_two_collections(tmp_path)
+        try:
+            n = store.replace_document_content(
+                "/d.md", chunks=["replacement text"], embeddings=[[0.3] * self.DIM]
+            )
+            assert n == 2
+            docs = self._doc_rows(store)
+            assert set(docs) == {"default", "research"}
+            # Per-copy metadata survives a content-only replace.
+            assert docs["default"]["title"] == "Default Title"
+            assert docs["default"]["project"] == "proj-a"
+            assert docs["default"]["layer"] == "layer-a"
+            assert docs["default"]["tags"] == "alpha"
+            assert docs["research"]["title"] == "Research Title"
+            assert docs["research"]["project"] == "proj-b"
+            assert docs["research"]["tags"] == "beta"
+            for coll in ("default", "research"):
+                assert self._chunk_texts(store, coll) == ["replacement text"]
+        finally:
+            store.close()
+
+    def test_scoped_to_one_collection(self, tmp_path) -> None:
+        store = self._store_with_two_collections(tmp_path)
+        try:
+            n = store.replace_document_content(
+                "/d.md",
+                chunks=["scoped replacement"],
+                embeddings=[[0.3] * self.DIM],
+                collection="research",
+            )
+            assert n == 1
+            assert self._chunk_texts(store, "research") == ["scoped replacement"]
+            assert self._chunk_texts(store, "default") == ["original default text"]
+        finally:
+            store.close()
+
+    def test_returns_zero_and_writes_nothing_when_missing(self, tmp_path) -> None:
+        store = self._store_with_two_collections(tmp_path)
+        try:
+            before = store._conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            n = store.replace_document_content(
+                "/nope.md", chunks=["x"], embeddings=[[0.3] * self.DIM]
+            )
+            assert n == 0
+            after = store._conn.execute("SELECT COUNT(*) FROM documents").fetchone()[0]
+            assert after == before
+        finally:
+            store.close()
+
+    def test_title_and_tags_overrides_apply_to_every_copy(self, tmp_path) -> None:
+        store = self._store_with_two_collections(tmp_path)
+        try:
+            n = store.replace_document_content(
+                "/d.md",
+                chunks=["override replacement"],
+                embeddings=[[0.3] * self.DIM],
+                title="New Title",
+                tags="x, y",
+            )
+            assert n == 2
+            docs = self._doc_rows(store)
+            for coll in ("default", "research"):
+                assert docs[coll]["title"] == "New Title"
+                # Tags are normalized on write ("x, y" -> "x,y").
+                assert docs[coll]["tags"] == "x,y"
+            # Non-overridden fields still preserved per copy.
+            assert docs["default"]["project"] == "proj-a"
+            assert docs["research"]["project"] == "proj-b"
+        finally:
+            store.close()
+
+    def test_content_hash_stored_when_provided(self, tmp_path) -> None:
+        store = self._store_with_two_collections(tmp_path)
+        try:
+            store.replace_document_content(
+                "/d.md",
+                chunks=["hashed replacement"],
+                embeddings=[[0.3] * self.DIM],
+                content_hash="deadbeef",
+            )
+            docs = self._doc_rows(store)
+            assert docs["default"]["content_hash"] == "deadbeef"
+            assert docs["research"]["content_hash"] == "deadbeef"
+        finally:
+            store.close()

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -929,28 +929,34 @@ class Memory:
         # Content update: replace the chunks in place with the
         # caller-supplied text. We deliberately do NOT re-read the
         # path from disk (the caller is overriding the content), and
-        # we preserve every metadata field the caller did NOT pass so
-        # tags / project / layer / source_type / collection survive a
-        # content-only refresh.
+        # the store preserves every metadata field the caller did NOT
+        # pass so tags / project / layer / source_type / collection
+        # survive a content-only refresh.
         #
         # The scope is whatever the caller asked for: ``col`` is
         # ``"default"`` / explicit string / ``None`` (=all collections).
         # We do NOT collapse ``"default"`` to ``None`` -- doing so
         # would silently widen the scope and re-introduce #165.
-        existing_rows = self._store._conn.execute(
-            "SELECT path, title, source_type, collection, "
-            "project, layer, tags, chunk_count, char_count, added_at "
-            "FROM documents WHERE path = ?" + (" AND collection = ?" if col is not None else ""),
+        #
+        # Advisory existence probe so a not-found update returns before
+        # paying the chunk+embed pipeline. The AUTHORITATIVE matched set
+        # is discovered inside ``replace_document_content``'s own
+        # transaction, so a concurrent writer in the embed window below
+        # cannot make us replay a stale snapshot (resurrect a deleted
+        # copy / miss a new one).
+        probe = self._store._conn.execute(
+            "SELECT 1 FROM documents WHERE path = ?"
+            + (" AND collection = ?" if col is not None else "")
+            + " LIMIT 1",
             [source_str, col] if col is not None else [source_str],
-        ).fetchall()
-        if not existing_rows:
+        ).fetchone()
+        if probe is None:
             return {
                 "status": "not_found",
                 "mode": "content",
                 "fields": [],
                 "chunks": 0,
             }
-        existing_docs = [DocumentInfo(**dict(row)) for row in existing_rows]
 
         # Chunk + embed the new text once and reuse for every
         # collection that holds this ``source``. ``chunk_text`` and
@@ -971,37 +977,33 @@ class Memory:
             }
         new_embeddings = embed_texts(new_chunks, self._cfg.embeddings.model)
 
-        # Replace-in-place, scoped to the same set of collections we
-        # just listed. Re-add into *each* existing collection so a
-        # multi-collection update does not silently collapse the doc
-        # into a single collection. ``add_documents_batch`` replaces
-        # each (collection, path) copy inside ONE transaction (its
-        # per-doc ``_delete_by_doc_id`` covers exactly the rows the
-        # listing above matched), so a failure on any collection rolls
-        # the whole update back -- no window where the document is
-        # missing or replaced in one collection but not another.
-        self._store.add_documents_batch(
-            [
-                {
-                    "path": source_str,
-                    "title": title if title is not None else existing.title,
-                    "chunks": new_chunks,
-                    "embeddings": new_embeddings,
-                    "source_type": existing.source_type,
-                    "collection": existing.collection,
-                    "project": existing.project,
-                    "layer": existing.layer,
-                    "tags": tags if tags is not None else existing.tags,
-                }
-                for existing in existing_docs
-            ]
+        # One store call: discovery + per-collection replace run inside
+        # a single write lock + BEGIN IMMEDIATE, so a failure on any
+        # collection rolls the whole update back and a concurrent
+        # delete/add cannot slip between listing and replacing.
+        replaced = self._store.replace_document_content(
+            source_str,
+            chunks=new_chunks,
+            embeddings=new_embeddings,
+            title=title,
+            tags=tags,
+            collection=col,
         )
+        if replaced == 0:
+            # The doc disappeared between the advisory probe and the
+            # replace (e.g. a concurrent remove). Nothing was written.
+            return {
+                "status": "not_found",
+                "mode": "content",
+                "fields": [],
+                "chunks": 0,
+            }
         fields = [k for k, v in (("text", text), ("title", title), ("tags", tags)) if v is not None]
         return {
             "status": "updated",
             "mode": "content",
             "fields": fields,
-            "chunks": len(new_chunks) * len(existing_docs),
+            "chunks": len(new_chunks) * replaced,
         }
 
     def list(

--- a/vstash/store/__init__.py
+++ b/vstash/store/__init__.py
@@ -332,89 +332,24 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
             limits=self._limits,
         )
 
-        # Normalize the on-disk tag representation to match the form
-        # the search-side comma-anchored ``LIKE`` expects. Writers
-        # routinely hand us ``"alpha, beta"`` (frontmatter style); if
-        # we stored it verbatim, a query for ``tag="beta"`` would
-        # generate ``%,beta,%`` against ``,alpha, beta,`` and miss
-        # because of the leading space. Round-tripping through
-        # ``_normalize_tags`` strips that whitespace and dedupes
-        # repeats once, at ingest time, so the storage invariant is
-        # ``"tag1,tag2,..."`` with no spaces and no duplicates.
-        stored_tags = ",".join(_normalize_tags(tags)) if tags else None
-
-        doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
-
         with self._write_lock:
             # Explicit transaction ensures atomicity — a crash mid-way
             # won't leave the database in an inconsistent state.
             self._conn.execute("BEGIN IMMEDIATE")
             try:
-                # Remove existing version if re-ingesting
-                self._delete_by_doc_id(doc_id)
-
-                self._conn.execute(
-                    """INSERT INTO documents
-                       (id, path, title, source_type, collection,
-                        project, layer, tags, content_hash,
-                        char_count, chunk_count, added_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    [
-                        doc_id,
-                        path,
-                        title,
-                        source_type,
-                        collection,
-                        project,
-                        layer,
-                        stored_tags,
-                        content_hash,
-                        sum(len(c) for c in chunks),
-                        len(chunks),
-                        datetime.now(timezone.utc).isoformat(),
-                    ],
+                doc_id, rowids, fts_data = self._insert_document_in_txn(
+                    path=path,
+                    title=title,
+                    chunks=chunks,
+                    embeddings=embeddings,
+                    source_type=source_type,
+                    collection=collection,
+                    project=project,
+                    layer=layer,
+                    tags=tags,
+                    content_hash=content_hash,
+                    now_iso=datetime.now(timezone.utc).isoformat(),
                 )
-
-                now_iso = datetime.now(timezone.utc).isoformat()
-
-                # Insert chunk — last_accessed_at is NULL until the chunk is actually accessed
-                # via search, so the decay formula doesn't treat new chunks as "recently accessed".
-                chunk_data = [(doc_id, seq, text, now_iso) for seq, text in enumerate(chunks)]
-                self._conn.executemany(
-                    "INSERT INTO chunks (doc_id, seq, text, access_count, created_at, last_accessed_at)"
-                    " VALUES (?, ?, ?, 0, ?, NULL)",
-                    chunk_data,
-                )
-
-                # Get rowids for linking vec + fts tables
-                rowids = [
-                    row[0]
-                    for row in self._conn.execute(
-                        "SELECT id FROM chunks WHERE doc_id = ? ORDER BY seq",
-                        [doc_id],
-                    ).fetchall()
-                ]
-
-                # Vector index entries. rowids comes from a SELECT-by-doc_id
-                # right after the chunk inserts above, so it must align 1:1
-                # with the input embeddings/chunks; strict=True surfaces any
-                # invariant violation as a ValueError instead of silently
-                # truncating to the shorter side.
-                vec_data = [
-                    (rowid, _serialize(emb)) for rowid, emb in zip(rowids, embeddings, strict=True)
-                ]
-                self._conn.executemany(
-                    "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
-                    vec_data,
-                )
-
-                # FTS5 entries (rowid must match chunks.id)
-                fts_data = [(rowid, text) for rowid, text in zip(rowids, chunks, strict=True)]
-                if not self._defer_fts:
-                    self._conn.executemany(
-                        "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
-                        fts_data,
-                    )
 
                 # Add to snapvec in-memory (persisted after successful commit)
                 if self._snap is not None:
@@ -432,6 +367,117 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 self._reload_snapvec()
                 raise
         return doc_id
+
+    def _insert_document_in_txn(
+        self,
+        *,
+        path: str,
+        title: str,
+        chunks: list[str],
+        embeddings: list[list[float]],
+        source_type: str,
+        collection: str,
+        project: str | None,
+        layer: str | None,
+        tags: str | None,
+        content_hash: str | None,
+        now_iso: str,
+    ) -> tuple[str, list[int], list[tuple[int, str]]]:
+        """Replace-insert one document's rows inside the caller's OPEN
+        transaction.
+
+        Shared per-document body of ``add_document``,
+        ``add_documents_batch``, and ``replace_document_content``:
+        normalize tags, delete the prior ``(collection, path)`` version,
+        insert documents/chunks/vec_chunks rows, and insert FTS rows
+        unless ``_defer_fts`` is on.
+
+        The caller owns the write lock, BEGIN/COMMIT/ROLLBACK, input
+        validation (kept at each public boundary per #133), snapvec
+        population (immediate vs coalesced varies by caller), deferred-
+        FTS buffering (extend ``_deferred_fts_rows`` only AFTER commit),
+        and cache invalidation.
+
+        Returns:
+            ``(doc_id, rowids, fts_data)`` — chunk rowids for snapvec
+            and the ``(rowid, text)`` pairs for deferred FTS.
+        """
+        # Normalize the on-disk tag representation to match the form
+        # the search-side comma-anchored ``LIKE`` expects. Writers
+        # routinely hand us ``"alpha, beta"`` (frontmatter style); if
+        # we stored it verbatim, a query for ``tag="beta"`` would
+        # generate ``%,beta,%`` against ``,alpha, beta,`` and miss
+        # because of the leading space. Round-tripping through
+        # ``_normalize_tags`` strips that whitespace and dedupes
+        # repeats once, at ingest time, so the storage invariant is
+        # ``"tag1,tag2,..."`` with no spaces and no duplicates.
+        stored_tags = ",".join(_normalize_tags(tags)) if tags else None
+
+        doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
+
+        # Remove existing version if re-ingesting
+        self._delete_by_doc_id(doc_id)
+
+        self._conn.execute(
+            """INSERT INTO documents
+               (id, path, title, source_type, collection,
+                project, layer, tags, content_hash,
+                char_count, chunk_count, added_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            [
+                doc_id,
+                path,
+                title,
+                source_type,
+                collection,
+                project,
+                layer,
+                stored_tags,
+                content_hash,
+                sum(len(c) for c in chunks),
+                len(chunks),
+                now_iso,
+            ],
+        )
+
+        # Insert chunk — last_accessed_at is NULL until the chunk is actually accessed
+        # via search, so the decay formula doesn't treat new chunks as "recently accessed".
+        chunk_data = [(doc_id, seq, text, now_iso) for seq, text in enumerate(chunks)]
+        self._conn.executemany(
+            "INSERT INTO chunks (doc_id, seq, text, access_count, created_at, last_accessed_at)"
+            " VALUES (?, ?, ?, 0, ?, NULL)",
+            chunk_data,
+        )
+
+        # Get rowids for linking vec + fts tables
+        rowids = [
+            row[0]
+            for row in self._conn.execute(
+                "SELECT id FROM chunks WHERE doc_id = ? ORDER BY seq",
+                [doc_id],
+            ).fetchall()
+        ]
+
+        # Vector index entries. rowids comes from a SELECT-by-doc_id
+        # right after the chunk inserts above, so it must align 1:1
+        # with the input embeddings/chunks; strict=True surfaces any
+        # invariant violation as a ValueError instead of silently
+        # truncating to the shorter side.
+        vec_data = [(rowid, _serialize(emb)) for rowid, emb in zip(rowids, embeddings, strict=True)]
+        self._conn.executemany(
+            "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
+            vec_data,
+        )
+
+        # FTS5 entries (rowid must match chunks.id)
+        fts_data = [(rowid, text) for rowid, text in zip(rowids, chunks, strict=True)]
+        if not self._defer_fts:
+            self._conn.executemany(
+                "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
+                fts_data,
+            )
+
+        return doc_id, rowids, fts_data
 
     def add_documents_batch(
         self,
@@ -472,91 +518,33 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 now_iso = datetime.now(timezone.utc).isoformat()
 
                 for doc in documents:
-                    path = doc["path"]
-                    title = doc["title"]
                     chunks = doc["chunks"]
                     embeddings = doc["embeddings"]
-                    source_type = doc["source_type"]
-                    collection = doc.get("collection", "default")
-                    project = doc.get("project")
-                    layer = doc.get("layer")
-                    tags = doc.get("tags")
-                    content_hash = doc.get("content_hash")
 
                     validate_document_input(
-                        path=path,
+                        path=doc["path"],
                         chunks=chunks,
                         embeddings=embeddings,
                         limits=self._limits,
                     )
 
-                    # Normalize tags on write so the search-side
-                    # comma-anchored ``LIKE`` matches reliably. Same
-                    # invariant as ``add_document``: stored form is
-                    # ``"tag1,tag2,..."`` with no whitespace and no
-                    # duplicates.
-                    stored_tags = ",".join(_normalize_tags(tags)) if tags else None
-
-                    doc_id = hashlib.sha256(f"{collection}:{path}".encode()).hexdigest()[:32]
+                    doc_id, rowids, fts_data = self._insert_document_in_txn(
+                        path=doc["path"],
+                        title=doc["title"],
+                        chunks=chunks,
+                        embeddings=embeddings,
+                        source_type=doc["source_type"],
+                        collection=doc.get("collection", "default"),
+                        project=doc.get("project"),
+                        layer=doc.get("layer"),
+                        tags=doc.get("tags"),
+                        content_hash=doc.get("content_hash"),
+                        now_iso=now_iso,
+                    )
                     doc_ids.append(doc_id)
 
-                    self._delete_by_doc_id(doc_id)
-
-                    self._conn.execute(
-                        """INSERT INTO documents
-                           (id, path, title, source_type, collection,
-                            project, layer, tags, content_hash,
-                            char_count, chunk_count, added_at)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                        [
-                            doc_id,
-                            path,
-                            title,
-                            source_type,
-                            collection,
-                            project,
-                            layer,
-                            stored_tags,
-                            content_hash,
-                            sum(len(c) for c in chunks),
-                            len(chunks),
-                            now_iso,
-                        ],
-                    )
-
-                    chunk_data = [(doc_id, seq, text, now_iso) for seq, text in enumerate(chunks)]
-                    self._conn.executemany(
-                        "INSERT INTO chunks (doc_id, seq, text, access_count, "
-                        "created_at, last_accessed_at) VALUES (?, ?, ?, 0, ?, NULL)",
-                        chunk_data,
-                    )
-
-                    rowids = [
-                        row[0]
-                        for row in self._conn.execute(
-                            "SELECT id FROM chunks WHERE doc_id = ? ORDER BY seq",
-                            [doc_id],
-                        ).fetchall()
-                    ]
-
-                    vec_data = [
-                        (rowid, _serialize(emb))
-                        for rowid, emb in zip(rowids, embeddings, strict=True)
-                    ]
-                    self._conn.executemany(
-                        "INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)",
-                        vec_data,
-                    )
-
-                    fts_data = list(zip(rowids, chunks, strict=True))
                     if self._defer_fts:
                         pending_fts.extend(fts_data)
-                    else:
-                        self._conn.executemany(
-                            "INSERT INTO fts_chunks (rowid, text) VALUES (?, ?)",
-                            fts_data,
-                        )
-
                     if self._snap is not None:
                         pending_snap_rowids.extend(rowids)
                         pending_snap_vecs.append(np.asarray(embeddings, dtype=np.float32))
@@ -584,6 +572,115 @@ class VstashStore(_IndexBackendMixin, _IntegrityMixin, _SchemaManagerMixin, _Sea
                 raise
 
         return doc_ids
+
+    def replace_document_content(
+        self,
+        path: str,
+        *,
+        chunks: list[str],
+        embeddings: list[list[float]],
+        title: str | None = None,
+        tags: str | None = None,
+        content_hash: str | None = None,
+        collection: str | None = None,
+    ) -> int:
+        """Atomically replace the chunk content of every ``(collection,
+        path)`` copy matching the filter, preserving each copy's
+        metadata fields the caller did not override.
+
+        Row discovery and replacement run inside ONE write lock +
+        ``BEGIN IMMEDIATE``: the matched set cannot change between
+        listing and replacing.  An SDK-level SELECT before the write
+        (the pre-#424 shape) could replay a stale snapshot — resurrect
+        a just-deleted copy, miss a newly-added collection copy, or
+        overwrite fresher metadata with old values.
+
+        Args:
+            path: Exact document path (caller resolves it first).
+            chunks: New text chunks, reused for every matching copy.
+            embeddings: Corresponding embedding vectors.
+            title: Optional override; ``None`` preserves each copy's title.
+            tags: Optional override; ``None`` preserves each copy's tags.
+            content_hash: Optional SHA-256 hex of the raw replacement
+                text (Tier-0 dedup; see ``add_document``).
+            collection: Exact collection to scope to, or ``None`` for
+                every collection holding ``path``.
+
+        Returns:
+            Number of copies replaced. 0 if nothing matched — nothing
+            is written in that case.
+        """
+        # Fail-safe validation at the public API boundary (#133),
+        # before we open a write transaction. The content is shared by
+        # every matching copy, so one check covers them all.
+        validate_document_input(
+            path=path,
+            chunks=chunks,
+            embeddings=embeddings,
+            limits=self._limits,
+        )
+
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            pending_fts: list[tuple[int, str]] = []
+            # Same coalescing rationale as add_documents_batch: one
+            # snapvec add_batch for the whole transaction.
+            pending_snap_rowids: list[int] = []
+            pending_snap_vecs: list[np.ndarray] = []
+            try:
+                # Discovery INSIDE the transaction: BEGIN IMMEDIATE has
+                # the write lock on the DB, so this is the authoritative
+                # matched set for the replace below.
+                existing = self._conn.execute(
+                    "SELECT title, source_type, collection, project, layer, tags "
+                    "FROM documents WHERE path = ?"
+                    + (" AND collection = ?" if collection is not None else ""),
+                    [path, collection] if collection is not None else [path],
+                ).fetchall()
+                if not existing:
+                    self._conn.rollback()
+                    return 0
+
+                now_iso = datetime.now(timezone.utc).isoformat()
+                for row in existing:
+                    _doc_id, rowids, fts_data = self._insert_document_in_txn(
+                        path=path,
+                        title=title if title is not None else row["title"],
+                        chunks=chunks,
+                        embeddings=embeddings,
+                        source_type=row["source_type"],
+                        collection=row["collection"],
+                        project=row["project"],
+                        layer=row["layer"],
+                        tags=tags if tags is not None else row["tags"],
+                        content_hash=content_hash,
+                        now_iso=now_iso,
+                    )
+                    if self._defer_fts:
+                        pending_fts.extend(fts_data)
+                    if self._snap is not None:
+                        pending_snap_rowids.extend(rowids)
+                        pending_snap_vecs.append(np.asarray(embeddings, dtype=np.float32))
+
+                if self._snap is not None and pending_snap_rowids:
+                    all_snap_vecs = (
+                        pending_snap_vecs[0]
+                        if len(pending_snap_vecs) == 1
+                        else np.concatenate(pending_snap_vecs, axis=0)
+                    )
+                    self._snap.add_batch(pending_snap_rowids, all_snap_vecs)
+                    self._snap_dirty = True
+
+                self._conn.commit()
+                if pending_fts:
+                    self._deferred_fts_rows.extend(pending_fts)
+                self._invalidate_idf_cache()
+                self._bump_cache_epoch()
+                return len(existing)
+            except Exception:
+                self._conn.rollback()
+                self._reload_snapvec()
+                raise
 
     def delete_by_path_prefix(self, prefix: str) -> int:
         """Remove all documents whose path starts with *prefix*.


### PR DESCRIPTION
## Summary

Closes the TOCTOU coderabbit flagged on #424 (committed follow-up): `Memory.update`'s content path SELECTed the matched `(collection, path)` rows at the SDK layer, **before** `add_documents_batch` acquired the write lock and opened its transaction. A concurrent writer in that gap (which includes the whole chunk+embed step) could make the update replay a stale snapshot — resurrect a just-deleted copy, miss a newly-added collection copy, or overwrite fresher metadata with old values.

**New primitive:** `VstashStore.replace_document_content(path, *, chunks, embeddings, title=, tags=, content_hash=, collection=)` — discovery + per-collection replace run inside ONE write lock + `BEGIN IMMEDIATE`. Per-copy metadata the caller did not override is preserved; returns the number of copies replaced (0 = nothing written). Snapvec vectors are coalesced into one `add_batch` like the batch path.

**Refactor:** to avoid a third copy of the per-document insert body, the shared `_insert_document_in_txn` helper is extracted and now backs `add_document`, `add_documents_batch`, AND the new primitive — one load-bearing insert path instead of two duplicated ones. Division of labor is explicit in its docstring: validation stays at each public boundary (per #133), commit/rollback + snapvec population (immediate vs coalesced) + deferred-FTS buffering + cache invalidation stay with the callers.

`Memory.update` keeps a cheap advisory existence probe (not-found returns before paying the embed pipeline; the authoritative check is inside the primitive's txn) and no longer runs inline SQL on `_store._conn`.

## Verification

- 5 new store-level tests: multi-collection replace + per-copy metadata preservation, collection scoping, zero-on-missing (nothing written), title/tags overrides (normalized), `content_hash` stamping.
- New race regression `test_update_does_not_resurrect_concurrently_deleted_doc`: doc deleted during the embed window → `not_found`, nothing written. **Fails against the previous implementation** (verified by reverting).
- Existing rollback test now injects failure via `_serialize` (per-chunk, inside the txn) and still proves whole-update rollback.
- **Full suite (1341) green**; ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race condition where documents deleted during concurrent operations could be resurrected by update operations.

* **Tests**
  * Enhanced rollback coverage for cross-collection scenarios.
  * Added comprehensive test suite for document content replacement, including metadata preservation, collection-scoped operations, and edge cases.
  * Added concurrency regression test for document deletion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->