### PR TITLE
chore(ci): test Python 3.13 (claimed in classifiers) + drop dead coverage omit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        # 3.13 is claimed in the pyproject classifiers -- test the claim.
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,12 +184,10 @@ filterwarnings = [
 source = ["vstash"]
 branch = true
 parallel = true
-# Skip the auto-generated CLI entry shim and the optional sub-backends
-# whose code paths are exercised by integration tests gated off the
-# default CI run (snapvec backends require the `snapvec` package and
-# fitted index files; treesitter requires the language pack).
+# Skip the optional sub-backend shim whose code paths are exercised by
+# integration tests gated off the default CI run (snapvec backends
+# require the `snapvec` package and fitted index files).
 omit = [
-    "vstash/__main__.py",
     "vstash/_ivfpq_backend.py",
 ]
 


### PR DESCRIPTION
## Summary

Two CI/packaging hygiene items from the 2026-06-10 review sweep:

**1. Python 3.13 in classifiers but never tested.** `pyproject.toml` has claimed `Programming Language :: Python :: 3.13` while the CI matrix stopped at 3.12. This PR adds 3.13 to the matrix so the claim is verified empirically — this PR's own CI run is the test. If the 3.13 job turns red (wheel availability for sqlite-vec / onnxruntime / fastembed is the likely culprit), the honest follow-up is removing the classifier instead.

**2. Dead coverage omit.** `vstash/__main__.py` is in the coverage omit list but the file does not exist — the console entry points are `vstash` / `vstash-mcp` via pyproject scripts; no `python -m vstash` shim was ever added.

Deliberately NOT in this PR:
- **mypy gate**: measured on develop — 113 errors in 16 files, dominated by `attr-defined` from the store mixin split (mixins referencing concrete-class attributes; needs Protocol bases to fix properly). That's a standalone project, recorded in the backlog, not a CI toggle.
- **Upper bounds on ingest/serve extras**: the existing pinning philosophy (core bounded, non-core loose) is deliberate; leaving as-is.