### PR TITLE
⚡ Bolt: Optimize MMR deduplication by lazy evaluation of L2 norms and skipping singleton similarity penalty updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - Lazy Evaluation and Skipping Singleton Sibling Checks in MMR
+**Learning:** Eagerly computing L2 norms (`math.hypot`) for all candidates before an MMR deduplication loop wastes operations if chunks are never compared (e.g., when a chunk has no siblings in the selected set). Similarly, running a nested loop to update sibling penalties is redundant if the selected chunk is the only one from its document.
+**Action:** Use lazy evaluation for L2 norms (initialize with `None` and compute only when needed) and add a fast-path guard (`if len(doc_indices) <= 1: continue`) to skip penalty updates entirely for singleton documents.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Precompute L2 norms for cosine similarity lazily to avoid O(N) up-front
+        # recomputation when most chunks never compete as siblings.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,15 +1649,31 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
+
+            # Fast path: if this is the only chunk for this document, skip sibling penalty updates
+            doc_indices = doc_to_indices[new_doc_key]
+            if len(doc_indices) <= 1:
+                continue
+
             new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
+
             if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
+                new_norm = chunk_norms[best_idx]
+                if new_norm is None:
+                    new_norm = math.hypot(*new_emb)
+                    chunk_norms[best_idx] = new_norm
+
+                for idx in doc_indices:
                     if in_remaining[idx]:
                         idx_emb = chunk_embs[idx]
                         if idx_emb is not None:
+                            idx_norm = chunk_norms[idx]
+                            if idx_norm is None:
+                                idx_norm = math.hypot(*idx_emb)
+                                chunk_norms[idx] = idx_norm
+
                             sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
+                                idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
                             )
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1672,9 +1672,7 @@ class _SearchEngineMixin:
                                 idx_norm = math.hypot(*idx_emb)
                                 chunk_norms[idx] = idx_norm
 
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
-                            )
+                            sim = _cosine_sim(idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm)
                             if sim > max_sims[idx]:
                                 max_sims[idx] = sim
 


### PR DESCRIPTION
### 💡 What
Optimized the MMR deduplication loop in `_SearchEngineMixin._mmr_dedup` by:
1. Lazily evaluating the L2 norms for cosine similarity instead of pre-computing them for all `O(N)` candidates up front.
2. Skipping the inner sibling penalty update loop completely if the newly selected chunk is the only candidate from its document.

### 🎯 Why
In many search results, chunks will not have siblings (they are the only match from their respective document) or they will never be evaluated because they rank low. Eagerly computing `math.hypot` for all chunks and stepping into the penalty update logic for singleton documents consumes unnecessary pure-Python ops.

### 📊 Impact
* Eliminates `O(N)` eager `math.hypot` calls, deferring them to only when chunks actually compete as siblings.
* Eliminates redundant setup and loop conditions for documents that only appear once in the candidate set.

### 🔬 Measurement
Run the full test suite (`pytest tests/`) to ensure the behavior (exact selected indices and ranking) matches the pre-optimized state. No regressions observed.

---
*PR created automatically by Jules for task [14295329858228708456](https://jules.google.com/task/14295329858228708456) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved result deduplication efficiency by computing similarity values only when needed.
  * Reduced unnecessary work for items that appear only once, which should make ranking faster in some cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->