### PR TITLE
feat(memory): project override on journal_save/recall/log/prune

### DIFF
--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -470,3 +470,69 @@ class TestMemoryJournal:
                 assert mock_prune.call_args.kwargs["dry_run"] is True
 
             mem.close()
+
+
+class TestMemoryJournalProjectOverride:
+    """journal_* parity with search/list: explicit ``project=`` override
+    beats the constructor default, explicit ``None`` clears the filter,
+    and omitting the argument keeps the instance default."""
+
+    def test_journal_save_project_override(self) -> None:
+        from unittest.mock import patch
+
+        with (
+            patch("vstash.memory.open_store_for_config"),
+            patch("vstash.memory.load_config"),
+        ):
+            from vstash.memory import Memory
+
+            mem = Memory(project="test-agent")
+            with patch("vstash.journal.journal_save") as mock_save:
+                mock_save.return_value = {"status": "ok"}
+                mem.journal_save("x", project="other-agent")
+                assert mock_save.call_args.kwargs["project"] == "other-agent"
+                mem.journal_save("x", project=None)
+                assert mock_save.call_args.kwargs["project"] is None
+                mem.journal_save("x")
+                assert mock_save.call_args.kwargs["project"] == "test-agent"
+            mem.close()
+
+    def test_journal_recall_log_prune_project_override(self) -> None:
+        from unittest.mock import patch
+
+        with (
+            patch("vstash.memory.open_store_for_config"),
+            patch("vstash.memory.load_config"),
+        ):
+            from vstash.memory import Memory
+
+            mem = Memory(project="test-agent")
+
+            with patch("vstash.journal.journal_recall") as mock_recall:
+                mock_recall.return_value = []
+                mem.journal_recall("q", project="other-agent")
+                assert mock_recall.call_args.kwargs["project"] == "other-agent"
+                mem.journal_recall("q", project=None)
+                assert mock_recall.call_args.kwargs["project"] is None
+                mem.journal_recall("q")
+                assert mock_recall.call_args.kwargs["project"] == "test-agent"
+
+            with patch("vstash.journal.journal_log") as mock_log:
+                mock_log.return_value = []
+                mem.journal_log(project="other-agent")
+                assert mock_log.call_args.kwargs["project"] == "other-agent"
+                mem.journal_log(project=None)
+                assert mock_log.call_args.kwargs["project"] is None
+                mem.journal_log()
+                assert mock_log.call_args.kwargs["project"] == "test-agent"
+
+            with patch("vstash.journal.journal_prune") as mock_prune:
+                mock_prune.return_value = {"status": "ok"}
+                mem.journal_prune("30d", project="other-agent")
+                assert mock_prune.call_args.kwargs["project"] == "other-agent"
+                mem.journal_prune("30d", project=None)
+                assert mock_prune.call_args.kwargs["project"] is None
+                mem.journal_prune("30d")
+                assert mock_prune.call_args.kwargs["project"] == "test-agent"
+
+            mem.close()

--- a/vstash/memory.py
+++ b/vstash/memory.py
@@ -1060,6 +1060,7 @@ class Memory:
         title: str | None = None,
         tags: str | None = None,
         source: str | None = None,
+        project: object = _UNSET,
     ) -> dict:
         """Save a journal entry for cross-session recall.
 
@@ -1071,6 +1072,9 @@ class Memory:
             title: Optional title (auto-generated with timestamp if None).
             tags: Comma-separated tags (auto-adds 'journal').
             source: Source identifier (e.g. 'agent', 'session', 'hook').
+            project: Override the constructor's project tag for this
+                entry. Pass ``None`` to save without a project; omit to
+                use the instance default (same semantics as ``search``).
 
         Returns:
             Dict with entry metadata.
@@ -1085,7 +1089,7 @@ class Memory:
         return journal_save(
             text,
             title=title,
-            project=self._project,
+            project=self._resolve_project(project),
             tags=tags,
             source=source,
             cfg=self._cfg,
@@ -1099,6 +1103,7 @@ class Memory:
         tags: str | list[str] | None = None,
         added_after: str | None = None,
         added_before: str | None = None,
+        project: object = _UNSET,
     ) -> list[dict]:
         """Recall relevant journal entries from past sessions.
 
@@ -1116,6 +1121,9 @@ class Memory:
                 entries logged on or after this date.
             added_before: ISO date — only return entries logged strictly
                 before this date.
+            project: Override the constructor's project filter. Pass
+                ``None`` to recall across every project; omit to use the
+                instance default (same semantics as ``search``).
 
         Returns:
             List of dicts with text, title, score/added_at.
@@ -1131,7 +1139,7 @@ class Memory:
         return journal_recall(
             query=query,
             top_k=top_k,
-            project=self._project,
+            project=self._resolve_project(project),
             tags=tags,
             added_after=added_after,
             added_before=added_before,
@@ -1143,12 +1151,16 @@ class Memory:
         *,
         limit: int = 20,
         recent: str | None = None,
+        project: object = _UNSET,
     ) -> list[dict]:
         """Chronological view of journal entries (newest first).
 
         Args:
             limit: Max number of entries to return.
             recent: Time window filter (e.g. '7d', '24h', '2w').
+            project: Override the constructor's project filter. Pass
+                ``None`` to list every project; omit to use the instance
+                default (same semantics as ``search``).
 
         Returns:
             List of dicts with title, project, tags, chunks, chars, added_at.
@@ -1158,7 +1170,7 @@ class Memory:
         return journal_log(
             limit=limit,
             recent=recent,
-            project=self._project,
+            project=self._resolve_project(project),
             cfg=self._cfg,
         )
 
@@ -1167,12 +1179,16 @@ class Memory:
         age: str,
         *,
         dry_run: bool = False,
+        project: object = _UNSET,
     ) -> dict:
         """Remove journal entries older than the specified age.
 
         Args:
             age: Age threshold like '30d', '2w', '24h'.
             dry_run: If True, report what would be deleted without deleting.
+            project: Override the constructor's project filter. Pass
+                ``None`` to prune across every project; omit to use the
+                instance default (same semantics as ``search``).
 
         Returns:
             Dict with count of deleted entries and their titles.
@@ -1181,7 +1197,7 @@ class Memory:
 
         return journal_prune(
             age,
-            project=self._project,
+            project=self._resolve_project(project),
             dry_run=dry_run,
             cfg=self._cfg,
         )


### PR DESCRIPTION
## Summary

The four `Memory.journal_*` methods hard-pinned `project=self._project`, so a Memory scoped to one agent could not save or recall journal entries for another project (or across all projects) without constructing a second `Memory`. This was a parity gap with `search`/`list`, which have taken a `project` override via the `_UNSET` sentinel since #165.

Same semantics as `search`:
- explicit value overrides the constructor default
- explicit `None` clears the filter (cross-project)
- omitting the argument keeps the instance default

## Verification

- New tests assert all three behaviors for each of the four methods (mocked-journal pattern matching the existing `TestMemoryJournal` class; the existing pass-through tests are untouched and still pin the default).
- `test_journal` (37) green; ruff clean.