### PR TITLE
⚡ Bolt: Lazy evaluate MMR norms and bypass single document penalties

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,11 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - In-place Sorting Avoids Reallocating Lists
+**Learning:** In hot paths (like search rankings or combining items), `sorted(lst, key=...)` allocates a new list, creating memory overhead and adding unnecessary object creations.
+**Action:** When working with existing lists or generating lists from other structures like dictionaries (e.g. `list(d.values())`), use the in-place `.sort(key=...)` method to avoid the allocation overhead while maintaining fast O(N log N) sorting.
+
+## 2024-05-20 - Lazily Evaluate Distances in MMR
+**Learning:** In MMR deduplication, computing L2 norms (e.g., using `math.hypot`) for *all* candidates upfront results in unnecessary computations because many candidates might never actually be evaluated against siblings. Moreover, updating similarity penalties via `_cosine_sim` is entirely unneeded if the selected chunk is the only one from its document.
+**Action:** Lazily evaluate L2 norms only when a chunk is actually compared against a selected sibling, and bypass similarity penalty updates entirely if the selected chunk is the only one from its document.

--- a/test_perf_2.py
+++ b/test_perf_2.py
@@ -1,0 +1,12 @@
+import time
+import random
+import math
+
+def test_norm():
+    chunk_embs = [[random.random() for _ in range(384)] for _ in range(1000)]
+    start = time.perf_counter()
+    chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+    end = time.perf_counter()
+    return end - start
+
+print(f"norm time: {test_norm():.5f}")

--- a/test_perf_3.py
+++ b/test_perf_3.py
@@ -1,0 +1,23 @@
+import time
+import random
+import math
+
+def test_norm_precalc():
+    chunk_embs = [[random.random() for _ in range(384)] for _ in range(1000)]
+    start = time.perf_counter()
+    chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+    end = time.perf_counter()
+    return end - start
+
+def test_norm_lazy():
+    chunk_embs = [[random.random() for _ in range(384)] for _ in range(1000)]
+    start = time.perf_counter()
+    chunk_norms = [None] * len(chunk_embs)
+    for i, emb in enumerate(chunk_embs):
+        if chunk_norms[i] is None:
+            chunk_norms[i] = math.hypot(*emb) if emb is not None else 0.0
+    end = time.perf_counter()
+    return end - start
+
+print(f"precalc: {test_norm_precalc():.5f}")
+print(f"lazy: {test_norm_lazy():.5f}")

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1508,25 +1508,31 @@ class _SearchEngineMixin:
 
         # Fast path: if mmr_lambda == 1.0, no diversity penalty — just dedup.
         # Also fast-path when there are no same-doc duplicates.
-        from collections import Counter
+        # Avoid Counter overhead, explicitly track duplicates and unique order.
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for r in ranked:
+            doc_key = str(r["path"])
+            if doc_key in seen:
+                duplicates.add(doc_key)
+            else:
+                seen.add(doc_key)
 
-        doc_counts = Counter(str(r["path"]) for r in ranked)
-        has_duplicates = any(c > 1 for c in doc_counts.values())
-
-        if mmr_lambda >= 1.0 or not has_duplicates:
+        if mmr_lambda >= 1.0 or not duplicates:
             # Hard dedup: keep first (highest-scoring) chunk per document.
-            seen: set[str] = set()
+            seen.clear()
             deduped: list[dict[str, str | int | float]] = []
             for r in ranked:
                 doc_key = str(r["path"])
                 if doc_key not in seen:
                     seen.add(doc_key)
                     deduped.append(r)
-            return deduped[:top_k]
+                    if len(deduped) == top_k:
+                        break
+            return deduped
 
         # --- Fetch embeddings for chunks with same-doc duplicates ---
-        dup_doc_paths = {p for p, c in doc_counts.items() if c > 1}
-        dup_ids = [int(r["id"]) for r in ranked if str(r["path"]) in dup_doc_paths]
+        dup_ids = [int(r["id"]) for r in ranked if str(r["path"]) in duplicates]
 
         embeddings: dict[int, list[float]] = {}
         if dup_ids:
@@ -1592,9 +1598,6 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
-
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
         # Together with the in_remaining mask this turns the dedup loop from
@@ -1606,6 +1609,10 @@ class _SearchEngineMixin:
         # Track the maximum similarity to any selected chunk from the *same document*.
         # Replaces O(N * S) recomputation with O(1) lookup + O(N) update.
         max_sims = [0.0] * len(ranked)
+
+        # Precompute L2 norms for cosine similarity lazily to avoid O(N) recomputation
+        # for chunks that are never evaluated for siblings.
+        chunk_norms: list[float | None] = [None] * len(chunk_embs)
 
         for _ in range(min(top_k, len(ranked))):
             best_idx = -1
@@ -1648,18 +1655,26 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
-            new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+            doc_indices = doc_to_indices[new_doc_key]
+            # Bypass similarity calculation entirely if there are no siblings.
+            if len(doc_indices) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = chunk_norms[best_idx] = math.hypot(*new_emb)
+                    for idx in doc_indices:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = chunk_norms[idx] = math.hypot(*idx_emb)
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
💡 What: Lazily evaluate L2 norms in MMR dedup instead of computing them upfront for all candidates, and skip cosine similarity penalty updates for singular document candidates.
🎯 Why: Computing `math.hypot` upfront for candidates that are never evaluated against siblings is inefficient. Likewise, evaluating similarities and updating max similarity states when a document only has a single candidate is redundant computation.
📊 Impact: Skips `O(N)` `math.hypot` operations and `O(N)` `max_sim` array updates per search when duplicates don't apply.
🔬 Measurement: Verified correctness via full pytest suite and linting passes. Measured individual function improvement in local scripts.

---
*PR created automatically by Jules for task [4530239293265303618](https://jules.google.com/task/4530239293265303618) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized search deduplication logic to reduce computational overhead by lazily evaluating embeddings and similarity comparisons only when needed.

* **Tests**
  * Added performance micro-benchmarks to measure norm computation efficiency.

* **Chores**
  * Updated optimization guidance documentation with best practices for list handling and computation efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->