### PR TITLE
⚡ Bolt: [performance improvement] Pre-fetch created_at for recency boost

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+## 2024-05-20 - Pre-fetch properties in candidate generation
+**Learning:** Fetching chunk properties like `created_at` in batched post-processing steps (like `_apply_recency_boost`) causes unnecessary database round-trips (N+1 queries pattern), even when chunked.
+**Action:** Pre-fetch required properties in the initial candidate generation SQL queries (`SELECT ... c.created_at ...`) and carry them through the pipeline dictionary (`scores`/`ranked`) to avoid subsequent lookups.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -211,6 +211,13 @@ class _SearchEngineMixin:
         for rank, row in enumerate(vec_rows):
             chunk_id: int = row["id"]
             vec_contrib = vec_weight * (1.0 / (RRF_K + rank))
+
+            # sqlite3.Row does not support .get(), handle Missing keys via keys()
+            try:
+                created_at = row["created_at"]
+            except IndexError:
+                created_at = None
+
             scores[chunk_id] = {
                 "id": chunk_id,
                 "text": row["text"],
@@ -222,6 +229,7 @@ class _SearchEngineMixin:
                 "collection": row["collection"],
                 "tags": row["tags"],
                 "layer": row["layer"],
+                "created_at": created_at,
             }
             if explain:
                 explain_rrf_vec[chunk_id] = vec_contrib
@@ -240,6 +248,10 @@ class _SearchEngineMixin:
                     explain_rrf_fts[chunk_id] = fts_contribution
                     explain_fts_rank[chunk_id] = rank
             elif chunk_id in relevant_chunk_ids or is_fts_top:
+                try:
+                    created_at = row["created_at"]
+                except IndexError:
+                    created_at = None
                 scores[chunk_id] = {
                     "id": chunk_id,
                     "text": row["text"],
@@ -251,6 +263,7 @@ class _SearchEngineMixin:
                     "collection": row["collection"],
                     "tags": row["tags"],
                     "layer": row["layer"],
+                    "created_at": created_at,
                 }
                 if explain:
                     explain_rrf_fts[chunk_id] = fts_contribution
@@ -273,30 +286,20 @@ class _SearchEngineMixin:
             return ranked
 
         now = datetime.now(timezone.utc)
-        chunk_ids = [int(r["id"]) for r in ranked]
-        # Batch the IN clause so large top_k / candidate pools don't trip
-        # SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER (999 on most builds).
-        created_map: dict[int, datetime] = {}
-        for start in range(0, len(chunk_ids), _SQLITE_PARAM_BATCH):
-            batch = chunk_ids[start : start + _SQLITE_PARAM_BATCH]
-            placeholders = ",".join("?" * len(batch))
-            for row in self._conn.execute(
-                f"SELECT id, created_at FROM chunks WHERE id IN ({placeholders})",
-                batch,
-            ).fetchall():
+
+        for r in ranked:
+            created_at_str = r.get("created_at")
+            if created_at_str:
                 try:
-                    created_map[row["id"]] = datetime.fromisoformat(row["created_at"])
+                    created_at = datetime.fromisoformat(str(created_at_str))
+                    days_ago = max(0.0, (now - created_at).total_seconds() / 86400)
+                    decay = math.exp(-0.05 * days_ago)
+                    r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
                 except (TypeError, ValueError):
                     pass
 
-        for r in ranked:
-            cid = int(r["id"])
-            if cid in created_map:
-                days_ago = max(0.0, (now - created_map[cid]).total_seconds() / 86400)
-                decay = math.exp(-0.05 * days_ago)
-                r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
-
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(
@@ -650,7 +653,7 @@ class _SearchEngineMixin:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -671,7 +674,7 @@ class _SearchEngineMixin:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer, c.created_at
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -819,7 +822,7 @@ class _SearchEngineMixin:
                     fts_rows = self._conn.execute(
                         f"""
                         SELECT c.id, c.text, d.title, d.path, c.seq,
-                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
+                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM fts_chunks f
                         JOIN chunks c ON c.id = f.rowid
                         JOIN documents d ON d.id = c.doc_id


### PR DESCRIPTION
💡 What: Added `c.created_at` to the `SELECT` statements in candidate generation (vector and FTS queries) and updated the `_fuse_rrf_scores` dictionary output to propagate `created_at`. This allows `_apply_recency_boost` to process recency boosts entirely in Python memory instead of performing batched SQLite queries to retrieve `created_at` times. `ranked.sort()` was also updated to use an in-place sort to reduce allocations.

🎯 Why: To eliminate an N+1 querying pattern during post-processing in `_apply_recency_boost`. Batched queries inside ranking logic slow down the hot path unnecessarily.

📊 Impact: Decreases latency of queries processed through the recency boost step by removing a dedicated database roundtrip. Avoids list allocation overhead via in-place `list.sort`.

🔬 Measurement: `pytest tests/ -m "not requires_sqlite_vec and not snapvec"` succeeds, validating that results preserve their expected semantic structure, and `vstash.metrics` telemetry will report `search_latency_ms` improvements over many queries.

---
*PR created automatically by Jules for task [13283499477362116303](https://jules.google.com/task/13283499477362116303) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved search ranking efficiency by retrieving result timestamps during the initial search.
  * Reduced unnecessary database lookups when applying recency-based ranking.

* **Bug Fixes**
  * Improved handling of search results where timestamp information is unavailable or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->