### PR TITLE
⚡ Bolt: Use in-place sort for RRF ranking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - In-place Sorting vs Sorted() For Performance
+**Learning:** Python's `list.sort()` is significantly faster than `sorted()` when we don't need a new list instance. This is especially true for large lists, because `sorted()` has to allocate a new list and copy elements. For `dict.values()`, converting to a list and calling `list.sort()` is actually slightly faster than calling `sorted(dict.values())`.
+**Action:** In hot paths like search ranking, use in-place `.sort()` on lists instead of `sorted()`. For iterables like `dict.values()`, cast to list and call `.sort()`.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -296,7 +296,8 @@ class _SearchEngineMixin:
                 decay = math.exp(-0.05 * days_ago)
                 r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
 
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(
@@ -919,7 +920,8 @@ class _SearchEngineMixin:
             )
 
             # Sort by RRF score descending
-            ranked = sorted(scores.values(), key=lambda x: float(x["rrf"]), reverse=True)
+            ranked = list(scores.values())
+            ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
 
             # --- Track: RRF fusion stage ---
             if track_target is not None:


### PR DESCRIPTION
* 💡 What: Replaced `sorted()` with `list.sort()` for sorting search results by RRF score in `vstash/store/_search.py`.
* 🎯 Why: `sorted()` allocates a new list which adds overhead, especially in hot paths like search ranking. Modifying lists in-place is faster.
* 📊 Impact: Modest latency improvement in the RRF fusion and recency boost stages.
* 🔬 Measurement: Run the `benchmark_scoring_latency.py` script.

---
*PR created automatically by Jules for task [4088799909901902826](https://jules.google.com/task/4088799909901902826) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added performance guidance for sorting operations.

* **Refactor**
  * Optimized search ranking algorithm efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->