### PR TITLE
⚡ Bolt: Use in-place sort for search ranking recency boost

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - In-Place Sort Over `sorted()` For Fast Paths
+**Learning:** In hot paths like search ranking (e.g., `_apply_recency_boost`), using `sorted()` incurs unnecessary time and memory overhead by allocating a completely new list. Conversely, using an in-place `.sort()` operates directly on the existing array, avoiding this overhead while achieving the same result. However, for dict structures like `.values()`, `sorted()` handles list creation efficiently in C.
+**Action:** When working with existing lists that need reordering in hot-paths (and the list itself doesn't need to be preserved exactly as-is for the caller's state), prefer `in-place .sort()` rather than `sorted()`. Keep using `sorted()` for iterables where a list would have to be created anyway, like `.values()`.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -266,8 +266,8 @@ class _SearchEngineMixin:
         """Multiply each chunk's RRF score by an exponential decay factor.
 
         ``recency_boost=0`` disables the boost. Chunks whose ``created_at``
-        is unparseable are left untouched. Returns a newly sorted list
-        so callers always see post-boost ordering.
+        is unparseable are left untouched. Sorts the list in place so
+        callers always see post-boost ordering.
         """
         if recency_boost <= 0 or not ranked:
             return ranked
@@ -296,7 +296,8 @@ class _SearchEngineMixin:
                 decay = math.exp(-0.05 * days_ago)
                 r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
 
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(


### PR DESCRIPTION
💡 **What**: Changed `_apply_recency_boost` in `vstash/store/_search.py` to sort the `ranked` list in-place (`ranked.sort()`) instead of creating a new list with `sorted()`.
🎯 **Why**: In hot paths like search ranking, allocating new lists with `sorted()` adds unnecessary time and memory overhead. Since we don't need to preserve the original unsorted order of the list for the caller, doing an in-place sort avoids this overhead while achieving the same outcome.
📊 **Impact**: Reduces memory allocation and garbage collection overhead during search queries that utilize recency boosting.
🔬 **Measurement**: Verified that search tests pass and documented the optimization in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [6946513152411243837](https://jules.google.com/task/6946513152411243837) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result ordering performance in a search-related flow, making ranking faster in common cases.
  * Clarified sorting guidance in the project notes to reflect the preferred approach for high-traffic paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->