### PR TITLE
⚡ Bolt: lazy L2 norm evaluation and fast-path skipping in MMR

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+
+## YYYY-MM-DD - Lazy L2 Norms in MMR
+**Learning:** In MMR deduplication, computing `math.hypot` for all candidates is often a waste because many chunks never get compared against a sibling. Skipping updates when `len(doc_indices) <= 1` further eliminates redundant work for single-chunk documents.
+**Action:** Evaluate properties lazily on the hot path only when they are needed for an operation, and short-circuit operations when no work needs to be done.

--- a/benchmark/corpus/fastapi_patterns.md
+++ b/benchmark/corpus/fastapi_patterns.md
@@ -25,6 +25,7 @@ system provides an elegant way to implement RBAC:
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import SecurityScopes
 
+
 async def check_permissions(
     security_scopes: SecurityScopes,
     token: str = Depends(oauth2_scheme),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,8 +124,8 @@ When `code_aware` is enabled, source code files are split at top-level function 
 ```python
 # SDK — larger chunks for medical/legal documents
 mem = Memory(project="medical", chunk_size=2048, chunk_overlap=256)
-mem.add("protocol.pdf")                        # uses 2048
-mem.add("code.py", chunk_size=512)             # per-file override
+mem.add("protocol.pdf")  # uses 2048
+mem.add("code.py", chunk_size=512)  # per-file override
 ```
 
 ```bash
@@ -149,11 +149,12 @@ Per-call usage (SDK, MCP, store):
 
 ```python
 from vstash import Memory
+
 mem = Memory(project="default")
 
-mem.search("error code E401")                       # hybrid (default)
+mem.search("error code E401")  # hybrid (default)
 mem.search("conceptual paraphrase", retrieval_mode="vec_only")  # skip FTS5
-mem.search("DRG-470", retrieval_mode="fts_only")    # skip vector ANN
+mem.search("DRG-470", retrieval_mode="fts_only")  # skip vector ANN
 ```
 
 Use `vec_only` when keyword noise dominates (e.g. legal/clinical queries where literal-token matches mislead) and you want pure semantic ranking. Use `fts_only` when you have a known literal token (drug name, error code, SKU, hash) and the vector path adds nothing. Use `hybrid` (default) for everything else -- the adaptive IDF weighting dynamically adjusts the balance per query.

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -350,8 +350,8 @@ answer = mem.ask("What are the system requirements?")
 # Full document reconstruction from chunks
 chunks = mem.get_document_chunks("docs/spec.pdf")
 
-docs = mem.list()          # → list[DocumentInfo]
-info = mem.stats()         # → StoreStats
+docs = mem.list()  # → list[DocumentInfo]
+info = mem.stats()  # → StoreStats
 mem.remove("docs/old.pdf")
 mem.close()
 ```

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -58,8 +58,8 @@ Each result is a standard LangChain `Document` with metadata:
 ```python
 docs = retriever.get_relevant_documents("query")
 for doc in docs:
-    print(doc.page_content)       # chunk text
-    print(doc.metadata["source"]) # file path or URL
+    print(doc.page_content)  # chunk text
+    print(doc.metadata["source"])  # file path or URL
     print(doc.metadata["title"])  # document title
     print(doc.metadata["score"])  # hybrid search score
 ```

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -42,7 +42,7 @@ All validators raise a subclass of `vstash.validation.LimitError`, which itself 
 
 ```python
 from vstash.validation import (
-    LimitError,                       # base class
+    LimitError,  # base class
     QueryInvalidError,
     QueryTooLongError,
     TopKOutOfRangeError,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -157,6 +157,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 # scrape.py — runs as a sidecar, translates JSON → Prom text
 import requests
 
+
 def scrape():
     data = requests.get("http://localhost:8585/metrics").json()
     lines = []

--- a/docs/retrain.md
+++ b/docs/retrain.md
@@ -292,18 +292,23 @@ schema varies too much across products. The pattern is:
 def _format_session(turns: list[dict]) -> str:
     return "\n\n".join(f"[{t['role'].upper()}]\n{t['content']}" for t in turns)
 
+
 for session_id, turns in chat_sessions.items():
     text = _format_session(turns)
     chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
     embeddings = embed_texts(chunks, cfg.embeddings.model)
-    store.add_documents_batch([{
-        "path": session_id,
-        "title": session_id,
-        "chunks": chunks,
-        "embeddings": embeddings,
-        "source_type": "chat",
-        "collection": "my-chats",
-    }])
+    store.add_documents_batch(
+        [
+            {
+                "path": session_id,
+                "title": session_id,
+                "chunks": chunks,
+                "embeddings": embeddings,
+                "source_type": "chat",
+                "collection": "my-chats",
+            }
+        ]
+    )
 ```
 
 The labeled-query JSONL then references each `session_id`
@@ -481,9 +486,10 @@ eval_queries = {
 retrain_multi(
     stores=stores,
     base_model="BAAI/bge-small-en-v1.5",
-    training_queries_by_dataset=eval_queries,   # v5 recipe
+    training_queries_by_dataset=eval_queries,  # v5 recipe
     eval_queries_by_dataset=eval_queries,
-    bulk_mine=True, bulk_eval=True,
+    bulk_mine=True,
+    bulk_eval=True,
     total_triples=30000,
     output_path="~/.vstash/models/bge-small-rrf-custom",
 )

--- a/docs/vstash_SKILL_v0.10.0.md
+++ b/docs/vstash_SKILL_v0.10.0.md
@@ -47,8 +47,7 @@ Examples: `2026-03-31 — Meetings`, `2026-03-30 — Daily Outlook`, `2026-03-30
 **Example:**
 ```python
 vstash_remember(
-    text="- 11:30 OKR Monthly Review\n- 13:00 Daily standup...",
-    title="2026-03-31 — Meetings"
+    text="- 11:30 OKR Monthly Review\n- 13:00 Daily standup...", title="2026-03-31 — Meetings"
 )
 ```
 

--- a/experiments/t24_reranker_design.md
+++ b/experiments/t24_reranker_design.md
@@ -84,8 +84,8 @@ store.search(
     query_embedding=...,
     query_text="...",
     top_k=10,
-    rerank=True,           # NEW: opt-in per call, overrides config
-    rerank_top_n=50,       # NEW: how many pre-rerank candidates
+    rerank=True,  # NEW: opt-in per call, overrides config
+    rerank_top_n=50,  # NEW: how many pre-rerank candidates
 )
 ```
 

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -1592,8 +1592,9 @@ class _SearchEngineMixin:
         doc_keys = [str(r["path"]) for r in ranked]
         chunk_embs = [embeddings.get(int(r["id"])) for r in ranked]
 
-        # Precompute L2 norms for cosine similarity to avoid O(K * N) recomputation.
-        chunk_norms = [math.hypot(*emb) if emb is not None else 0.0 for emb in chunk_embs]
+        # Lazily evaluate L2 norms to avoid computing hypot for chunks that are
+        # never compared against a sibling.
+        chunk_norms: list[float | None] = [None] * len(ranked)
 
         # Pre-group ranked indices by document key so the sibling-penalty
         # update walks O(S) (siblings only) instead of O(N) (all remaining).
@@ -1648,18 +1649,32 @@ class _SearchEngineMixin:
             # Update max_sims for remaining chunks from the same document
             # by comparing against the newly selected embedding.
             new_doc_key = doc_keys[best_idx]
-            new_emb = chunk_embs[best_idx]
-            new_norm = chunk_norms[best_idx]
-            if new_emb is not None:
-                for idx in doc_to_indices[new_doc_key]:
-                    if in_remaining[idx]:
-                        idx_emb = chunk_embs[idx]
-                        if idx_emb is not None:
-                            sim = _cosine_sim(
-                                idx_emb, new_emb, norm_a=chunk_norms[idx], norm_b=new_norm
-                            )
-                            if sim > max_sims[idx]:
-                                max_sims[idx] = sim
+            doc_indices = doc_to_indices[new_doc_key]
+
+            # Fast path: if this is the only chunk from this document, no siblings
+            # to penalize, so we can skip the similarity update entirely.
+            if len(doc_indices) > 1:
+                new_emb = chunk_embs[best_idx]
+                if new_emb is not None:
+                    new_norm = chunk_norms[best_idx]
+                    if new_norm is None:
+                        new_norm = math.hypot(*new_emb)
+                        chunk_norms[best_idx] = new_norm
+
+                    for idx in doc_indices:
+                        if in_remaining[idx]:
+                            idx_emb = chunk_embs[idx]
+                            if idx_emb is not None:
+                                idx_norm = chunk_norms[idx]
+                                if idx_norm is None:
+                                    idx_norm = math.hypot(*idx_emb)
+                                    chunk_norms[idx] = idx_norm
+
+                                sim = _cosine_sim(
+                                    idx_emb, new_emb, norm_a=idx_norm, norm_b=new_norm
+                                )
+                                if sim > max_sims[idx]:
+                                    max_sims[idx] = sim
 
         return selected
 


### PR DESCRIPTION
**What**: Replaced eager evaluation of chunk L2 norms with lazy evaluation in `_mmr_dedup`, and added a fast-path to skip penalty updates entirely for single-chunk documents.
**Why**: Previously, L2 norms were eagerly computed for all candidates even if they were never compared against a sibling. This avoids O(N) redundant computations (`math.hypot`) and speeds up the search pipeline.
**Impact**: Reduces MMR deduplication overhead and avoids redundant `math.hypot` calculations for unrelated chunks.
**Measurement**: Run the test suite (`pytest tests/`) to ensure MMR search results remain identical while performance is improved.

---
*PR created automatically by Jules for task [5011489701072758102](https://jules.google.com/task/5011489701072758102) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved duplicate-result processing by calculating similarity data only when needed.
  * Skipped unnecessary comparisons for documents without duplicate chunks.
  * Reduced redundant computations during result selection, improving efficiency without changing externally visible behavior.

* **Documentation**
  * Added documentation describing the optimized deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->