### PR TITLE
⚡ Bolt: Eliminate N+1 query in recency boost by pre-fetching created_at

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Precompute Loop Invariants in Greedy Selection Algorithms
 **Learning:** In greedy selection algorithms like MMR deduplication, recalculating invariant values within nested loops (such as the term `mmr_lambda * norm_score`) drastically increases computational overhead. Because `norm_score` depends only on the candidate's static score and `mmr_lambda` is a constant, recalculating this product inside the inner loop wastes $O(K \times N)$ operations.
 **Action:** Always hoist per-item invariant calculations (like `mmr_lambda * norm_score` or `1 - mmr_lambda`) out of nested loops and precompute them in arrays or variables before the loop begins to reduce complexity and improve runtime performance.
+## 2024-05-20 - Pre-fetch database properties to avoid N+1 queries
+**Learning:** Pre-fetching necessary properties like `created_at` in initial SQL candidate generation queries and carrying them through the pipeline in dictionaries avoids expensive batched queries or N+1 round-trips in post-processing steps (like `_apply_recency_boost`).
+**Action:** When a post-processing stage needs column data for scoring or filtering, join and retrieve that column in the initial `SELECT` rather than performing subsequent queries.

--- a/benchmark/corpus/fastapi_patterns.md
+++ b/benchmark/corpus/fastapi_patterns.md
@@ -25,6 +25,7 @@ system provides an elegant way to implement RBAC:
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import SecurityScopes
 
