### PR TITLE
⚡ Bolt: Lazy evaluation of L2 norms in MMR deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - MMR deduplication optimizations
+**Learning:** In MMR deduplication loops, eagerness in evaluating items (like precomputing L2 norms for all items) can become a bottleneck when chunks aren't always evaluated against siblings. Also, updating similarity penalties for chunks that are the only ones from their document adds unnecessary computational overhead.
+**Action:** Lazily evaluate expensive functions like L2 norms (e.g. `math.hypot`) only for siblings being actively compared, and bypass similarity penalty loops explicitly when the selected chunk is the sole chunk retrieved from its source document.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily compute L2 norms for cosine similarity to avoid O(N) recomputation
+        # for chunks that are never evaluated against siblings.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,16 +1649,28 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+            siblings = doc_to_indices[new_doc_key]
+
+            if len(siblings) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
             if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+                new_norm = chunk_norms[best_idx]
+                if new_norm is None:
+                    new_norm = math.hypot(*new_emb)
+                    chunk_norms[best_idx] = new_norm
+
+                for idx in siblings:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
+                            idx_norm = chunk_norms[idx]
+                            if idx_norm is None:
+                                idx_norm = math.hypot(*idx_emb)
+                                chunk_norms[idx] = idx_norm
+
+                            sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim
 


### PR DESCRIPTION
💡 What: Replaced the eager `math.hypot()` evaluation of L2 norms in `_mmr_dedup` with lazy evaluation. Also added an early short-circuit to entirely skip similarity penalty checks for solitary chunks.
🎯 Why: MMR routinely fetches embeddings for items it will never compare against siblings. Eagerly evaluating norms costs operations for no purpose, and looping over sole document chunks to update penalties wastes CPU cycles.
📊 Impact: Expected to reduce redundant loop cycles inside `_mmr_dedup` and substantially drop the number of math operations when ranking chunks.
🔬 Measurement: Verify by measuring CPU cycle differences or time elapsed in the `_mmr_dedup` method. Run the full test suite (passed).

---
*PR created automatically by Jules for task [8974958997095938275](https://jules.google.com/task/8974958997095938275) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result deduplication performance by reducing unnecessary similarity calculations.
  * Added a shortcut for cases where a document contributes only one result, avoiding extra comparison work.
  * Kept similarity behavior the same while making calculations happen only when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->