### PR TITLE
⚡ Bolt: Optimize MMR dedup with lazy L2 norms and single-chunk bypass

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2026-07-02 - Lazily evaluate L2 norms and bypass updates for single-chunk MMR
+**Learning:** In MMR deduplication, computing L2 norms eagerly for all chunks is extremely inefficient when most chunks are never compared against each other, especially for documents that only return a single chunk in the search results.
+**Action:** Lazily calculate L2 norms only during active cosine similarity comparisons. Furthermore, check the number of chunks returned for a document (`len(doc_indices)`) and completely bypass the similarity penalty update loop if the selected chunk is the only one from its document (`len <= 1`).

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily evaluate L2 norms for cosine similarity to avoid computing
+        # norms for chunks that are never compared (e.g. single-chunk docs).
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1649,15 +1650,25 @@ class _SearchEngineMixin:
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+            doc_indices = doc_to_indices[new_doc_key]
+
+            # Bypass similarity updates if this is the only chunk from the document
+            if len(doc_indices) > 1 and new_emb is not None:
+                new_norm = chunk_norms[best_idx]
+                if new_norm is None:
+                    new_norm = math.hypot(*new_emb)
+                    chunk_norms[best_idx] = new_norm
+
+                for idx in doc_indices:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
+                            idx_norm = chunk_norms[idx]
+                            if idx_norm is None:
+                                idx_norm = math.hypot(*idx_emb)
+                                chunk_norms[idx] = idx_norm
+
+                            sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim
 


### PR DESCRIPTION
💡 **What:** 
- Converted eager `chunk_norms` L2 norm precomputation into a lazily-evaluated cache.
- Added a fast-path bypass for documents that only return a single chunk (`len(doc_indices) <= 1`).

🎯 **Why:**
During MMR (Maximal Marginal Relevance) deduplication, dense vectors (often 384-1536 dimensions) need their L2 norms computed for cosine similarities. Previously, `math.hypot` was eagerly computed for *all* candidates `N`, even though MMR only selects `K` chunks, and only computes similarities against siblings (chunks from the *same* document). For queries returning many documents that only have a single chunk in the results, calculating these norms and spinning up the inner loops was entirely wasted CPU overhead. 

📊 **Impact:**
- Significantly reduces pure-Python overhead in the MMR fast loop for sparse result distributions.
- Drops the number of `math.hypot` calculations from $O(N)$ to bounded $O(\min(N, K \times S_{siblings}))$.
- Completely eliminates dictionary lookups and empty loop spin-ups for single-chunk documents.

🔬 **Measurement:**
Tested and verified with existing unit tests (`pytest tests/test_search_engine.py -m "not requires_sqlite_vec and not snapvec"`) which ensure functional equivalency of MMR edge cases. No regressions in score ranking were observed.

---
*PR created automatically by Jules for task [5157253512295852323](https://jules.google.com/task/5157253512295852323) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search result processing with smarter, on-demand similarity calculations.
* **Bug Fixes**
  * Reduced unnecessary work when a document only has one matching chunk, helping results return more efficiently.
  * Made duplicate handling more efficient for larger result sets, which may improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->