### PR TITLE
⚡ Bolt: Pre-fetch created_at to avoid database query in recency boost

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## 2024-05-20 - Pre-fetch database columns for batched post-processing
+**Learning:** During post-processing steps like `_apply_recency_boost`, executing batched `SELECT` queries to fetch additional properties (e.g., `created_at`) based on chunk IDs creates unnecessary database round-trips (N+1-like issue for batches).
+**Action:** Pre-fetch necessary properties like `created_at` in the initial candidate generation SQL queries (`vec_chunks`, `fts_chunks`, `snapvec`), propagate them through the ranking dictionary, and read them directly during post-processing to save database calls.

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -222,6 +222,7 @@ class _SearchEngineMixin:
                 "collection": row["collection"],
                 "tags": row["tags"],
                 "layer": row["layer"],
+                "created_at": row["created_at"],
             }
             if explain:
                 explain_rrf_vec[chunk_id] = vec_contrib
@@ -251,6 +252,7 @@ class _SearchEngineMixin:
                     "collection": row["collection"],
                     "tags": row["tags"],
                     "layer": row["layer"],
+                    "created_at": row["created_at"],
                 }
                 if explain:
                     explain_rrf_fts[chunk_id] = fts_contribution
@@ -273,30 +275,20 @@ class _SearchEngineMixin:
             return ranked
 
         now = datetime.now(timezone.utc)
-        chunk_ids = [int(r["id"]) for r in ranked]
-        # Batch the IN clause so large top_k / candidate pools don't trip
-        # SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER (999 on most builds).
-        created_map: dict[int, datetime] = {}
-        for start in range(0, len(chunk_ids), _SQLITE_PARAM_BATCH):
-            batch = chunk_ids[start : start + _SQLITE_PARAM_BATCH]
-            placeholders = ",".join("?" * len(batch))
-            for row in self._conn.execute(
-                f"SELECT id, created_at FROM chunks WHERE id IN ({placeholders})",
-                batch,
-            ).fetchall():
+
+        for r in ranked:
+            created_at_str = r.get("created_at")
+            if created_at_str:
                 try:
-                    created_map[row["id"]] = datetime.fromisoformat(row["created_at"])
+                    created_at = datetime.fromisoformat(str(created_at_str))
+                    days_ago = max(0.0, (now - created_at).total_seconds() / 86400)
+                    decay = math.exp(-0.05 * days_ago)
+                    r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
                 except (TypeError, ValueError):
                     pass
 
-        for r in ranked:
-            cid = int(r["id"])
-            if cid in created_map:
-                days_ago = max(0.0, (now - created_map[cid]).total_seconds() / 86400)
-                decay = math.exp(-0.05 * days_ago)
-                r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
-
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(
@@ -650,7 +642,7 @@ class _SearchEngineMixin:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -671,7 +663,7 @@ class _SearchEngineMixin:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer, c.created_at
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -819,7 +811,7 @@ class _SearchEngineMixin:
                     fts_rows = self._conn.execute(
                         f"""
                         SELECT c.id, c.text, d.title, d.path, c.seq,
-                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
+                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM fts_chunks f
                         JOIN chunks c ON c.id = f.rowid
                         JOIN documents d ON d.id = c.doc_id


### PR DESCRIPTION
- What: Pre-fetches created_at column during initial search queries rather than running an extra batched SELECT during _apply_recency_boost, and uses in-place sort for the results.
- Why: To eliminate an unnecessary database round trip in the search pipeline and avoid memory allocations.
- Impact: Eliminates an extra DB query per search and avoids list allocation, speeding up the recency boost step.
- Measurement: Validated through passing tests and performance characteristics.

---
*PR created automatically by Jules for task [2752037785819088625](https://jules.google.com/task/2752037785819088625) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved search ranking performance by reducing additional database lookups during recency-based result ordering.
  * Search results now carry required timing information through the retrieval and ranking process for more efficient processing.

* **Documentation**
  * Added a changelog entry documenting the search performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->