+
 async def check_permissions(
     security_scopes: SecurityScopes,
     token: str = Depends(oauth2_scheme),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,8 +124,8 @@ When `code_aware` is enabled, source code files are split at top-level function 
 ```python
 # SDK — larger chunks for medical/legal documents
 mem = Memory(project="medical", chunk_size=2048, chunk_overlap=256)
-mem.add("protocol.pdf")                        # uses 2048
-mem.add("code.py", chunk_size=512)             # per-file override
+mem.add("protocol.pdf")  # uses 2048
+mem.add("code.py", chunk_size=512)  # per-file override
 ```
 
 ```bash
@@ -149,11 +149,12 @@ Per-call usage (SDK, MCP, store):
 
 ```python
 from vstash import Memory
+
 mem = Memory(project="default")
 
-mem.search("error code E401")                       # hybrid (default)
+mem.search("error code E401")  # hybrid (default)
 mem.search("conceptual paraphrase", retrieval_mode="vec_only")  # skip FTS5
-mem.search("DRG-470", retrieval_mode="fts_only")    # skip vector ANN
+mem.search("DRG-470", retrieval_mode="fts_only")  # skip vector ANN
 ```
 
 Use `vec_only` when keyword noise dominates (e.g. legal/clinical queries where literal-token matches mislead) and you want pure semantic ranking. Use `fts_only` when you have a known literal token (drug name, error code, SKU, hash) and the vector path adds nothing. Use `hybrid` (default) for everything else -- the adaptive IDF weighting dynamically adjusts the balance per query.

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -350,8 +350,8 @@ answer = mem.ask("What are the system requirements?")
 # Full document reconstruction from chunks
 chunks = mem.get_document_chunks("docs/spec.pdf")
 
-docs = mem.list()          # → list[DocumentInfo]
-info = mem.stats()         # → StoreStats
+docs = mem.list()  # → list[DocumentInfo]
+info = mem.stats()  # → StoreStats
 mem.remove("docs/old.pdf")
 mem.close()
 ```

--- a/docs/langchain.md
+++ b/docs/langchain.md
@@ -58,8 +58,8 @@ Each result is a standard LangChain `Document` with metadata:
 ```python
 docs = retriever.get_relevant_documents("query")
 for doc in docs:
-    print(doc.page_content)       # chunk text
-    print(doc.metadata["source"]) # file path or URL
+    print(doc.page_content)  # chunk text
+    print(doc.metadata["source"])  # file path or URL
     print(doc.metadata["title"])  # document title
     print(doc.metadata["score"])  # hybrid search score
 ```

--- a/docs/limits.md
+++ b/docs/limits.md
@@ -42,7 +42,7 @@ All validators raise a subclass of `vstash.validation.LimitError`, which itself 
 
 ```python
 from vstash.validation import (
-    LimitError,                       # base class
+    LimitError,  # base class
     QueryInvalidError,
     QueryTooLongError,
     TopKOutOfRangeError,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -157,6 +157,7 @@ HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
 # scrape.py — runs as a sidecar, translates JSON → Prom text
 import requests
 
+
 def scrape():
     data = requests.get("http://localhost:8585/metrics").json()
     lines = []

--- a/docs/retrain.md
+++ b/docs/retrain.md
@@ -292,18 +292,23 @@ schema varies too much across products. The pattern is:
 def _format_session(turns: list[dict]) -> str:
     return "\n\n".join(f"[{t['role'].upper()}]\n{t['content']}" for t in turns)
 
+
 for session_id, turns in chat_sessions.items():
     text = _format_session(turns)
     chunks = chunk_text(text, cfg.chunking.size, cfg.chunking.overlap)
     embeddings = embed_texts(chunks, cfg.embeddings.model)
-    store.add_documents_batch([{
-        "path": session_id,
-        "title": session_id,
-        "chunks": chunks,
-        "embeddings": embeddings,
-        "source_type": "chat",
-        "collection": "my-chats",
-    }])
+    store.add_documents_batch(
+        [
+            {
+                "path": session_id,
+                "title": session_id,
+                "chunks": chunks,
+                "embeddings": embeddings,
+                "source_type": "chat",
+                "collection": "my-chats",
+            }
+        ]
+    )
 ```
 
 The labeled-query JSONL then references each `session_id`
@@ -481,9 +486,10 @@ eval_queries = {
 retrain_multi(
     stores=stores,
     base_model="BAAI/bge-small-en-v1.5",
-    training_queries_by_dataset=eval_queries,   # v5 recipe
+    training_queries_by_dataset=eval_queries,  # v5 recipe
     eval_queries_by_dataset=eval_queries,
-    bulk_mine=True, bulk_eval=True,
+    bulk_mine=True,
+    bulk_eval=True,
     total_triples=30000,
     output_path="~/.vstash/models/bge-small-rrf-custom",
 )

--- a/docs/vstash_SKILL_v0.10.0.md
+++ b/docs/vstash_SKILL_v0.10.0.md
@@ -47,8 +47,7 @@ Examples: `2026-03-31 — Meetings`, `2026-03-30 — Daily Outlook`, `2026-03-30
 **Example:**
 ```python
 vstash_remember(
-    text="- 11:30 OKR Monthly Review\n- 13:00 Daily standup...",
-    title="2026-03-31 — Meetings"
+    text="- 11:30 OKR Monthly Review\n- 13:00 Daily standup...", title="2026-03-31 — Meetings"
 )
 ```
 

--- a/experiments/t24_reranker_design.md
+++ b/experiments/t24_reranker_design.md
@@ -84,8 +84,8 @@ store.search(
     query_embedding=...,
     query_text="...",
     top_k=10,
-    rerank=True,           # NEW: opt-in per call, overrides config
-    rerank_top_n=50,       # NEW: how many pre-rerank candidates
+    rerank=True,  # NEW: opt-in per call, overrides config
+    rerank_top_n=50,  # NEW: how many pre-rerank candidates
 )
 ```
 

--- a/vstash/store/_search.py
+++ b/vstash/store/_search.py
@@ -223,6 +223,10 @@ class _SearchEngineMixin:
                 "tags": row["tags"],
                 "layer": row["layer"],
             }
+            try:
+                scores[chunk_id]["created_at"] = row["created_at"]
+            except (IndexError, KeyError):
+                pass
             if explain:
                 explain_rrf_vec[chunk_id] = vec_contrib
 
@@ -252,6 +256,10 @@ class _SearchEngineMixin:
                     "tags": row["tags"],
                     "layer": row["layer"],
                 }
+                try:
+                    scores[chunk_id]["created_at"] = row["created_at"]
+                except (IndexError, KeyError):
+                    pass
                 if explain:
                     explain_rrf_fts[chunk_id] = fts_contribution
                     explain_fts_rank[chunk_id] = rank
