### PR TITLE
⚡ Bolt: Remove N+1 query in recency boost and use in-place sort

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+## YYYY-MM-DD - Pre-fetch SQL properties to avoid N+1 queries in batched post-processing
+**Learning:** In pipelines doing batch querying on large candidate lists, doing an N+1 secondary batch query (e.g., retrieving `created_at` for an entire result set) slows things down.
+**Action:** Pre-fetch necessary properties in initial candidate generation SQL queries and carry them through the processing pipeline (e.g., in dictionaries) to avoid N+1 database round-trips in batched post-processing steps (like `_apply_recency_boost`).

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -219,6 +219,7 @@ class _SearchEngineMixin:
                 "chunk": row["seq"],
                 "rrf": vec_contrib,
                 "added_at": row["added_at"],
+                "created_at": row["created_at"],
                 "collection": row["collection"],
                 "tags": row["tags"],
                 "layer": row["layer"],
@@ -248,6 +249,7 @@ class _SearchEngineMixin:
                     "chunk": row["seq"],
                     "rrf": fts_contribution,
                     "added_at": row["added_at"],
+                    "created_at": row["created_at"],
                     "collection": row["collection"],
                     "tags": row["tags"],
                     "layer": row["layer"],
@@ -273,30 +275,20 @@ class _SearchEngineMixin:
             return ranked
 
         now = datetime.now(timezone.utc)
-        chunk_ids = [int(r["id"]) for r in ranked]
-        # Batch the IN clause so large top_k / candidate pools don't trip
-        # SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER (999 on most builds).
-        created_map: dict[int, datetime] = {}
-        for start in range(0, len(chunk_ids), _SQLITE_PARAM_BATCH):
-            batch = chunk_ids[start : start + _SQLITE_PARAM_BATCH]
-            placeholders = ",".join("?" * len(batch))
-            for row in self._conn.execute(
-                f"SELECT id, created_at FROM chunks WHERE id IN ({placeholders})",
-                batch,
-            ).fetchall():
+
+        for r in ranked:
+            created_at_raw = r.get("created_at")
+            if created_at_raw:
                 try:
-                    created_map[row["id"]] = datetime.fromisoformat(row["created_at"])
+                    created_at_dt = datetime.fromisoformat(str(created_at_raw))
+                    days_ago = max(0.0, (now - created_at_dt).total_seconds() / 86400)
+                    decay = math.exp(-0.05 * days_ago)
+                    r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
                 except (TypeError, ValueError):
                     pass
 
-        for r in ranked:
-            cid = int(r["id"])
-            if cid in created_map:
-                days_ago = max(0.0, (now - created_map[cid]).total_seconds() / 86400)
-                decay = math.exp(-0.05 * days_ago)
-                r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
-
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(
@@ -650,7 +642,7 @@ class _SearchEngineMixin:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, c.created_at, d.collection, d.tags, d.layer
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -671,7 +663,7 @@ class _SearchEngineMixin:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, c.created_at, d.collection, d.tags, d.layer
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -819,7 +811,7 @@ class _SearchEngineMixin:
                     fts_rows = self._conn.execute(
                         f"""
                         SELECT c.id, c.text, d.title, d.path, c.seq,
-                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
+                               rank as fts_rank, d.added_at, c.created_at, d.collection, d.tags, d.layer
                         FROM fts_chunks f
                         JOIN chunks c ON c.id = f.rowid
                         JOIN documents d ON d.id = c.doc_id


### PR DESCRIPTION
💡 What: Update the `_search.py` pipeline to pre-fetch `created_at` during the candidate generation queries (for snapvec, vec_chunks, and fts_chunks) and remove the secondary batch fetching loop in `_apply_recency_boost`. It also swaps `sorted()` for an in-place `.sort()` call for the ranked chunks list.

🎯 Why: To avoid N+1 round trips to the SQLite database during result post-processing. Additionally, using `.sort()` over `sorted()` saves memory allocations in the hot ranking loop.

📊 Impact: Faster query execution time for any searches utilizing recency boosting, reducing redundant DB load and minor memory allocation overheads.

🔬 Measurement: Query latency drops via reduced DB ops, verifiable via profiling the query execution flow.

---
*PR created automatically by Jules for task [149751647431918099](https://jules.google.com/task/149751647431918099) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved recency-based search ranking by reusing existing result metadata instead of making additional database lookups.
  * Reduced unnecessary database activity during combined vector and full-text searches.
* **Search**
  * Preserved creation timestamps throughout search result processing to support more efficient recency boosting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->