### PR TITLE
⚡ Bolt: Lazy L2 norms and sibling bypass in MMR

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2026-06-28 - Lazily evaluate L2 norms and bypass similarity updates in MMR
+**Learning:** In MMR deduplication, eagerly calculating L2 norms using `math.hypot` for all chunks creates O(N) overhead even for candidates that are never compared against a sibling. Also, attempting to calculate similarity penalties inside the sibling loop for documents that only have a single chunk in the candidate pool is wasteful.
+**Action:** Lazily evaluate L2 norms in a list initialized with `None` and only compute `math.hypot` just-in-time when a sibling candidate actually needs it. Furthermore, bypass the sibling update loop entirely by checking `if len(doc_indices) <= 1: continue`.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,10 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazy L2 norms: initialize to None and only compute if needed for
+        # similarity penalty calculations to save O(N) math.hypot() overhead
+        # on candidates that never get compared against a sibling.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,16 +1650,30 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+
+            # Bypass similarity penalty updates entirely if this is the only chunk
+            # for this document. Avoids the inner loop overhead for single-chunk docs.
+            doc_indices = doc_to_indices[new_doc_key]
+            if len(doc_indices) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+                new_norm = chunk_norms[best_idx]
+                if new_norm is None:
+                    new_norm = math.hypot(*new_emb)
+                    chunk_norms[best_idx] = new_norm
+
+                for idx in doc_indices:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
+                            idx_norm = chunk_norms[idx]
+                            if idx_norm is None:
+                                idx_norm = math.hypot(*idx_emb)
+                                chunk_norms[idx] = idx_norm
+
+                            sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim
 


### PR DESCRIPTION
⚡ Bolt: Lazy L2 norms and sibling bypass in MMR

*   **💡 What:** We lazily evaluate L2 norms for embedding vectors using a list initialized with `None` instead of eagerly calculating them with `math.hypot`. Also added an early bypass `if len(doc_indices) <= 1: continue` logic before updating `max_sims` loops.
*   **🎯 Why:** In `_mmr_dedup`, eagerly calling `math.hypot` for all `N` candidate chunks incurs noticeable overhead, especially when many candidates are never actually compared against siblings (either due to top_k early exit, or because they are the only returned chunk from their document). Furthermore, executing the `max_sims` tracking loop when `len(doc_indices) <= 1` does pointless dictionary and list lookups since there are no remaining sibling chunks left to penalize.
*   **📊 Impact:** Reduces unnecessary inner loop operations, especially on sparse single-chunk per document queries. Avoids O(N) calls to `math.hypot()` for chunks that are never compared to siblings.
*   **🔬 Measurement:** Verified with existing MMR unit test coverage. No observable degradation in accuracy, but strict bounds limit the number of loops and floating operations per query.

---
*PR created automatically by Jules for task [13647076294764915512](https://jules.google.com/task/13647076294764915512) started by @stffns*