@@ -273,30 +281,20 @@ class _SearchEngineMixin:
             return ranked
 
         now = datetime.now(timezone.utc)
-        chunk_ids = [int(r["id"]) for r in ranked]
-        # Batch the IN clause so large top_k / candidate pools don't trip
-        # SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER (999 on most builds).
-        created_map: dict[int, datetime] = {}
-        for start in range(0, len(chunk_ids), _SQLITE_PARAM_BATCH):
-            batch = chunk_ids[start : start + _SQLITE_PARAM_BATCH]
-            placeholders = ",".join("?" * len(batch))
-            for row in self._conn.execute(
-                f"SELECT id, created_at FROM chunks WHERE id IN ({placeholders})",
-                batch,
-            ).fetchall():
+
+        for r in ranked:
+            created_str = r.get("created_at")
+            if created_str:
                 try:
-                    created_map[row["id"]] = datetime.fromisoformat(row["created_at"])
+                    created_dt = datetime.fromisoformat(str(created_str))
+                    days_ago = max(0.0, (now - created_dt).total_seconds() / 86400)
+                    decay = math.exp(-0.05 * days_ago)
+                    r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
                 except (TypeError, ValueError):
                     pass
 
-        for r in ranked:
-            cid = int(r["id"])
-            if cid in created_map:
-                days_ago = max(0.0, (now - created_map[cid]).total_seconds() / 86400)
-                decay = math.exp(-0.05 * days_ago)
-                r["rrf"] = float(r["rrf"]) * (1.0 + recency_boost * decay)
-
-        return sorted(ranked, key=lambda x: float(x["rrf"]), reverse=True)
+        ranked.sort(key=lambda x: float(x["rrf"]), reverse=True)
+        return ranked
 
     @staticmethod
     def _build_search_results(
@@ -650,7 +648,7 @@ class _SearchEngineMixin:
                     snap_filter = vec_clause.replace("v.rowid", "c.id") if vec_clause else ""
                     rows = self._conn.execute(
                         f"""
-                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer
+                        SELECT c.id, c.text, d.title, d.path, c.seq, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM chunks c
                         JOIN documents d ON d.id = c.doc_id
                         WHERE c.id IN ({placeholders})
@@ -671,7 +669,7 @@ class _SearchEngineMixin:
             else:
                 vec_rows = self._conn.execute(
                     f"""
-                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer
+                    SELECT c.id, c.text, d.title, d.path, c.seq, v.distance, d.added_at, d.collection, d.tags, d.layer, c.created_at
                     FROM vec_chunks v
                     JOIN chunks c ON c.id = v.rowid
                     JOIN documents d ON d.id = c.doc_id
@@ -819,7 +817,7 @@ class _SearchEngineMixin:
                     fts_rows = self._conn.execute(
                         f"""
                         SELECT c.id, c.text, d.title, d.path, c.seq,
-                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer
+                               rank as fts_rank, d.added_at, d.collection, d.tags, d.layer, c.created_at
                         FROM fts_chunks f
                         JOIN chunks c ON c.id = f.rowid
                         JOIN documents d ON d.id = c.doc_id


### PR DESCRIPTION
💡 What: Pre-fetch `c.created_at` in the initial vector and FTS search SQL queries and pass it through to the `_apply_recency_boost` function. Refactor `_apply_recency_boost` to use the pre-fetched values and perform an in-place sort on the list.
     🎯 Why: `_apply_recency_boost` previously executed batched SQL queries to fetch `created_at` for every candidate chunk in the pipeline, adding database round-trip overhead during the ranking phase.
     📊 Impact: Eliminates a database query during the critical path of the search pipeline. Using `ranked.sort()` instead of `sorted(ranked)` saves the overhead of allocating a new list.
     🔬 Measurement: The test suite passes without regressions. `_apply_recency_boost` no longer executes SQL queries.

---
*PR created automatically by Jules for task [16044881537142586759](https://jules.google.com/task/16044881537142586759) started by @stffns*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Search results now use available creation dates to apply recency ranking more efficiently.
  - Results with missing or invalid dates continue to display without recency enhancement.
  - Improved ranking consistency across vector, full-text, and combined search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->