### PR TITLE
fix(langchain): expose full SearchResult metadata on retrieved Documents

### DIFF
--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -32,15 +32,19 @@ class TestVstashRetrieverUnit:
         mock_memory = MagicMock(spec=Memory)
         mock_memory.search.return_value = [
             SearchResult(
-                chunk_id=0,
+                chunk_id=7,
                 text="Python is a programming language.",
                 title="Python Guide",
                 path="/docs/python.md",
                 chunk=0,
                 score=0.95,
+                collection="docs",
+                tags="python,guide",
+                layer="reference",
+                added_at="2026-06-10T00:00:00+00:00",
             ),
             SearchResult(
-                chunk_id=1,
+                chunk_id=8,
                 text="Python supports multiple paradigms.",
                 title="Python Guide",
                 path="/docs/python.md",
@@ -67,7 +71,9 @@ class TestVstashRetrieverUnit:
         assert docs[1].page_content == "Python supports multiple paradigms."
 
     def test_document_metadata(self) -> None:
-        """Document metadata contains source, title, score, and chunk."""
+        """Document metadata exposes the full SearchResult surface
+        (parity with the other adapters): source/title/score/chunk plus
+        chunk_id, collection, tags, layer, and added_at."""
         retriever = self._make_retriever()
         docs = retriever.invoke("programming language")
 
@@ -76,6 +82,17 @@ class TestVstashRetrieverUnit:
         assert meta["title"] == "Python Guide"
         assert meta["score"] == 0.95
         assert meta["chunk"] == 0
+        assert meta["chunk_id"] == 7
+        assert meta["collection"] == "docs"
+        assert meta["tags"] == "python,guide"
+        assert meta["layer"] == "reference"
+        assert meta["added_at"] == "2026-06-10T00:00:00+00:00"
+        # Optional fields default to None (still present, never missing).
+        meta2 = docs[1].metadata
+        assert meta2["chunk_id"] == 8
+        assert meta2["collection"] is None
+        assert meta2["tags"] is None
+        assert meta2["layer"] is None
 
     def test_top_k_passed_to_search(self) -> None:
         """top_k parameter is forwarded to Memory.search()."""

--- a/vstash/langchain.py
+++ b/vstash/langchain.py
@@ -103,6 +103,12 @@ class VstashRetriever(BaseRetriever):
 
         results = self.memory.search(query, **search_kwargs)
 
+        # Expose the full SearchResult surface (parity with the other
+        # adapters): chunk_id lets callers fetch context via
+        # Memory.get_chunk, and collection/tags/layer carry the
+        # organizational metadata LangChain filters routinely key on.
+        # chunk_id is only valid for the current index state (it may
+        # change on re-ingest) -- same contract as SearchResult.
         return [
             Document(
                 page_content=r.text,
@@ -111,6 +117,11 @@ class VstashRetriever(BaseRetriever):
                     "title": r.title,
                     "score": r.score,
                     "chunk": r.chunk,
+                    "chunk_id": r.chunk_id,
+                    "collection": r.collection,
+                    "tags": r.tags,
+                    "layer": r.layer,
+                    "added_at": r.added_at,
                 },
             )
             for r in results


### PR DESCRIPTION
## Summary

`VstashRetriever` dropped `chunk_id`, `collection`, `tags`, `layer`, and `added_at` from `Document.metadata` — a parity gap with the other adapters (MCP/web/SDK all surface the full `SearchResult`). `chunk_id` in particular is what lets a LangChain caller fetch surrounding context via `Memory.get_chunk`; `collection`/`tags`/`layer` are the organizational fields LangChain metadata filters routinely key on.

Optional fields are always **present** (`None` when unset) so downstream filter code never `KeyError`s on a sparse result. `chunk_id` carries the same contract as `SearchResult` (valid for the current index state; may change on re-ingest) — noted in the code comment.

## Verification

- Extended `test_document_metadata`: asserts the five new keys on a fully-populated result AND `None`-defaults present on a sparse one.
- `test_langchain` (15) green; ruff clean.