### PR TITLE
⚡ Bolt: [performance improvement] Lazy L2 norm evaluation and early exit in MMR dedup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - Lazy evaluation and early returns in pure-Python hot loops
+**Learning:** In MMR deduplication, eagerly precomputing values (like `math.hypot` for L2 norms) for the entire candidate pool is wasteful when many candidates are either dropped by early break conditions or never need to be compared (e.g., chunks that are the sole representative of their document).
+**Action:** In pure-Python hot loops, lazily evaluate expensive operations (like `math.hypot`) only at the exact moment they are needed for a comparison, and skip the loop entirely (`len(siblings) > 1`) if the penalty logic doesn't apply to the current chunk.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,8 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazy L2 norms: initialize to None, compute only when compared.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,18 +1648,29 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
-            new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+            siblings = doc_to_indices[new_doc_key]
+
+            # Fast path: if this is the only chunk from this doc, no penalty to apply.
+            if len(siblings) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = chunk_norms[best_idx] = math.hypot(*new_emb)
+
+                    for idx in siblings:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = chunk_norms[idx] = math.hypot(*idx_emb)
+
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
💡 What:
Implemented lazy evaluation of L2 norms (`math.hypot`) in `_mmr_dedup` and added a fast-path early exit to skip penalty evaluations entirely when a chunk is the only one from its document.

🎯 Why:
Eagerly precomputing L2 norms for all candidates in the MMR pool was wasteful because many chunks are either dropped by early break conditions or never need to have a redundancy penalty calculated (since they don't have siblings in the selected set). Deferring the calculation until the chunk is actually compared reduces unnecessary operations.

📊 Impact:
Reduces redundant pure-Python math overhead. In queries where `mmr_lambda < 1.0` and many single-chunk documents appear in the candidate pool, it prevents computing norms and executing inner-loop setup logic entirely for those chunks.

🔬 Measurement:
Verified via `pytest tests/ -k 'test_mmr'` and the full test suite which run identically as before. 

(Verified with `pytest tests/`)

---
*PR created automatically by Jules for task [8554176168806558731](https://jules.google.com/task/8554176168806558731) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication performance during search result processing by calculating expensive similarity values only when needed.
  * Skips extra work when the sibling-based penalty does not apply, which can reduce latency for certain queries.

* **Documentation**
  * Added a note with guidance for more efficient handling of high-traffic deduplication paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->