### PR TITLE
⚡ Bolt: MMR deduplication optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-06-25 - [Lazy Evaluation for High-Dimensional Vector Norms]
+**Learning:** In purely Python-based algorithms like Maximal Marginal Relevance (MMR) deduplication, eagerly evaluating expensive operations (like `math.hypot` for L2 norms) on all candidate vectors can be heavily wasteful if many are never actually compared (e.g. because they are the only hit from their document). Fast-path bypasses combined with lazy initialization arrays perform much faster.
+**Action:** When working on greedy diversity algorithms (MMR) or sibling penalty loops, delay vector norm calculations until the exact moment of comparison and skip penalty updates entirely if a document only contributes a single chunk to the candidate pool. Use a `[None] * len(items)` array for cached lazy evaluation.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Initialize L2 norms array for lazy evaluation during similarity penalty updates.
+        # This avoids eagerly computing math.hypot for chunks that are never compared.
+        chunk_norms = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,18 +1649,32 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
-            new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+            doc_indices = doc_to_indices[new_doc_key]
+
+            # Fast path: bypass similarity penalty updates if this is the only
+            # chunk from this document (no siblings to penalize).
+            if len(doc_indices) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = math.hypot(*new_emb)
+                        chunk_norms[best_idx] = new_norm
+
+                    for idx in doc_indices:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = math.hypot(*idx_emb)
+                                    chunk_norms[idx] = idx_norm
+
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
💡 **What:** Modified the MMR deduplication loop in `_search.py` to lazily evaluate the `math.hypot` L2 norm. In addition, it bypasses similarity penalty logic entirely when a document only has a single hit in the pool.

🎯 **Why:** Eagerly computing `math.hypot` on all candidate chunk embeddings upfront involves relatively slow pure-Python operations across hundreds of dimensions, even for chunks that might never be compared. We want to skip redundant computations as much as possible.

📊 **Impact:** Significantly reduces CPU overhead inside the ranking loops. For queries that return a broad set of single-chunk document results, the penalty update bypass eliminates O(N) operations and completely avoids calculating L2 norms.

🔬 **Measurement:** Measured successfully using isolated test scripts, the patch was validated for correctness against fast paths and verified against the comprehensive Pytest test suite to ensure regressions were absent.

---
*PR created automatically by Jules for task [7619169008233991323](https://jules.google.com/task/7619169008233991323) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved search result deduplication performance by reducing unnecessary similarity calculations.
  * Search handling is now more efficient for large result sets, especially when many related items are considered together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->